### PR TITLE
[Issue #55]: reduce memory copy in column readers.

### DIFF
--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/StringColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/StringColumnReader.java
@@ -247,14 +247,13 @@ public class StringColumnReader
             // read starts and orders
             ByteBuf startsBuf = inputBuffer.slice(startsOffset, ordersOffset - startsOffset);
             ByteBuf ordersBuf = inputBuffer.slice(ordersOffset, inputLength - ordersOffset);
-            this.originNum = 0;
-            DynamicIntArray startsArray = new DynamicIntArray();
+            DynamicIntArray startsArray = new DynamicIntArray(1024);
             RunLenIntDecoder startsDecoder = new RunLenIntDecoder(new ByteBufInputStream(startsBuf), false);
             while (startsDecoder.hasNext())
             {
                 startsArray.add((int) startsDecoder.next());
-                this.originNum++;
             }
+            this.originNum = startsArray.size();
             RunLenIntDecoder ordersDecoder = new RunLenIntDecoder(new ByteBufInputStream(ordersBuf), false);
             starts = startsArray.toArray();
             orders = new int[originNum];

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/utils/BitUtils.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/utils/BitUtils.java
@@ -19,6 +19,8 @@
  */
 package io.pixelsdb.pixels.core.utils;
 
+import io.netty.buffer.ByteBuf;
+
 import java.io.ByteArrayOutputStream;
 import java.nio.ByteBuffer;
 
@@ -192,6 +194,38 @@ public class BitUtils
         while (offset < length)
         {
             b = input.get(offset);
+            offset++;
+            while (bitsLeft > 0)
+            {
+                bitsLeft -= bitsToRead;
+                current = mask & (b >> bitsLeft);
+                bits[index] = (byte) current;
+                index++;
+            }
+            bitsLeft = 8;
+        }
+    }
+
+    /**
+     * Bit de-compaction, this method does not modify the current position in input byte buffer.
+     *
+     * @param input input byte buffer, which can be direct.
+     * @param offset starting offset of the input
+     * @param length byte length of the input
+     * @return de-compacted bits
+     */
+    public static void bitWiseDeCompact(byte[] bits, ByteBuf input, int offset, int length)
+    {
+        int bitsToRead = 1;
+        int bitsLeft = 8;
+        int current;
+        byte mask = 0x01;
+
+        int index = 0;
+        byte b;
+        while (offset < length)
+        {
+            b = input.getByte(offset);
             offset++;
             while (bitsLeft > 0)
             {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/utils/ByteBufferInputStream.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/utils/ByteBufferInputStream.java
@@ -85,9 +85,10 @@ public class ByteBufferInputStream extends InputStream
         if (isDirect)
         {
             // ByteBuffer is not thread safe by itself, so I think it does not matter.
-            byteBuffer.mark();
+            // Do not use mark as it has side effects for position().
+            int p = byteBuffer.position();
             byteBuffer.get(b, off, len);
-            byteBuffer.reset();
+            byteBuffer.position(p);
             position += len;
         }
         else

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/utils/ByteBufferInputStream.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/utils/ByteBufferInputStream.java
@@ -84,11 +84,10 @@ public class ByteBufferInputStream extends InputStream
 
         if (isDirect)
         {
-            // TODO: it not thread safe to restore position like this.
-            // But ByteBuffer is not thread safe by itself, so I think it does not matter.
-            int p = byteBuffer.position();
+            // ByteBuffer is not thread safe by itself, so I think it does not matter.
+            byteBuffer.mark();
             byteBuffer.get(b, off, len);
-            byteBuffer.position(p);
+            byteBuffer.reset();
             position += len;
         }
         else

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/utils/DynamicIntArray.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/utils/DynamicIntArray.java
@@ -158,4 +158,33 @@ public final class DynamicIntArray
 
         return sb.toString();
     }
+
+    /**
+     * Convert this to an integer array. The returned array's length
+     * is >= this.length, so that *DO NOT* use the length of the returned array.
+     * If there are only one chunk used, no memory copy is performed.
+     * @return
+     */
+    public int[] toArray()
+    {
+        if (initializedChunks == 1)
+        {
+            return data[0];
+        }
+        else
+        {
+            int[] array = new int[length];
+            int i;
+            for (i = 0; i < initializedChunks-1; i++)
+            {
+                System.arraycopy(data[i], 0, array, i*chunkSize, chunkSize);
+            }
+            int tail = length % chunkSize;
+            for (int j = 0, k = i*chunkSize; j < tail; ++j, ++k)
+            {
+                array[k] = data[i][j];
+            }
+            return array;
+        }
+    }
 }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/utils/DynamicIntArray.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/utils/DynamicIntArray.java
@@ -38,7 +38,7 @@ package io.pixelsdb.pixels.core.utils;
 public final class DynamicIntArray
 {
     static final int DEFAULT_CHUNKSIZE = 8 * 1024;
-    static final int INIT_CHUNKS = 128;
+    static final int INIT_CHUNKS = 256;
 
     private final int chunkSize;       // our allocation size
     private int[][] data;              // the real data


### PR DESCRIPTION
Memory copy in double/float/timestamp/string column readers is reduced.

Currently, memory copy only exists for copying dictionary in string column reader. Such memory copy is necessary to improve CPU performance.