### PR TITLE
[Issue #72]: optimize memory allocation and access in PixelsCacheReader.

### DIFF
--- a/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsCacheUtil.java
+++ b/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsCacheUtil.java
@@ -35,6 +35,7 @@ import java.nio.charset.StandardCharsets;
  * - CONTENT
  *
  * @author guodong
+ * @author hank
  */
 public class PixelsCacheUtil
 {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/PixelsReaderImpl.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/PixelsReaderImpl.java
@@ -49,6 +49,7 @@ import static java.util.Objects.requireNonNull;
  * Pixels file reader default implementation
  *
  * @author guodong
+ * @author hank
  */
 @NotThreadSafe
 public class PixelsReaderImpl

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/PixelsWriterImpl.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/PixelsWriterImpl.java
@@ -61,6 +61,7 @@ import static java.util.Objects.requireNonNull;
  * This writer is NOT thread safe!
  *
  * @author guodong
+ * @author hank
  */
 @NotThreadSafe
 public class PixelsWriterImpl

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/encoding/Decoder.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/encoding/Decoder.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 
 /**
  * @author guodong
+ * @author hank
  */
 public abstract class Decoder implements AutoCloseable
 {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/encoding/Encoder.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/encoding/Encoder.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 
 /**
  * @author guodong
+ * @author hank
  */
 public abstract class Encoder implements AutoCloseable
 {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/encoding/RunLenByteDecoder.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/encoding/RunLenByteDecoder.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 
 /**
  * @author guodong
+ * @author hank
  */
 public class RunLenByteDecoder
         extends Decoder

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/encoding/RunLenIntDecoder.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/encoding/RunLenIntDecoder.java
@@ -33,6 +33,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 /**
  * @author guodong
+ * @author hank
  */
 public class RunLenIntDecoder
         extends IntDecoder


### PR DESCRIPTION
1. eliminate the memory allocation for edge of nodes;
2. combine the memory read of edge and children into one.