### PR TITLE
Hotfix: fix bugs in CacheWriter initialization and cache update.

### DIFF
--- a/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsCacheUtil.java
+++ b/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsCacheUtil.java
@@ -44,10 +44,15 @@ public class PixelsCacheUtil
     public static final int READER_COUNT_MASK;
     public static final int READER_COUNT_INC;
     /**
-     * We only use the first 12 bytes in the index, but we start radix tree
-     * from offset 16 for memory alignment.
+     * We only use the first 14 bytes in the index {magic(6)+rwflag(2)+readcount(2)+version(4)}
+     * for metadata header, but we start radix tree from offset 16 for memory alignment.
      */
     public static final int INDEX_RADIX_OFFSET = 16;
+    /**
+     * We use the first 16 bytes in the cache file {magic(6)+status(2)+size(8)} for
+     * metadata header.
+     */
+    public static final int CACHE_DATA_OFFSET = 16;
 
     static
     {

--- a/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/cache/CacheManager.java
+++ b/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/cache/CacheManager.java
@@ -109,9 +109,9 @@ public class CacheManager
      *      if not, existing cache is out of date, goto step #2.
      * 2. else, update caches with latest layout in etcd/mysql.
      * 3. update the status of CacheManager in etcd
-     * 4. start a scheduled thread to update node(CacheManager) status
+     * 4. start a scheduled thread to update node (CacheManager) status
      * 5. add a watcher to listen to changes of the cache version in etcd.
-     *    if there is a new version, we need update caches according to new layouts.
+     *    if there is a new version, we need to update caches according to new layouts.
      * */
     private void initialize()
     {
@@ -128,15 +128,18 @@ public class CacheManager
             FileSystem fs = FileSystem.get(URI.create(cacheConfig.getWarehousePath()), conf);
             this.cacheWriter =
                     PixelsCacheWriter.newBuilder()
-                                     .setCacheLocation(cacheConfig.getCacheLocation())
-                                     .setCacheSize(cacheConfig.getCacheSize())
-                                     .setIndexLocation(cacheConfig.getIndexLocation())
-                                     .setIndexSize(cacheConfig.getIndexSize())
-                                     .setOverwrite(false)
-                                     .setFS(fs)
-                                     .setHostName(hostName)
-                                     .build();
+                            .setCacheLocation(cacheConfig.getCacheLocation())
+                            .setCacheSize(cacheConfig.getCacheSize())
+                            .setIndexLocation(cacheConfig.getIndexLocation())
+                            .setIndexSize(cacheConfig.getIndexSize())
+                            .setOverwrite(false)
+                            .setFS(fs)
+                            .setHostName(hostName)
+                            .setCacheConfig(cacheConfig)
+                            .build(); // cache version in the index file is cleared if its first 6 bytes are not magic ("PIXELS").
             this.metadataService = new MetadataService(cacheConfig.getMetaHost(), cacheConfig.getMetaPort());
+
+            // Update cache if necessary.
             // If the cache is new created using start-vm.sh script, localCacheVersion would be zero.
             localCacheVersion = PixelsCacheUtil.getIndexVersion(cacheWriter.getIndexFile());
             logger.debug("Local cache version: " + localCacheVersion);


### PR DESCRIPTION
1. the first 16 bytes in cache file was overwritten when updating cache;
2. wrong current offset is used in PixelsCacheWriter when updating cache.