### PR TITLE
Issue #58: add gc threshold to optimize gc for small queries.

### DIFF
--- a/pixels-common/src/main/resources/pixels.properties
+++ b/pixels-common/src/main/resources/pixels.properties
@@ -56,6 +56,9 @@ etcd.port=2379
 # split size will be set to this fixed value if it is positive
 fixed.split.size=-1
 
+# the rate of free memory in jvm.
+pixels.gc.threshold=0.3
+
 # pixels cache
 cache.location=/mnt/ramfs/pixels.cache
 cache.size=102400000


### PR DESCRIPTION
Add a threshold for gc. If the leave free memory ratio is lower than the given threshold, explicit gc will be issued when closing the PixelsReaderImpl.