### PR TITLE
[Issue #94]: Support Date and Time types.

### DIFF
--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/PixelsWriterImpl.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/PixelsWriterImpl.java
@@ -560,6 +560,12 @@ public class PixelsWriterImpl
                 case TIMESTAMP:
                     tmpType.setKind(PixelsProto.Type.Kind.TIMESTAMP);
                     break;
+                case DATE:
+                    tmpType.setKind(PixelsProto.Type.Kind.DATE);
+                    break;
+                case TIME:
+                    tmpType.setKind(PixelsProto.Type.Kind.TIME);
+                    break;
                 default:
                     throw new IllegalArgumentException("Unknown category: " +
                             schema.getCategory());

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/PixelsWriterImpl.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/PixelsWriterImpl.java
@@ -29,17 +29,7 @@ import io.pixelsdb.pixels.core.exception.PixelsWriterException;
 import io.pixelsdb.pixels.core.stats.StatsRecorder;
 import io.pixelsdb.pixels.core.vector.ColumnVector;
 import io.pixelsdb.pixels.core.vector.VectorizedRowBatch;
-import io.pixelsdb.pixels.core.writer.BinaryColumnWriter;
-import io.pixelsdb.pixels.core.writer.BooleanColumnWriter;
-import io.pixelsdb.pixels.core.writer.ByteColumnWriter;
-import io.pixelsdb.pixels.core.writer.CharColumnWriter;
-import io.pixelsdb.pixels.core.writer.ColumnWriter;
-import io.pixelsdb.pixels.core.writer.DoubleColumnWriter;
-import io.pixelsdb.pixels.core.writer.FloatColumnWriter;
-import io.pixelsdb.pixels.core.writer.IntegerColumnWriter;
-import io.pixelsdb.pixels.core.writer.StringColumnWriter;
-import io.pixelsdb.pixels.core.writer.TimestampColumnWriter;
-import io.pixelsdb.pixels.core.writer.VarcharColumnWriter;
+import io.pixelsdb.pixels.core.writer.*;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.logging.log4j.LogManager;
@@ -602,6 +592,10 @@ public class PixelsWriterImpl
                 return new VarcharColumnWriter(schema, pixelStride, isEncoding);
             case BINARY:
                 return new BinaryColumnWriter(schema, pixelStride, isEncoding);
+            case DATE:
+                return new DateColumnWriter(schema, pixelStride, isEncoding);
+            case TIME:
+                return new TimeColumnWriter(schema, pixelStride, isEncoding);
             case TIMESTAMP:
                 return new TimestampColumnWriter(schema, pixelStride, isEncoding);
             default:

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/TypeDescription.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/TypeDescription.java
@@ -104,6 +104,7 @@ public final class TypeDescription
         DOUBLE("double", true),
         STRING("string", true),
         DATE("date", true),
+        TIME("time", true),
         TIMESTAMP("timestamp", true),
         BINARY("binary", true),
         VARCHAR("varchar", true),

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/TypeDescription.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/TypeDescription.java
@@ -19,14 +19,7 @@
  */
 package io.pixelsdb.pixels.core;
 
-import io.pixelsdb.pixels.core.vector.BinaryColumnVector;
-import io.pixelsdb.pixels.core.vector.ByteColumnVector;
-import io.pixelsdb.pixels.core.vector.ColumnVector;
-import io.pixelsdb.pixels.core.vector.DoubleColumnVector;
-import io.pixelsdb.pixels.core.vector.LongColumnVector;
-import io.pixelsdb.pixels.core.vector.StructColumnVector;
-import io.pixelsdb.pixels.core.vector.TimestampColumnVector;
-import io.pixelsdb.pixels.core.vector.VectorizedRowBatch;
+import io.pixelsdb.pixels.core.vector.*;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -176,6 +169,11 @@ public final class TypeDescription
         return new TypeDescription(Category.DATE);
     }
 
+    public static TypeDescription createTime()
+    {
+        return new TypeDescription(Category.TIME);
+    }
+
     public static TypeDescription createTimestamp()
     {
         return new TypeDescription(Category.TIMESTAMP);
@@ -206,6 +204,9 @@ public final class TypeDescription
                     break;
                 case DATE:
                     fieldType = TypeDescription.createDate();
+                    break;
+                case TIME:
+                    fieldType = TypeDescription.createTime();
                     break;
                 case LONG:
                     fieldType = TypeDescription.createLong();
@@ -424,6 +425,7 @@ public final class TypeDescription
             case BOOLEAN:
             case BYTE:
             case DATE:
+            case TIME:
             case DOUBLE:
             case FLOAT:
             case INT:
@@ -692,8 +694,11 @@ public final class TypeDescription
             case SHORT:
             case INT:
             case LONG:
-            case DATE:
                 return new LongColumnVector(maxSize);
+            case DATE:
+                return new DateColumnVector(maxSize);
+            case TIME:
+                return new TimeColumnVector(maxSize);
             case TIMESTAMP:
                 return new TimestampColumnVector(maxSize);
             case FLOAT:

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/TypeDescription.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/TypeDescription.java
@@ -436,6 +436,7 @@ public final class TypeDescription
                 break;
             case CHAR:
             case VARCHAR:
+                // TODO: fix varchar
                 requireChar(source, '(');
                 result.withMaxLength(parseInt(source));
                 requireChar(source, ')');

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/encoding/Encoder.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/encoding/Encoder.java
@@ -44,7 +44,7 @@ public abstract class Encoder implements AutoCloseable
         throw new PixelsEncodingException("Encoding char values is not supported");
     }
 
-    public byte[] encode(char[] values, long offset, long length)
+    public byte[] encode(char[] values, int offset, int length)
     {
         throw new PixelsEncodingException("Encoding char values is not supported");
     }
@@ -55,7 +55,7 @@ public abstract class Encoder implements AutoCloseable
         throw new PixelsEncodingException("Encoding byte values is not supported");
     }
 
-    public byte[] encode(byte[] values, long offset, long length)
+    public byte[] encode(byte[] values, int offset, int length)
             throws IOException
     {
         throw new PixelsEncodingException("Encoding byte values is not supported");
@@ -67,13 +67,20 @@ public abstract class Encoder implements AutoCloseable
         throw new PixelsEncodingException("Encoding long values is not supported");
     }
 
-    public byte[] encode(long[] values, long offset, long length)
+    public byte[] encode(long[] values, int offset, int length)
             throws IOException
     {
         throw new PixelsEncodingException("Encoding long values is not supported");
     }
 
     public byte[] encode(int[] values)
+            throws IOException
+    {
+        throw new PixelsEncodingException("Encoding int values is not supported");
+    }
+
+    public byte[] encode(int[] values, int offset, int length)
+            throws IOException
     {
         throw new PixelsEncodingException("Encoding int values is not supported");
     }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/encoding/RunLenByteEncoder.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/encoding/RunLenByteEncoder.java
@@ -26,6 +26,8 @@ import java.io.IOException;
  * A encoder for a sequence of bytes.
  * A control byte is written before each run with positive values 0 to 127 meaning 2 to 129 repetitions.
  * If the bytes is -1 to -128, 1 to 128 literal byte values follow.
+ *
+ * @author guodong
  */
 public class RunLenByteEncoder
         extends Encoder
@@ -60,12 +62,12 @@ public class RunLenByteEncoder
     }
 
     @Override
-    public byte[] encode(byte[] values, long offset, long length)
+    public byte[] encode(byte[] values, int offset, int length)
             throws IOException
     {
         for (int i = 0; i < length; i++)
         {
-            write(values[i + (int) offset]);
+            write(values[i + offset]);
         }
         flush();
         byte[] result = output.toByteArray();

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/encoding/RunLenIntEncoder.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/encoding/RunLenIntEncoder.java
@@ -34,6 +34,7 @@ import static com.google.common.base.Preconditions.checkArgument;
  * More details can be found at https://orc.apache.org/docs/run-length.html
  *
  * @author guodong
+ * @author hank
  */
 public class RunLenIntEncoder
         extends Encoder
@@ -87,12 +88,27 @@ public class RunLenIntEncoder
         clear();
     }
 
-    public byte[] encode(long[] values, long offset, long length)
+    @Override
+    public byte[] encode(long[] values, int offset, int length)
             throws IOException
     {
         for (int i = 0; i < length; i++)
         {
-            this.write(values[i]);
+            this.write(values[i+offset]);
+        }
+        flush();
+        byte[] result = outputStream.toByteArray();
+        outputStream.reset();
+        return result;
+    }
+
+    @Override
+    public byte[] encode(int[] values, int offset, int length)
+            throws IOException
+    {
+        for (int i = 0; i < length; i++)
+        {
+            this.write(values[i+offset]);
         }
         flush();
         byte[] result = outputStream.toByteArray();
@@ -102,6 +118,13 @@ public class RunLenIntEncoder
 
     @Override
     public byte[] encode(long[] values)
+            throws IOException
+    {
+        return encode(values, 0, values.length);
+    }
+
+    @Override
+    public byte[] encode(int[] values)
             throws IOException
     {
         return encode(values, 0, values.length);

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/ColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/ColumnReader.java
@@ -62,6 +62,10 @@ public abstract class ColumnReader implements Closeable
                 return new FloatColumnReader(type);
             case STRING:
                 return new StringColumnReader(type);
+            case DATE:
+                return new DateColumnReader(type);
+            case TIME:
+                return new TimeColumnReader(type);
             case TIMESTAMP:
                 return new TimestampColumnReader(type);
             case VARCHAR:

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/DateColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/DateColumnReader.java
@@ -30,7 +30,6 @@ import io.pixelsdb.pixels.core.vector.DateColumnVector;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
-import java.sql.Date;
 
 /**
  * pixels date column reader
@@ -96,7 +95,7 @@ public class DateColumnReader
             }
             this.inputBuffer = input;
             inputStream = new ByteBufferInputStream(inputBuffer, 0, inputBuffer.limit());
-            decoder = new RunLenIntDecoder(inputStream, false);
+            decoder = new RunLenIntDecoder(inputStream, true);
             isNullOffset = (int) chunkIndex.getIsNullOffset();
             hasNull = true;
             elementIndex = 0;
@@ -129,7 +128,7 @@ public class DateColumnReader
                 }
                 else
                 {
-                    columnVector.set(i + vectorIndex, new Date(decoder.next()));
+                    columnVector.set(i + vectorIndex, (int)decoder.next());
                 }
                 if (hasNull)
                 {
@@ -164,7 +163,7 @@ public class DateColumnReader
                 }
                 else
                 {
-                    columnVector.set(i + vectorIndex, new Date(inputBuffer.getInt()));
+                    columnVector.set(i + vectorIndex, inputBuffer.getInt());
                 }
                 if (hasNull)
                 {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/DateColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/DateColumnReader.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2017-2019 PixelsDB.
+ *
+ * This file is part of Pixels.
+ *
+ * Pixels is free software: you can redistribute it and/or modify
+ * it under the terms of the Affero GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * Pixels is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Affero GNU General Public License for more details.
+ *
+ * You should have received a copy of the Affero GNU General Public
+ * License along with Pixels.  If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package io.pixelsdb.pixels.core.reader;
+
+import io.pixelsdb.pixels.core.PixelsProto;
+import io.pixelsdb.pixels.core.TypeDescription;
+import io.pixelsdb.pixels.core.encoding.RunLenIntDecoder;
+import io.pixelsdb.pixels.core.utils.BitUtils;
+import io.pixelsdb.pixels.core.utils.ByteBufferInputStream;
+import io.pixelsdb.pixels.core.vector.ColumnVector;
+import io.pixelsdb.pixels.core.vector.DateColumnVector;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.sql.Date;
+
+/**
+ * pixels date column reader
+ * All date values are translated to the specified time zone after read from file.
+ *
+ * @author hank
+ */
+public class DateColumnReader
+        extends ColumnReader
+{
+    private ByteBuffer inputBuffer = null;
+    private InputStream inputStream = null;
+    private RunLenIntDecoder decoder = null;
+    private int isNullOffset = 0;
+    private int isNullBitIndex = 0;
+    private byte[] isNull = new byte[8];
+
+    DateColumnReader(TypeDescription type)
+    {
+        super(type);
+    }
+
+    /**
+     * Closes this column reader and releases any resources associated
+     * with it. If the column reader is already closed then invoking this
+     * method has no effect.
+     * <p>
+     * <p> As noted in {@link AutoCloseable#close()}, cases where the
+     * close may fail require careful attention. It is strongly advised
+     * to relinquish the underlying resources and to internally
+     * <em>mark</em> the {@code Closeable} as closed, prior to throwing
+     * the {@code IOException}.
+     *
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    public void close() throws IOException
+    {
+
+    }
+
+    /**
+     * Read values from input buffer.
+     *
+     * @param input    input buffer
+     * @param encoding encoding type
+     * @param size     number of values to read
+     * @param vector   vector to read into
+     * @throws IOException
+     */
+    @Override
+    public void read(ByteBuffer input, PixelsProto.ColumnEncoding encoding,
+                     int offset, int size, int pixelStride, final int vectorIndex,
+                     ColumnVector vector, PixelsProto.ColumnChunkIndex chunkIndex)
+            throws IOException
+    {
+        DateColumnVector columnVector = (DateColumnVector) vector;
+        if (offset == 0)
+        {
+            if (inputStream != null)
+            {
+                inputStream.close();
+            }
+            this.inputBuffer = input;
+            inputStream = new ByteBufferInputStream(inputBuffer, 0, inputBuffer.limit());
+            decoder = new RunLenIntDecoder(inputStream, false);
+            isNullOffset = (int) chunkIndex.getIsNullOffset();
+            hasNull = true;
+            elementIndex = 0;
+            isNullBitIndex = 8;
+        }
+
+        if (encoding.getKind().equals(PixelsProto.ColumnEncoding.Kind.RUNLENGTH))
+        {
+            for (int i = 0; i < size; i++)
+            {
+                if (elementIndex % pixelStride == 0)
+                {
+                    int pixelId = elementIndex / pixelStride;
+                    hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
+                    if (hasNull && isNullBitIndex > 0)
+                    {
+                        BitUtils.bitWiseDeCompact(isNull, inputBuffer, isNullOffset++, 1);
+                        isNullBitIndex = 0;
+                    }
+                }
+                if (hasNull && isNullBitIndex >= 8)
+                {
+                    BitUtils.bitWiseDeCompact(isNull, inputBuffer, isNullOffset++, 1);
+                    isNullBitIndex = 0;
+                }
+                if (hasNull && isNull[isNullBitIndex] == 1)
+                {
+                    columnVector.isNull[i + vectorIndex] = true;
+                    columnVector.noNulls = false;
+                }
+                else
+                {
+                    columnVector.set(i + vectorIndex, new Date(decoder.next()));
+                }
+                if (hasNull)
+                {
+                    isNullBitIndex++;
+                }
+                elementIndex++;
+            }
+        }
+        else
+        {
+            for (int i = 0; i < size; i++)
+            {
+                if (elementIndex % pixelStride == 0)
+                {
+                    int pixelId = elementIndex / pixelStride;
+                    hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
+                    if (hasNull && isNullBitIndex > 0)
+                    {
+                        BitUtils.bitWiseDeCompact(isNull, inputBuffer, isNullOffset++, 1);
+                        isNullBitIndex = 0;
+                    }
+                }
+                if (hasNull && isNullBitIndex >= 8)
+                {
+                    BitUtils.bitWiseDeCompact(isNull, inputBuffer, isNullOffset++, 1);
+                    isNullBitIndex = 0;
+                }
+                if (hasNull && isNull[isNullBitIndex] == 1)
+                {
+                    columnVector.isNull[i + vectorIndex] = true;
+                    columnVector.noNulls = false;
+                }
+                else
+                {
+                    columnVector.set(i + vectorIndex, new Date(inputBuffer.getLong()));
+                }
+                if (hasNull)
+                {
+                    isNullBitIndex++;
+                }
+                elementIndex++;
+            }
+        }
+    }
+}

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/DateColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/DateColumnReader.java
@@ -164,7 +164,7 @@ public class DateColumnReader
                 }
                 else
                 {
-                    columnVector.set(i + vectorIndex, new Date(inputBuffer.getLong()));
+                    columnVector.set(i + vectorIndex, new Date(inputBuffer.getInt()));
                 }
                 if (hasNull)
                 {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/TimeColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/TimeColumnReader.java
@@ -30,7 +30,6 @@ import io.pixelsdb.pixels.core.vector.TimeColumnVector;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
-import java.sql.Time;
 
 /**
  * pixels time column reader
@@ -96,7 +95,7 @@ public class TimeColumnReader
             }
             this.inputBuffer = input;
             inputStream = new ByteBufferInputStream(inputBuffer, 0, inputBuffer.limit());
-            decoder = new RunLenIntDecoder(inputStream, false);
+            decoder = new RunLenIntDecoder(inputStream, true);
             isNullOffset = (int) chunkIndex.getIsNullOffset();
             hasNull = true;
             elementIndex = 0;
@@ -129,7 +128,7 @@ public class TimeColumnReader
                 }
                 else
                 {
-                    columnVector.set(i + vectorIndex, new Time(decoder.next()));
+                    columnVector.set(i + vectorIndex, (int)decoder.next());
                 }
                 if (hasNull)
                 {
@@ -165,7 +164,7 @@ public class TimeColumnReader
                 else
                 {
                     // If time column is not encoded, it is written as integers instead of longs.
-                    columnVector.set(i + vectorIndex, new Time(inputBuffer.getInt()));
+                    columnVector.set(i + vectorIndex, inputBuffer.getInt());
                 }
                 if (hasNull)
                 {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/TimeColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/TimeColumnReader.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2017-2019 PixelsDB.
+ *
+ * This file is part of Pixels.
+ *
+ * Pixels is free software: you can redistribute it and/or modify
+ * it under the terms of the Affero GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * Pixels is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Affero GNU General Public License for more details.
+ *
+ * You should have received a copy of the Affero GNU General Public
+ * License along with Pixels.  If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package io.pixelsdb.pixels.core.reader;
+
+import io.pixelsdb.pixels.core.PixelsProto;
+import io.pixelsdb.pixels.core.TypeDescription;
+import io.pixelsdb.pixels.core.encoding.RunLenIntDecoder;
+import io.pixelsdb.pixels.core.utils.BitUtils;
+import io.pixelsdb.pixels.core.utils.ByteBufferInputStream;
+import io.pixelsdb.pixels.core.vector.ColumnVector;
+import io.pixelsdb.pixels.core.vector.TimeColumnVector;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.sql.Time;
+
+/**
+ * pixels time column reader
+ * All time values are translated to the specified time zone after read from file.
+ *
+ * @author hank
+ */
+public class TimeColumnReader
+        extends ColumnReader
+{
+    private ByteBuffer inputBuffer = null;
+    private InputStream inputStream = null;
+    private RunLenIntDecoder decoder = null;
+    private int isNullOffset = 0;
+    private int isNullBitIndex = 0;
+    private byte[] isNull = new byte[8];
+
+    TimeColumnReader(TypeDescription type)
+    {
+        super(type);
+    }
+
+    /**
+     * Closes this column reader and releases any resources associated
+     * with it. If the column reader is already closed then invoking this
+     * method has no effect.
+     * <p>
+     * <p> As noted in {@link AutoCloseable#close()}, cases where the
+     * close may fail require careful attention. It is strongly advised
+     * to relinquish the underlying resources and to internally
+     * <em>mark</em> the {@code Closeable} as closed, prior to throwing
+     * the {@code IOException}.
+     *
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    public void close() throws IOException
+    {
+
+    }
+
+    /**
+     * Read values from input buffer.
+     *
+     * @param input    input buffer
+     * @param encoding encoding type
+     * @param size     number of values to read
+     * @param vector   vector to read into
+     * @throws IOException
+     */
+    @Override
+    public void read(ByteBuffer input, PixelsProto.ColumnEncoding encoding,
+                     int offset, int size, int pixelStride, final int vectorIndex,
+                     ColumnVector vector, PixelsProto.ColumnChunkIndex chunkIndex)
+            throws IOException
+    {
+        TimeColumnVector columnVector = (TimeColumnVector) vector;
+        if (offset == 0)
+        {
+            if (inputStream != null)
+            {
+                inputStream.close();
+            }
+            this.inputBuffer = input;
+            inputStream = new ByteBufferInputStream(inputBuffer, 0, inputBuffer.limit());
+            decoder = new RunLenIntDecoder(inputStream, false);
+            isNullOffset = (int) chunkIndex.getIsNullOffset();
+            hasNull = true;
+            elementIndex = 0;
+            isNullBitIndex = 8;
+        }
+
+        if (encoding.getKind().equals(PixelsProto.ColumnEncoding.Kind.RUNLENGTH))
+        {
+            for (int i = 0; i < size; i++)
+            {
+                if (elementIndex % pixelStride == 0)
+                {
+                    int pixelId = elementIndex / pixelStride;
+                    hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
+                    if (hasNull && isNullBitIndex > 0)
+                    {
+                        BitUtils.bitWiseDeCompact(isNull, inputBuffer, isNullOffset++, 1);
+                        isNullBitIndex = 0;
+                    }
+                }
+                if (hasNull && isNullBitIndex >= 8)
+                {
+                    BitUtils.bitWiseDeCompact(isNull, inputBuffer, isNullOffset++, 1);
+                    isNullBitIndex = 0;
+                }
+                if (hasNull && isNull[isNullBitIndex] == 1)
+                {
+                    columnVector.isNull[i + vectorIndex] = true;
+                    columnVector.noNulls = false;
+                }
+                else
+                {
+                    columnVector.set(i + vectorIndex, new Time(decoder.next()));
+                }
+                if (hasNull)
+                {
+                    isNullBitIndex++;
+                }
+                elementIndex++;
+            }
+        }
+        else
+        {
+            for (int i = 0; i < size; i++)
+            {
+                if (elementIndex % pixelStride == 0)
+                {
+                    int pixelId = elementIndex / pixelStride;
+                    hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
+                    if (hasNull && isNullBitIndex > 0)
+                    {
+                        BitUtils.bitWiseDeCompact(isNull, inputBuffer, isNullOffset++, 1);
+                        isNullBitIndex = 0;
+                    }
+                }
+                if (hasNull && isNullBitIndex >= 8)
+                {
+                    BitUtils.bitWiseDeCompact(isNull, inputBuffer, isNullOffset++, 1);
+                    isNullBitIndex = 0;
+                }
+                if (hasNull && isNull[isNullBitIndex] == 1)
+                {
+                    columnVector.isNull[i + vectorIndex] = true;
+                    columnVector.noNulls = false;
+                }
+                else
+                {
+                    // If time column is not encoded, it is written as integers instead of longs.
+                    columnVector.set(i + vectorIndex, new Time(inputBuffer.getInt()));
+                }
+                if (hasNull)
+                {
+                    isNullBitIndex++;
+                }
+                elementIndex++;
+            }
+        }
+    }
+}

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/TimestampColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/TimestampColumnReader.java
@@ -96,7 +96,7 @@ public class TimestampColumnReader
             }
             this.inputBuffer = input;
             inputStream = new ByteBufferInputStream(inputBuffer, 0, inputBuffer.limit());
-            decoder = new RunLenIntDecoder(inputStream, false);
+            decoder = new RunLenIntDecoder(inputStream, true);
             isNullOffset = (int) chunkIndex.getIsNullOffset();
             hasNull = true;
             elementIndex = 0;

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/stats/DateColumnStats.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/stats/DateColumnStats.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017-2019 PixelsDB.
+ *
+ * This file is part of Pixels.
+ *
+ * Pixels is free software: you can redistribute it and/or modify
+ * it under the terms of the Affero GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * Pixels is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Affero GNU General Public License for more details.
+ *
+ * You should have received a copy of the Affero GNU General Public
+ * License along with Pixels.  If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package io.pixelsdb.pixels.core.stats;
+
+/**
+ * pixels
+ *
+ * 2021-04-25
+ * @author hank
+ */
+public interface DateColumnStats extends RangeStats<Integer>
+{
+    Integer getMinimum();
+
+    Integer getMaximum();
+}

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/stats/StatsRecorder.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/stats/StatsRecorder.java
@@ -113,7 +113,7 @@ public class StatsRecorder
         throw new UnsupportedOperationException("Can't update date");
     }
 
-    public void updateDate(long value)
+    public void updateDate(int value)
     {
         throw new UnsupportedOperationException("Can't update date");
     }
@@ -198,6 +198,10 @@ public class StatsRecorder
             case CHAR:
             case VARCHAR:
                 return new StringStatsRecorder();
+            case DATE:
+                return new DateStatsRecorder();
+            case TIME:
+                return new TimeStatsRecorder();
             case TIMESTAMP:
                 return new TimestampStatsRecorder();
             case BINARY:
@@ -225,6 +229,10 @@ public class StatsRecorder
             case CHAR:
             case VARCHAR:
                 return new StringStatsRecorder(statistic);
+            case DATE:
+                return new DateStatsRecorder(statistic);
+            case TIME:
+                return new TimeStatsRecorder(statistic);
             case TIMESTAMP:
                 return new TimestampStatsRecorder(statistic);
             case BINARY:

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/stats/StatsRecorder.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/stats/StatsRecorder.java
@@ -22,6 +22,8 @@ package io.pixelsdb.pixels.core.stats;
 import io.pixelsdb.pixels.core.PixelsProto;
 import io.pixelsdb.pixels.core.TypeDescription;
 
+import java.sql.Date;
+import java.sql.Time;
 import java.sql.Timestamp;
 
 /**
@@ -106,9 +108,24 @@ public class StatsRecorder
         throw new UnsupportedOperationException("Can't update binary");
     }
 
-    public void updateDate(int value)
+    public void updateDate(Date value)
     {
         throw new UnsupportedOperationException("Can't update date");
+    }
+
+    public void updateDate(long value)
+    {
+        throw new UnsupportedOperationException("Can't update date");
+    }
+
+    public void updateTime(Time value)
+    {
+        throw new UnsupportedOperationException("Can't update time");
+    }
+
+    public void updateTime(int value)
+    {
+        throw new UnsupportedOperationException("Can't update time");
     }
 
     public void updateTimestamp(Timestamp value)

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/stats/TimeColumnStats.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/stats/TimeColumnStats.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017-2019 PixelsDB.
+ *
+ * This file is part of Pixels.
+ *
+ * Pixels is free software: you can redistribute it and/or modify
+ * it under the terms of the Affero GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * Pixels is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Affero GNU General Public License for more details.
+ *
+ * You should have received a copy of the Affero GNU General Public
+ * License along with Pixels.  If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package io.pixelsdb.pixels.core.stats;
+
+/**
+ * pixels
+ *
+ * 2021-04-25
+ * @author hank
+ */
+public interface TimeColumnStats extends RangeStats<Integer>
+{
+    Integer getMinimum();
+
+    Integer getMaximum();
+}

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/stats/TimeStatsRecorder.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/stats/TimeStatsRecorder.java
@@ -21,37 +21,37 @@ package io.pixelsdb.pixels.core.stats;
 
 import io.pixelsdb.pixels.core.PixelsProto;
 
-import java.sql.Timestamp;
+import java.sql.Time;
 
 /**
  * pixels
  *
- * @author guodong
+ * 2021-04-25
+ * @author hank
  */
-public class TimestampStatsRecorder
-        extends StatsRecorder implements TimestampColumnStats
+public class TimeStatsRecorder
+        extends StatsRecorder implements TimeColumnStats
 {
-    // Issue #94: change hasMinimum to hasMinMax according to its semantic.
     private boolean hasMinMax = false;
-    private long minimum = Long.MAX_VALUE;
-    private long maximum = Long.MIN_VALUE;
+    private int minimum = Integer.MAX_VALUE;
+    private int maximum = Integer.MIN_VALUE;
 
-    TimestampStatsRecorder()
+    TimeStatsRecorder()
     {
     }
 
-    TimestampStatsRecorder(PixelsProto.ColumnStatistic statistic)
+    TimeStatsRecorder(PixelsProto.ColumnStatistic statistic)
     {
         super(statistic);
-        PixelsProto.TimestampStatistic tsState = statistic.getTimestampStatistics();
-        if (tsState.hasMinimum())
+        PixelsProto.TimeStatistic tState = statistic.getTimeStatistics();
+        if (tState.hasMinimum())
         {
-            minimum = tsState.getMinimum();
+            minimum = tState.getMinimum();
             hasMinMax = true;
         }
-        if (tsState.hasMaximum())
+        if (tState.hasMaximum())
         {
-            maximum = tsState.getMaximum();
+            maximum = tState.getMaximum();
             hasMinMax = true;
         }
     }
@@ -61,12 +61,12 @@ public class TimestampStatsRecorder
     {
         super.reset();
         hasMinMax = false;
-        minimum = Long.MIN_VALUE;
-        maximum = Long.MAX_VALUE;
+        minimum = Integer.MIN_VALUE;
+        maximum = Integer.MAX_VALUE;
     }
 
     @Override
-    public void updateTimestamp(long value)
+    public void updateTime(int value)
     {
         if (hasMinMax)
         {
@@ -88,22 +88,22 @@ public class TimestampStatsRecorder
     }
 
     @Override
-    public void updateTimestamp(Timestamp value)
+    public void updateTime(Time value)
     {
         if (hasMinMax)
         {
             if (value.getTime() < minimum)
             {
-                minimum = value.getTime();
+                minimum = (int)value.getTime();
             }
             if (value.getTime() > maximum)
             {
-                maximum = value.getTime();
+                maximum = (int)value.getTime();
             }
         }
         else
         {
-            minimum = maximum = value.getTime();
+            minimum = maximum = (int)value.getTime();
             hasMinMax = true;
         }
         numberOfValues++;
@@ -114,29 +114,29 @@ public class TimestampStatsRecorder
     {
         if (other instanceof TimestampColumnStats)
         {
-            TimestampStatsRecorder tsStat = (TimestampStatsRecorder) other;
+            TimeStatsRecorder tStat = (TimeStatsRecorder) other;
             if (hasMinMax)
             {
-                if (tsStat.getMinimum() < minimum)
+                if (tStat.getMinimum() < minimum)
                 {
-                    minimum = tsStat.getMinimum();
+                    minimum = tStat.getMinimum();
                 }
-                if (tsStat.getMaximum() > maximum)
+                if (tStat.getMaximum() > maximum)
                 {
-                    maximum = tsStat.getMaximum();
+                    maximum = tStat.getMaximum();
                 }
             }
             else
             {
-                minimum = tsStat.getMinimum();
-                maximum = tsStat.getMaximum();
+                minimum = tStat.getMinimum();
+                maximum = tStat.getMaximum();
             }
         }
         else
         {
             if (isStatsExists() && hasMinMax)
             {
-                throw new IllegalArgumentException("Incompatible merging of timestamp column statistics");
+                throw new IllegalArgumentException("Incompatible merging of time column statistics");
             }
         }
         super.merge(other);
@@ -146,23 +146,23 @@ public class TimestampStatsRecorder
     public PixelsProto.ColumnStatistic.Builder serialize()
     {
         PixelsProto.ColumnStatistic.Builder builder = super.serialize();
-        PixelsProto.TimestampStatistic.Builder tsBuilder =
-                PixelsProto.TimestampStatistic.newBuilder();
-        tsBuilder.setMinimum(minimum);
-        tsBuilder.setMaximum(maximum);
-        builder.setTimestampStatistics(tsBuilder);
+        PixelsProto.TimeStatistic.Builder tBuilder =
+                PixelsProto.TimeStatistic.newBuilder();
+        tBuilder.setMinimum(minimum);
+        tBuilder.setMaximum(maximum);
+        builder.setTimeStatistics(tBuilder);
         builder.setNumberOfValues(numberOfValues);
         return builder;
     }
 
     @Override
-    public Long getMinimum()
+    public Integer getMinimum()
     {
         return minimum;
     }
 
     @Override
-    public Long getMaximum()
+    public Integer getMaximum()
     {
         return maximum;
     }
@@ -190,7 +190,7 @@ public class TimestampStatsRecorder
         {
             return true;
         }
-        if (!(o instanceof TimestampStatsRecorder))
+        if (!(o instanceof TimeStatsRecorder))
         {
             return false;
         }
@@ -199,7 +199,7 @@ public class TimestampStatsRecorder
             return false;
         }
 
-        TimestampStatsRecorder that = (TimestampStatsRecorder) o;
+        TimeStatsRecorder that = (TimeStatsRecorder) o;
 
         if (hasMinMax ? !(minimum == that.minimum) : that.hasMinMax)
         {
@@ -222,8 +222,8 @@ public class TimestampStatsRecorder
     public int hashCode()
     {
         int result = super.hashCode();
-        result = 31 * result + (int) (minimum ^ (minimum >>> 32));
-        result = 31 * result + (int) (maximum ^ (maximum >>> 32));
+        result = 15 * result + (minimum ^ (minimum >>> 16));
+        result = 15 * result + (maximum ^ (maximum >>> 16));
         return result;
     }
 }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/utils/DatetimeUtils.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/utils/DatetimeUtils.java
@@ -8,6 +8,7 @@ import java.util.Calendar;
  */
 public class DatetimeUtils
 {
+    // TODO: currently we assume there are 86400000 millis in a day, without dealing with leap second.
     private static final int TIMEZONE_OFFSET;
 
     static
@@ -25,5 +26,10 @@ public class DatetimeUtils
     public static int millisToDay (long millis)
     {
         return (int)((millis-TIMEZONE_OFFSET)/86400000);
+    }
+
+    public static int roundSqlTime (long millis)
+    {
+        return (int)(millis%86400000);
     }
 }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/utils/DatetimeUtils.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/utils/DatetimeUtils.java
@@ -1,0 +1,29 @@
+package io.pixelsdb.pixels.core.utils;
+
+import java.util.Calendar;
+
+/**
+ * Created at: 26/04/2021
+ * Author: hank
+ */
+public class DatetimeUtils
+{
+    private static final int TIMEZONE_OFFSET;
+
+    static
+    {
+        Calendar calendar = Calendar.getInstance();
+        TIMEZONE_OFFSET = -(calendar.get(Calendar.ZONE_OFFSET) +
+                calendar.get(Calendar.DST_OFFSET)) / (60 * 1000);
+    }
+
+    public static long dayToMillis (int day)
+    {
+        return day*86400000L+TIMEZONE_OFFSET;
+    }
+
+    public static int millisToDay (long millis)
+    {
+        return (int)((millis-TIMEZONE_OFFSET)/86400000);
+    }
+}

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/ColumnVector.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/ColumnVector.java
@@ -19,6 +19,8 @@
  */
 package io.pixelsdb.pixels.core.vector;
 
+import java.sql.Date;
+import java.sql.Time;
 import java.sql.Timestamp;
 import java.util.Arrays;
 
@@ -136,6 +138,16 @@ public abstract class ColumnVector implements AutoCloseable
     public void add(String value)
     {
         throw new UnsupportedOperationException("Adding string is not supported");
+    }
+
+    public void add(Date value)
+    {
+        throw new UnsupportedOperationException("Adding date is not supported");
+    }
+
+    public void add(Time value)
+    {
+        throw new UnsupportedOperationException("Adding time is not supported");
     }
 
     public void add(Timestamp value)

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/DateColumnVector.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/DateColumnVector.java
@@ -1,0 +1,445 @@
+/*
+ * Copyright 2021 PixelsDB.
+ *
+ * This file is part of Pixels.
+ *
+ * Pixels is free software: you can redistribute it and/or modify
+ * it under the terms of the Affero GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * Pixels is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Affero GNU General Public License for more details.
+ *
+ * You should have received a copy of the Affero GNU General Public
+ * License along with Pixels.  If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package io.pixelsdb.pixels.core.vector;
+
+import java.sql.Date;
+import java.util.Arrays;
+
+/**
+ * DateColumnVector derived from io.pixelsdb.pixels.core.vector.TimestampColumnVector.
+ * <p>
+ * This class represents a nullable date column vector capable of handing a wide range of
+ * date values.
+ * <p>
+ * We store the value field of a Date class in primitive arrays.
+ * <p>
+ * We do this to avoid an array of Java Date objects which would have poor storage
+ * and memory access characteristics.
+ * <p>
+ * Generally, the caller will fill in a scratch date object with values from a row, work
+ * using the scratch date, and then perhaps update the column vector row with a result.
+ *
+ * 2021-04-24
+ * @author hank
+ */
+public class DateColumnVector extends ColumnVector
+{
+    /*
+     * The storage arrays for this column vector corresponds to the storage of a Date:
+     */
+    public long[] time;
+    // The values from Date.getTime().
+
+    /*
+     * Scratch objects.
+     */
+    private final Date scratchDate;
+
+    /**
+     * Use this constructor by default. All column vectors
+     * should normally be the default size.
+     */
+    public DateColumnVector()
+    {
+        this(VectorizedRowBatch.DEFAULT_SIZE);
+    }
+
+    /**
+     * Don't use this except for testing purposes.
+     *
+     * @param len the number of rows
+     */
+    public DateColumnVector(int len)
+    {
+        super(len);
+
+        time = new long[len];
+
+        scratchDate = new Date(0);
+    }
+
+    /**
+     * Return the number of rows.
+     *
+     * @return
+     */
+    public int getLength()
+    {
+        return time.length;
+    }
+
+    /**
+     * Return a row's Date.getTime() value.
+     * We assume the entry has already been NULL checked and isRepeated adjusted.
+     *
+     * @param elementNum
+     * @return
+     */
+    public long getTime(int elementNum)
+    {
+        return time[elementNum];
+    }
+
+    /**
+     * Set a Date object from a row of the column.
+     * We assume the entry has already been NULL checked and isRepeated adjusted.
+     *
+     * @param date
+     * @param elementNum
+     */
+    public void dateUpdate(Date date, int elementNum)
+    {
+        date.setTime(time[elementNum]);
+    }
+
+    /**
+     * Return the scratch Date object set from a row.
+     * We assume the entry has already been NULL checked and isRepeated adjusted.
+     *
+     * @param elementNum
+     * @return
+     */
+    public Date asScratchDate(int elementNum)
+    {
+        scratchDate.setTime(time[elementNum]);
+        return scratchDate;
+    }
+
+    /**
+     * Return the scratch date (contents undefined).
+     *
+     * @return
+     */
+    public Date getScratchDate()
+    {
+        return scratchDate;
+    }
+
+    /**
+     * Return a long representation of a date.
+     *
+     * @param elementNum
+     * @return
+     */
+    public long getDateAsLong(int elementNum)
+    {
+        scratchDate.setTime(time[elementNum]);
+        return getDateAsLong(scratchDate);
+    }
+
+    /**
+     * Return a long representation of a Date.
+     *
+     * @param date
+     * @return
+     */
+    public static long getDateAsLong(Date date)
+    {
+        return millisToSeconds(date.getTime());
+    }
+
+    // Copy of TimestampWritable.millisToSeconds
+
+    /**
+     * Rounds the number of milliseconds relative to the epoch down to the nearest whole number of
+     * seconds. 500 would round to 0, -500 would round to -1.
+     */
+    private static long millisToSeconds(long millis)
+    {
+        if (millis >= 0)
+        {
+            return millis / 1000;
+        }
+        else
+        {
+            return (millis - 999) / 1000;
+        }
+    }
+
+    /**
+     * Compare row to Date.
+     * We assume the entry has already been NULL checked and isRepeated adjusted.
+     *
+     * @param elementNum
+     * @param date
+     * @return -1, 0, 1 standard compareTo values.
+     */
+    public int compareTo(int elementNum, Date date)
+    {
+        return asScratchDate(elementNum).compareTo(date);
+    }
+
+    /**
+     * Compare Date to row.
+     * We assume the entry has already been NULL checked and isRepeated adjusted.
+     *
+     * @param date
+     * @param elementNum
+     * @return -1, 0, 1 standard compareTo values.
+     */
+    public int compareTo(Date date, int elementNum)
+    {
+        return date.compareTo(asScratchDate(elementNum));
+    }
+
+    /**
+     * Compare a row to another DateColumnVector's row.
+     *
+     * @param elementNum1
+     * @param dateColVector2
+     * @param elementNum2
+     * @return
+     */
+    public int compareTo(int elementNum1, DateColumnVector dateColVector2,
+                         int elementNum2)
+    {
+        return asScratchDate(elementNum1).compareTo(
+                dateColVector2.asScratchDate(elementNum2));
+    }
+
+    /**
+     * Compare another DateColumnVector's row to a row.
+     *
+     * @param dateColVector1
+     * @param elementNum1
+     * @param elementNum2
+     * @return
+     */
+    public int compareTo(DateColumnVector dateColVector1, int elementNum1,
+                         int elementNum2)
+    {
+        return dateColVector1.asScratchDate(elementNum1).compareTo(
+                asScratchDate(elementNum2));
+    }
+
+    @Override
+    public void setElement(int outElementNum, int inputElementNum, ColumnVector inputVector)
+    {
+        DateColumnVector dateColVector = (DateColumnVector) inputVector;
+
+        time[outElementNum] = dateColVector.time[inputElementNum];
+    }
+
+    @Override
+    public void duplicate(ColumnVector inputVector)
+    {
+        if (inputVector instanceof DateColumnVector)
+        {
+            DateColumnVector srcVector = (DateColumnVector) inputVector;
+            this.time = srcVector.time;
+            this.isNull = srcVector.isNull;
+            this.noNulls = srcVector.noNulls;
+            this.isRepeating = srcVector.isRepeating;
+            this.writeIndex = srcVector.writeIndex;
+        }
+    }
+
+    /**
+     * Simplify vector by brute-force flattening noNulls and isRepeating
+     * This can be used to reduce combinatorial explosion of code paths in VectorExpressions
+     * with many arguments.
+     * @param selectedInUse whether use the selected indexes in sel or not.
+     * @param sel the selected indexes.
+     * @param size the size of sel or the number of values to flatten.
+     */
+    public void flatten(boolean selectedInUse, int[] sel, int size)
+    {
+        flattenPush();
+        if (isRepeating)
+        {
+            isRepeating = false;
+            long repeatFastTime = time[0];
+            if (selectedInUse)
+            {
+                for (int j = 0; j < size; j++)
+                {
+                    int i = sel[j];
+                    time[i] = repeatFastTime;
+                }
+            }
+            else
+            {
+                Arrays.fill(time, 0, size, repeatFastTime);
+            }
+            flattenRepeatingNulls(selectedInUse, sel, size);
+        }
+        flattenNoNulls(selectedInUse, sel, size);
+    }
+
+    @Override
+    public void add(Date value)
+    {
+        set(writeIndex++, value);
+    }
+
+    /**
+     * Set a row from a date.
+     * We assume the entry has already been isRepeated adjusted.
+     *
+     * @param elementNum
+     * @param date
+     */
+    public void set(int elementNum, Date date)
+    {
+        if (date == null)
+        {
+            this.noNulls = false;
+            this.isNull[elementNum] = true;
+        }
+        else
+        {
+            this.time[elementNum] = date.getTime();
+        }
+    }
+
+    /**
+     * Set a row from the current value in the scratch date.
+     *
+     * @param elementNum
+     */
+    public void setFromScratchDate(int elementNum)
+    {
+        this.time[elementNum] = scratchDate.getTime();
+    }
+
+    /**
+     * Set row to standard null value(s).
+     * We assume the entry has already been isRepeated adjusted.
+     *
+     * @param elementNum
+     */
+    public void setNullValue(int elementNum)
+    {
+        time[elementNum] = 0;
+    }
+
+    // Copy the current object contents into the output. Only copy selected entries,
+    // as indicated by selectedInUse and the sel array.
+    public void copySelected(
+            boolean selectedInUse, int[] sel, int size, DateColumnVector output)
+    {
+        // Output has nulls if and only if input has nulls.
+        output.noNulls = noNulls;
+        output.isRepeating = false;
+
+        // Handle repeating case
+        if (isRepeating)
+        {
+            output.time[0] = time[0];
+            output.isNull[0] = isNull[0];
+            output.isRepeating = true;
+            return;
+        }
+
+        // Handle normal case
+
+        // Copy data values over
+        if (selectedInUse)
+        {
+            for (int j = 0; j < size; j++)
+            {
+                int i = sel[j];
+                output.time[i] = time[i];
+            }
+        }
+        else
+        {
+            System.arraycopy(time, 0, output.time, 0, size);
+        }
+
+        // Copy nulls over if needed
+        if (!noNulls)
+        {
+            if (selectedInUse)
+            {
+                for (int j = 0; j < size; j++)
+                {
+                    int i = sel[j];
+                    output.isNull[i] = isNull[i];
+                }
+            }
+            else
+            {
+                System.arraycopy(isNull, 0, output.isNull, 0, size);
+            }
+        }
+    }
+
+    /**
+     * Fill all the vector entries with a date.
+     *
+     * @param date
+     */
+    public void fill(Date date)
+    {
+        noNulls = true;
+        isRepeating = true;
+        time[0] = date.getTime();
+    }
+
+    @Override
+    public void stringifyValue(StringBuilder buffer, int row)
+    {
+        if (isRepeating)
+        {
+            row = 0;
+        }
+        if (noNulls || !isNull[row])
+        {
+            scratchDate.setTime(time[row]);
+            buffer.append(scratchDate.toString());
+        }
+        else
+        {
+            buffer.append("null");
+        }
+    }
+
+    @Override
+    public void ensureSize(int size, boolean preserveData)
+    {
+        super.ensureSize(size, preserveData);
+        if (size <= time.length)
+        {
+            return;
+        }
+        long[] oldTime = time;
+        time = new long[size];
+        length = size;
+        if (preserveData)
+        {
+            if (isRepeating)
+            {
+                time[0] = oldTime[0];
+            }
+            else
+            {
+                System.arraycopy(oldTime, 0, time, 0, oldTime.length);
+            }
+        }
+    }
+
+    @Override
+    public void close()
+    {
+        super.close();
+        this.time = null;
+    }
+}

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/DateColumnVector.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/DateColumnVector.java
@@ -22,7 +22,8 @@ package io.pixelsdb.pixels.core.vector;
 import java.sql.Date;
 import java.util.Arrays;
 
-import static io.pixelsdb.pixels.core.utils.DatetimeUtils.*;
+import static io.pixelsdb.pixels.core.utils.DatetimeUtils.dayToMillis;
+import static io.pixelsdb.pixels.core.utils.DatetimeUtils.millisToDay;
 
 /**
  * DateColumnVector derived from io.pixelsdb.pixels.core.vector.TimestampColumnVector.
@@ -291,6 +292,12 @@ public class DateColumnVector extends ColumnVector
     public void add(Date value)
     {
         set(writeIndex++, value);
+    }
+
+    @Override
+    public void add(String value)
+    {
+        set(writeIndex++, Date.valueOf(value));
     }
 
     /**

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/DateColumnVector.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/DateColumnVector.java
@@ -49,7 +49,6 @@ public class DateColumnVector extends ColumnVector
      * representation in Presto.
      */
     public int[] time;
-    // The values from Date.getTime().
 
     /*
      * Scratch objects.
@@ -90,7 +89,7 @@ public class DateColumnVector extends ColumnVector
     }
 
     /**
-     * Return a row's Date.getTime() value.
+     * Return a row's value, which is the days from epoch (1970-1-1 0:0:0 UTC).
      * We assume the entry has already been NULL checked and isRepeated adjusted.
      *
      * @param elementNum
@@ -312,6 +311,18 @@ public class DateColumnVector extends ColumnVector
         {
             this.time[elementNum] = millisToDay(date.getTime());
         }
+    }
+
+    /**
+     * Set a row from a value, which is the days from 1970-1-1 UTC.
+     * We assume the entry has already been isRepeated adjusted.
+     *
+     * @param elementNum
+     * @param days
+     */
+    public void set(int elementNum, int days)
+    {
+        this.time[elementNum] = days;
     }
 
     /**

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/TimeColumnVector.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/TimeColumnVector.java
@@ -22,6 +22,8 @@ package io.pixelsdb.pixels.core.vector;
 import java.sql.Time;
 import java.util.Arrays;
 
+import static io.pixelsdb.pixels.core.utils.DatetimeUtils.roundSqlTime;
+
 /**
  * TimeColumnVector derived from io.pixelsdb.pixels.core.vector.TimestampColumnVector.
  * <p>
@@ -86,7 +88,7 @@ public class TimeColumnVector extends ColumnVector
     }
 
     /**
-     * Return a row's Time.getTime() value.
+     * Return a row's value, which is the millis in a day.
      * We assume the entry has already been NULL checked and isRepeated adjusted.
      *
      * @param elementNum
@@ -305,8 +307,20 @@ public class TimeColumnVector extends ColumnVector
         }
         else
         {
-            this.time[elementNum] = (int)t.getTime();
+            this.time[elementNum] = roundSqlTime(t.getTime());
         }
+    }
+
+    /**
+     * Set a row from a value, which is the millis in the day.
+     * We assume the entry has already been isRepeated adjusted.
+     *
+     * @param elementNum
+     * @param millis
+     */
+    public void set(int elementNum, int millis)
+    {
+        this.time[elementNum] = millis;
     }
 
     /**
@@ -316,7 +330,8 @@ public class TimeColumnVector extends ColumnVector
      */
     public void setFromScratchTime(int elementNum)
     {
-        this.time[elementNum] = (int)scratchTime.getTime();
+        // scratchTime may be changed outside this class, so we also mod it by millis in a day.
+        this.time[elementNum] = roundSqlTime(scratchTime.getTime());
     }
 
     /**
@@ -391,7 +406,7 @@ public class TimeColumnVector extends ColumnVector
     {
         noNulls = true;
         isRepeating = true;
-        time[0] = (int)t.getTime();
+        time[0] = roundSqlTime(t.getTime());
     }
 
     @Override

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/TimeColumnVector.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/TimeColumnVector.java
@@ -286,9 +286,15 @@ public class TimeColumnVector extends ColumnVector
     }
 
     @Override
-    public void add(Time t)
+    public void add(Time value)
     {
-        set(writeIndex++, t);
+        set(writeIndex++, value);
+    }
+
+    @Override
+    public void add(String value)
+    {
+        set(writeIndex++, Time.valueOf(value));
     }
 
     /**

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/TimeColumnVector.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/TimeColumnVector.java
@@ -1,0 +1,445 @@
+/*
+ * Copyright 2021 PixelsDB.
+ *
+ * This file is part of Pixels.
+ *
+ * Pixels is free software: you can redistribute it and/or modify
+ * it under the terms of the Affero GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * Pixels is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Affero GNU General Public License for more details.
+ *
+ * You should have received a copy of the Affero GNU General Public
+ * License along with Pixels.  If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package io.pixelsdb.pixels.core.vector;
+
+import java.sql.Time;
+import java.util.Arrays;
+
+/**
+ * TimeColumnVector derived from io.pixelsdb.pixels.core.vector.TimestampColumnVector.
+ * <p>
+ * This class represents a nullable time column vector capable of handing a wide range of
+ * time values.
+ * <p>
+ * We store the value field of a Time class in primitive arrays.
+ * <p>
+ * We do this to avoid an array of Java Time objects which would have poor storage
+ * and memory access characteristics.
+ * <p>
+ * Generally, the caller will fill in a scratch time object with values from a row, work
+ * using the scratch time, and then perhaps update the column vector row with a result.
+ *
+ * 2021-04-25
+ * @author hank
+ */
+public class TimeColumnVector extends ColumnVector
+{
+    /*
+     * The storage arrays for this column vector corresponds to the storage of a Time:
+     */
+    public int[] time;
+    // The values from Time.getTime().
+
+    /*
+     * Scratch objects.
+     */
+    private final Time scratchTime;
+
+    /**
+     * Use this constructor by default. All column vectors
+     * should normally be the default size.
+     */
+    public TimeColumnVector()
+    {
+        this(VectorizedRowBatch.DEFAULT_SIZE);
+    }
+
+    /**
+     * Don't use this except for testing purposes.
+     *
+     * @param len the number of rows
+     */
+    public TimeColumnVector(int len)
+    {
+        super(len);
+
+        time = new int[len];
+
+        scratchTime = new Time(0);
+    }
+
+    /**
+     * Return the number of rows.
+     *
+     * @return
+     */
+    public int getLength()
+    {
+        return time.length;
+    }
+
+    /**
+     * Return a row's Time.getTime() value.
+     * We assume the entry has already been NULL checked and isRepeated adjusted.
+     *
+     * @param elementNum
+     * @return
+     */
+    public long getTime(int elementNum)
+    {
+        return time[elementNum];
+    }
+
+    /**
+     * Set a Time object from a row of the column.
+     * We assume the entry has already been NULL checked and isRepeated adjusted.
+     *
+     * @param t the time
+     * @param elementNum
+     */
+    public void timeUpdate(Time t, int elementNum)
+    {
+        t.setTime(time[elementNum]);
+    }
+
+    /**
+     * Return the scratch Time object set from a row.
+     * We assume the entry has already been NULL checked and isRepeated adjusted.
+     *
+     * @param elementNum
+     * @return
+     */
+    public Time asScratchTime(int elementNum)
+    {
+        scratchTime.setTime(time[elementNum]);
+        return scratchTime;
+    }
+
+    /**
+     * Return the scratch time (contents undefined).
+     *
+     * @return
+     */
+    public Time getScratchTime()
+    {
+        return scratchTime;
+    }
+
+    /**
+     * Return a long representation of a time.
+     *
+     * @param elementNum
+     * @return
+     */
+    public long getTimeAsLong(int elementNum)
+    {
+        scratchTime.setTime(time[elementNum]);
+        return getTimeAsLong(scratchTime);
+    }
+
+    /**
+     * Return a long representation of a Time.
+     *
+     * @param t the time
+     * @return
+     */
+    public static long getTimeAsLong(Time t)
+    {
+        return millisToSeconds(t.getTime());
+    }
+
+    // Copy of TimestampWritable.millisToSeconds
+
+    /**
+     * Rounds the number of milliseconds relative to the epoch down to the nearest whole number of
+     * seconds. 500 would round to 0, -500 would round to -1.
+     */
+    private static long millisToSeconds(long millis)
+    {
+        if (millis >= 0)
+        {
+            return millis / 1000;
+        }
+        else
+        {
+            return (millis - 999) / 1000;
+        }
+    }
+
+    /**
+     * Compare row to Time.
+     * We assume the entry has already been NULL checked and isRepeated adjusted.
+     *
+     * @param elementNum
+     * @param t the time
+     * @return -1, 0, 1 standard compareTo values.
+     */
+    public int compareTo(int elementNum, Time t)
+    {
+        return asScratchTime(elementNum).compareTo(t);
+    }
+
+    /**
+     * Compare Time to row.
+     * We assume the entry has already been NULL checked and isRepeated adjusted.
+     *
+     * @param t the time
+     * @param elementNum
+     * @return -1, 0, 1 standard compareTo values.
+     */
+    public int compareTo(Time t, int elementNum)
+    {
+        return t.compareTo(asScratchTime(elementNum));
+    }
+
+    /**
+     * Compare a row to another TimeColumnVector's row.
+     *
+     * @param elementNum1
+     * @param timeColVector2
+     * @param elementNum2
+     * @return
+     */
+    public int compareTo(int elementNum1, TimeColumnVector timeColVector2,
+                         int elementNum2)
+    {
+        return asScratchTime(elementNum1).compareTo(
+                timeColVector2.asScratchTime(elementNum2));
+    }
+
+    /**
+     * Compare another TimeColumnVector's row to a row.
+     *
+     * @param timeColVector1
+     * @param elementNum1
+     * @param elementNum2
+     * @return
+     */
+    public int compareTo(TimeColumnVector timeColVector1, int elementNum1,
+                         int elementNum2)
+    {
+        return timeColVector1.asScratchTime(elementNum1).compareTo(
+                asScratchTime(elementNum2));
+    }
+
+    @Override
+    public void setElement(int outElementNum, int inputElementNum, ColumnVector inputVector)
+    {
+        TimeColumnVector timeColVector = (TimeColumnVector) inputVector;
+
+        time[outElementNum] = timeColVector.time[inputElementNum];
+    }
+
+    @Override
+    public void duplicate(ColumnVector inputVector)
+    {
+        if (inputVector instanceof TimeColumnVector)
+        {
+            TimeColumnVector srcVector = (TimeColumnVector) inputVector;
+            this.time = srcVector.time;
+            this.isNull = srcVector.isNull;
+            this.noNulls = srcVector.noNulls;
+            this.isRepeating = srcVector.isRepeating;
+            this.writeIndex = srcVector.writeIndex;
+        }
+    }
+
+    /**
+     * Simplify vector by brute-force flattening noNulls and isRepeating
+     * This can be used to reduce combinatorial explosion of code paths in VectorExpressions
+     * with many arguments.
+     * @param selectedInUse whether use the selected indexes in sel or not.
+     * @param sel the selected indexes.
+     * @param size the size of sel or the number of values to flatten.
+     */
+    public void flatten(boolean selectedInUse, int[] sel, int size)
+    {
+        flattenPush();
+        if (isRepeating)
+        {
+            isRepeating = false;
+            int repeatFastTime = time[0];
+            if (selectedInUse)
+            {
+                for (int j = 0; j < size; j++)
+                {
+                    int i = sel[j];
+                    time[i] = repeatFastTime;
+                }
+            }
+            else
+            {
+                Arrays.fill(time, 0, size, repeatFastTime);
+            }
+            flattenRepeatingNulls(selectedInUse, sel, size);
+        }
+        flattenNoNulls(selectedInUse, sel, size);
+    }
+
+    @Override
+    public void add(Time t)
+    {
+        set(writeIndex++, t);
+    }
+
+    /**
+     * Set a row from a time.
+     * We assume the entry has already been isRepeated adjusted.
+     *
+     * @param elementNum
+     * @param t the time
+     */
+    public void set(int elementNum, Time t)
+    {
+        if (t == null)
+        {
+            this.noNulls = false;
+            this.isNull[elementNum] = true;
+        }
+        else
+        {
+            this.time[elementNum] = (int)t.getTime();
+        }
+    }
+
+    /**
+     * Set a row from the current value in the scratch time.
+     *
+     * @param elementNum
+     */
+    public void setFromScratchTime(int elementNum)
+    {
+        this.time[elementNum] = (int)scratchTime.getTime();
+    }
+
+    /**
+     * Set row to standard null value(s).
+     * We assume the entry has already been isRepeated adjusted.
+     *
+     * @param elementNum
+     */
+    public void setNullValue(int elementNum)
+    {
+        time[elementNum] = 0;
+    }
+
+    // Copy the current object contents into the output. Only copy selected entries,
+    // as indicated by selectedInUse and the sel array.
+    public void copySelected(
+            boolean selectedInUse, int[] sel, int size, TimeColumnVector output)
+    {
+        // Output has nulls if and only if input has nulls.
+        output.noNulls = noNulls;
+        output.isRepeating = false;
+
+        // Handle repeating case
+        if (isRepeating)
+        {
+            output.time[0] = time[0];
+            output.isNull[0] = isNull[0];
+            output.isRepeating = true;
+            return;
+        }
+
+        // Handle normal case
+
+        // Copy data values over
+        if (selectedInUse)
+        {
+            for (int j = 0; j < size; j++)
+            {
+                int i = sel[j];
+                output.time[i] = time[i];
+            }
+        }
+        else
+        {
+            System.arraycopy(time, 0, output.time, 0, size);
+        }
+
+        // Copy nulls over if needed
+        if (!noNulls)
+        {
+            if (selectedInUse)
+            {
+                for (int j = 0; j < size; j++)
+                {
+                    int i = sel[j];
+                    output.isNull[i] = isNull[i];
+                }
+            }
+            else
+            {
+                System.arraycopy(isNull, 0, output.isNull, 0, size);
+            }
+        }
+    }
+
+    /**
+     * Fill all the vector entries with a time.
+     *
+     * @param t the time
+     */
+    public void fill(Time t)
+    {
+        noNulls = true;
+        isRepeating = true;
+        time[0] = (int)t.getTime();
+    }
+
+    @Override
+    public void stringifyValue(StringBuilder buffer, int row)
+    {
+        if (isRepeating)
+        {
+            row = 0;
+        }
+        if (noNulls || !isNull[row])
+        {
+            scratchTime.setTime(time[row]);
+            buffer.append(scratchTime.toString());
+        }
+        else
+        {
+            buffer.append("null");
+        }
+    }
+
+    @Override
+    public void ensureSize(int size, boolean preserveData)
+    {
+        super.ensureSize(size, preserveData);
+        if (size <= time.length)
+        {
+            return;
+        }
+        int[] oldTime = time;
+        time = new int[size];
+        length = size;
+        if (preserveData)
+        {
+            if (isRepeating)
+            {
+                time[0] = oldTime[0];
+            }
+            else
+            {
+                System.arraycopy(oldTime, 0, time, 0, oldTime.length);
+            }
+        }
+    }
+
+    @Override
+    public void close()
+    {
+        super.close();
+        this.time = null;
+    }
+}

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/TimestampColumnVector.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/TimestampColumnVector.java
@@ -44,6 +44,7 @@ public class TimestampColumnVector extends ColumnVector
     public long[] time;
     // The values from Timestamp.getTime().
 
+    // TODO: fully support or remove nanos. And it can be int[].
     public long[] nanos;
     // The values from Timestamp.getNanos().
 

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/DateColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/DateColumnWriter.java
@@ -30,14 +30,15 @@ import java.nio.ByteBuffer;
 
 /**
  * Date column writer.
- * All date values are converted to standard UTC time before they are stored as long values.
+ * All date values are converted to the number of days from
+ * UTC 1970-1-1 0:0：0 before they are stored as int values.
  *
  * 2021-04-25
  * @author hank
  */
 public class DateColumnWriter extends BaseColumnWriter
 {
-    private final long[] curPixelVector = new long[pixelStride];
+    private final int[] curPixelVector = new int[pixelStride];
 
     public DateColumnWriter(TypeDescription schema, int pixelStride, boolean isEncoding)
     {
@@ -51,7 +52,7 @@ public class DateColumnWriter extends BaseColumnWriter
             throws IOException
     {
         DateColumnVector columnVector = (DateColumnVector) vector;
-        long[] times = columnVector.time;
+        int[] times = columnVector.time;
         int curPartLength;
         int curPartOffset = 0;
         int nextPartLength = size;
@@ -71,7 +72,7 @@ public class DateColumnWriter extends BaseColumnWriter
         return outputStream.size();
     }
 
-    private void writeCurPartTime(DateColumnVector columnVector, long[] values, int curPartLength, int curPartOffset)
+    private void writeCurPartTime(DateColumnVector columnVector, int[] values, int curPartLength, int curPartOffset)
     {
         for (int i = 0; i < curPartLength; i++)
         {
@@ -101,17 +102,17 @@ public class DateColumnWriter extends BaseColumnWriter
 
         if (isEncoding)
         {
-            long[] values = new long[curPixelVectorIndex];
+            int[] values = new int[curPixelVectorIndex];
             System.arraycopy(curPixelVector, 0, values, 0, curPixelVectorIndex);
             outputStream.write(encoder.encode(values));
         }
         else
         {
             ByteBuffer curVecPartitionBuffer =
-                    ByteBuffer.allocate(curPixelVectorIndex * Long.BYTES);
+                    ByteBuffer.allocate(curPixelVectorIndex * Integer.BYTES);
             for (int i = 0; i < curPixelVectorIndex; i++)
             {
-                curVecPartitionBuffer.putLong(curPixelVector[i]);
+                curVecPartitionBuffer.putInt(curPixelVector[i]);
             }
             outputStream.write(curVecPartitionBuffer.array());
         }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/DateColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/DateColumnWriter.java
@@ -23,26 +23,26 @@ import io.pixelsdb.pixels.core.PixelsProto;
 import io.pixelsdb.pixels.core.TypeDescription;
 import io.pixelsdb.pixels.core.encoding.RunLenIntEncoder;
 import io.pixelsdb.pixels.core.vector.ColumnVector;
-import io.pixelsdb.pixels.core.vector.TimestampColumnVector;
+import io.pixelsdb.pixels.core.vector.DateColumnVector;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
 /**
- * Timestamp column writer.
- * All timestamp values are converted to standard UTC time before they are stored as long values.
- * Currently not support nanos
+ * Date column writer.
+ * All date values are converted to standard UTC time before they are stored as long values.
  *
- * @author guodong
+ * 2021-04-25
+ * @author hank
  */
-public class TimestampColumnWriter extends BaseColumnWriter
+public class DateColumnWriter extends BaseColumnWriter
 {
     private final long[] curPixelVector = new long[pixelStride];
 
-    public TimestampColumnWriter(TypeDescription schema, int pixelStride, boolean isEncoding)
+    public DateColumnWriter(TypeDescription schema, int pixelStride, boolean isEncoding)
     {
         super(schema, pixelStride, isEncoding);
-        // Issue #94: time can be negative if it is before 1970-1-1 0:0:0.
+        // Issue #94: Date.getTime() can be negative if the date is before 1970-1-1.
         encoder = new RunLenIntEncoder(true, true);
     }
 
@@ -50,7 +50,7 @@ public class TimestampColumnWriter extends BaseColumnWriter
     public int write(ColumnVector vector, int size)
             throws IOException
     {
-        TimestampColumnVector columnVector = (TimestampColumnVector) vector;
+        DateColumnVector columnVector = (DateColumnVector) vector;
         long[] times = columnVector.time;
         int curPartLength;
         int curPartOffset = 0;
@@ -71,7 +71,7 @@ public class TimestampColumnWriter extends BaseColumnWriter
         return outputStream.size();
     }
 
-    private void writeCurPartTime(TimestampColumnVector columnVector, long[] values, int curPartLength, int curPartOffset)
+    private void writeCurPartTime(DateColumnVector columnVector, long[] values, int curPartLength, int curPartOffset)
     {
         for (int i = 0; i < curPartLength; i++)
         {
@@ -96,7 +96,7 @@ public class TimestampColumnWriter extends BaseColumnWriter
     {
         for (int i = 0; i < curPixelVectorIndex; i++)
         {
-            pixelStatRecorder.updateTimestamp(curPixelVector[i]);
+            pixelStatRecorder.updateDate(curPixelVector[i]);
         }
 
         if (isEncoding)

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/IntegerColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/IntegerColumnWriter.java
@@ -82,7 +82,7 @@ public class IntegerColumnWriter extends BaseColumnWriter
             if (columnVector.isNull[i + curPartOffset])
             {
                 hasNull = true;
-                pixelStatRecorder.increment(); // TODO: check if it is correct.
+                pixelStatRecorder.increment();
             }
             else
             {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/IntegerColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/IntegerColumnWriter.java
@@ -82,7 +82,7 @@ public class IntegerColumnWriter extends BaseColumnWriter
             if (columnVector.isNull[i + curPartOffset])
             {
                 hasNull = true;
-                pixelStatRecorder.increment();
+                pixelStatRecorder.increment(); // TODO: check if it is correct.
             }
             else
             {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/TimestampColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/TimestampColumnWriter.java
@@ -31,7 +31,7 @@ import java.nio.ByteBuffer;
 /**
  * Timestamp column writer.
  * All timestamp values are converted to standard UTC time before they are stored as long values.
- * Currently not support nanos
+ * TODO: Currently not support nanos
  *
  * @author guodong
  */

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/TestColumnVector.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/TestColumnVector.java
@@ -73,6 +73,10 @@ public class TestColumnVector
         System.out.println((int)time.getTime());
         Timestamp timestamp = Timestamp.valueOf("2018-05-07 20:39:20");
         System.out.println(timestamp.getNanos());
+        date = new Date(System.currentTimeMillis());
+        System.out.println(date.toString());
+        time = new Time(System.currentTimeMillis());
+        System.out.println(time.toString());
     }
 
     @Test

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/TestColumnVector.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/TestColumnVector.java
@@ -27,6 +27,8 @@ import io.pixelsdb.pixels.core.vector.TimestampColumnVector;
 import io.pixelsdb.pixels.core.vector.VectorizedRowBatch;
 import org.junit.Test;
 
+import java.sql.Date;
+import java.sql.Time;
 import java.sql.Timestamp;
 
 import static org.junit.Assert.assertEquals;
@@ -60,6 +62,17 @@ public class TestColumnVector
             sb.append("\n");
         }
         System.out.println(sb.toString());
+    }
+
+    @Test
+    public void testDateTimeTypes()
+    {
+        Date date = Date.valueOf("1900-12-31");
+        System.out.println(date.getTime());
+        Time time = Time.valueOf("23:59:59");
+        System.out.println((int)time.getTime());
+        Timestamp timestamp = Timestamp.valueOf("2018-05-07 20:39:20");
+        System.out.println(timestamp.getNanos());
     }
 
     @Test

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/writer/TestPixelsWriter.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/writer/TestPixelsWriter.java
@@ -50,6 +50,7 @@ import java.util.List;
  * pixels
  *
  * @author guodong
+ * @author hank
  */
 public class TestPixelsWriter
 {

--- a/pixels-load/src/main/java/io/pixelsdb/pixels/load/multi/Config.java
+++ b/pixels-load/src/main/java/io/pixelsdb/pixels/load/multi/Config.java
@@ -159,6 +159,7 @@ public class Config
             {
                 type = "string";
             }
+            // TODO: support varchar(n).
             schemaBuilder.append(name).append(":").append(type)
                     .append(",");
         }

--- a/pixels-load/src/test/java/io/pixelsdb/pixels/load/TestSplitString.java
+++ b/pixels-load/src/test/java/io/pixelsdb/pixels/load/TestSplitString.java
@@ -1,0 +1,19 @@
+package io.pixelsdb.pixels.load;
+
+import org.junit.Test;
+
+/**
+ * Created at: 29/04/2021
+ * Author: hank
+ */
+public class TestSplitString
+{
+    @Test
+    public void test()
+    {
+        String s = "1|3689999|O|224560.83|1996-01-02|5-LOW|Clerk#000095055|0|nstructions sleep furiously among |";
+        String reg = "\\\\|";
+        String splits[] = s.split(reg);
+        System.out.println(splits.length);
+    }
+}

--- a/pixels-presto/src/main/java/io/pixelsdb/pixels/presto/PixelsTypeManager.java
+++ b/pixels-presto/src/main/java/io/pixelsdb/pixels/presto/PixelsTypeManager.java
@@ -29,9 +29,11 @@ import java.util.*;
 
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.type.DateType.DATE;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
 import static com.facebook.presto.spi.type.RealType.REAL;
+import static com.facebook.presto.spi.type.TimeType.TIME;
 import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -75,7 +77,7 @@ public class PixelsTypeManager
         // TODO: support more data types.
         // TODO: map presto data type to pixels data type more gracefully.
         // currently we do this by hard code in PixelsPageSource
-        supportedTypes = ImmutableList.of(BOOLEAN, INTEGER, BIGINT, DOUBLE, REAL, VARCHAR, TIMESTAMP);
+        supportedTypes = ImmutableList.of(BOOLEAN, INTEGER, BIGINT, DOUBLE, REAL, VARCHAR, TIMESTAMP, DATE, TIME);
         signatureToType = new HashMap<>();
         for (Type type : supportedTypes)
         {

--- a/pixels-presto/src/main/java/io/pixelsdb/pixels/presto/block/BlockUtil.java
+++ b/pixels-presto/src/main/java/io/pixelsdb/pixels/presto/block/BlockUtil.java
@@ -12,6 +12,11 @@ import static java.lang.Math.ceil;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
+/**
+ * This class is derived from com.facebook.presto.spi.block.BlockUtil.
+ * Created at: 19-6-1
+ * Author: hank
+ */
 final class BlockUtil
 {
     private static final double BLOCK_RESET_SKEW = 1.25;

--- a/pixels-presto/src/main/java/io/pixelsdb/pixels/presto/block/TimeArrayBlock.java
+++ b/pixels-presto/src/main/java/io/pixelsdb/pixels/presto/block/TimeArrayBlock.java
@@ -1,0 +1,240 @@
+package io.pixelsdb.pixels.presto.block;
+
+import com.facebook.presto.spi.block.*;
+import org.openjdk.jol.info.ClassLayout;
+
+import java.util.function.BiConsumer;
+
+import static io.pixelsdb.pixels.presto.block.BlockUtil.*;
+import static io.airlift.slice.SizeOf.sizeOf;
+
+/**
+ * This class is derived from com.facebook.presto.spi.block.IntArrayBlock.
+ *
+ * With this class, we use int values to simulate a LongArrayBlock, so that
+ * we can reduce 50% memory footprint. Int value is enough for time type
+ * in Pixels.
+ *
+ * Modifications:
+ * 1. add getLong, getShort, getByte, so that this class can be compatible
+ * with com.facebook.presto.spi.block.LongArrayBlock.
+ *
+ * 2. change the returned statement of the methods that return Block or
+ * BlockEncoding.
+ *
+ * Created at: 26/04/2021
+ * Author: hank
+ */
+public class TimeArrayBlock implements Block
+{
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(TimeArrayBlock.class).instanceSize();
+
+    private final int arrayOffset;
+    private final int positionCount;
+    private final boolean[] valueIsNull;
+    private final int[] values;
+
+    private final long sizeInBytes;
+    private final long retainedSizeInBytes;
+
+    public TimeArrayBlock(int positionCount, boolean[] valueIsNull, int[] values)
+    {
+        this(0, positionCount, valueIsNull, values);
+    }
+
+    TimeArrayBlock(int arrayOffset, int positionCount, boolean[] valueIsNull, int[] values)
+    {
+        if (arrayOffset < 0) {
+            throw new IllegalArgumentException("arrayOffset is negative");
+        }
+        this.arrayOffset = arrayOffset;
+        if (positionCount < 0) {
+            throw new IllegalArgumentException("positionCount is negative");
+        }
+        this.positionCount = positionCount;
+
+        if (values.length - arrayOffset < positionCount) {
+            throw new IllegalArgumentException("values length is less than positionCount");
+        }
+        this.values = values;
+
+        if (valueIsNull.length - arrayOffset < positionCount) {
+            throw new IllegalArgumentException("isNull length is less than positionCount");
+        }
+        this.valueIsNull = valueIsNull;
+
+        sizeInBytes = (Integer.BYTES + Byte.BYTES) * (long) positionCount;
+        retainedSizeInBytes = INSTANCE_SIZE + sizeOf(valueIsNull) + sizeOf(values);
+    }
+
+    @Override
+    public long getSizeInBytes()
+    {
+        return sizeInBytes;
+    }
+
+    @Override
+    public long getRegionSizeInBytes(int position, int length)
+    {
+        return (Integer.BYTES + Byte.BYTES) * (long) length;
+    }
+
+    @Override
+    public long getRetainedSizeInBytes()
+    {
+        return retainedSizeInBytes;
+    }
+
+    @Override
+    public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
+    {
+        consumer.accept(values, sizeOf(values));
+        consumer.accept(valueIsNull, sizeOf(valueIsNull));
+        consumer.accept(this, (long) INSTANCE_SIZE);
+    }
+
+    @Override
+    public int getPositionCount()
+    {
+        return positionCount;
+    }
+
+    @Override
+    public long getLong(int position, int offset)
+    {
+        checkReadablePosition(position);
+        if (offset != 0) {
+            throw new IllegalArgumentException("offset must be zero");
+        }
+        return values[position + arrayOffset];
+    }
+
+    @Override
+    public int getInt(int position, int offset)
+    {
+        checkReadablePosition(position);
+        if (offset != 0) {
+            throw new IllegalArgumentException("offset must be zero");
+        }
+        return values[position + arrayOffset];
+    }
+
+    @Override
+    @Deprecated
+    // TODO: Remove when we fix intermediate types on aggregations.
+    public short getShort(int position, int offset)
+    {
+        checkReadablePosition(position);
+        if (offset != 0) {
+            throw new IllegalArgumentException("offset must be zero");
+        }
+
+        short value = (short) (values[position + arrayOffset]);
+        if (value != values[position + arrayOffset]) {
+            throw new ArithmeticException("short overflow");
+        }
+        return value;
+    }
+
+    @Override
+    @Deprecated
+    // TODO: Remove when we fix intermediate types on aggregations.
+    public byte getByte(int position, int offset)
+    {
+        checkReadablePosition(position);
+        if (offset != 0) {
+            throw new IllegalArgumentException("offset must be zero");
+        }
+
+        byte value = (byte) (values[position + arrayOffset]);
+        if (value != values[position + arrayOffset]) {
+            throw new ArithmeticException("byte overflow");
+        }
+        return value;
+    }
+
+    @Override
+    public boolean isNull(int position)
+    {
+        checkReadablePosition(position);
+        return valueIsNull[position + arrayOffset];
+    }
+
+    @Override
+    public void writePositionTo(int position, BlockBuilder blockBuilder)
+    {
+        checkReadablePosition(position);
+        blockBuilder.writeInt(values[position + arrayOffset]);
+    }
+
+    @Override
+    public Block getSingleValueBlock(int position)
+    {
+        checkReadablePosition(position);
+        return new TimeArrayBlock(
+                1,
+                new boolean[] {valueIsNull[position + arrayOffset]},
+                new int[] {values[position + arrayOffset]});
+    }
+
+    @Override
+    public Block copyPositions(int[] positions, int offset, int length)
+    {
+        checkArrayRange(positions, offset, length);
+
+        boolean[] newValueIsNull = new boolean[length];
+        int[] newValues = new int[length];
+        for (int i = 0; i < length; i++) {
+            int position = positions[offset + i];
+            checkReadablePosition(position);
+            newValueIsNull[i] = valueIsNull[position + arrayOffset];
+            newValues[i] = values[position + arrayOffset];
+        }
+        return new TimeArrayBlock(length, newValueIsNull, newValues);
+    }
+
+    @Override
+    public Block getRegion(int positionOffset, int length)
+    {
+        checkValidRegion(getPositionCount(), positionOffset, length);
+
+        return new TimeArrayBlock(positionOffset + arrayOffset, length, valueIsNull, values);
+    }
+
+    @Override
+    public Block copyRegion(int positionOffset, int length)
+    {
+        checkValidRegion(getPositionCount(), positionOffset, length);
+
+        positionOffset += arrayOffset;
+        boolean[] newValueIsNull = compactArray(valueIsNull, positionOffset, length);
+        int[] newValues = compactArray(values, positionOffset, length);
+
+        if (newValueIsNull == valueIsNull && newValues == values) {
+            return this;
+        }
+        return new TimeArrayBlock(length, newValueIsNull, newValues);
+    }
+
+    @Override
+    public BlockEncoding getEncoding()
+    {
+        return new IntArrayBlockEncoding();
+    }
+
+    @Override
+    public String toString()
+    {
+        StringBuilder sb = new StringBuilder("TimeArrayBlock{");
+        sb.append("positionCount=").append(getPositionCount());
+        sb.append('}');
+        return sb.toString();
+    }
+
+    private void checkReadablePosition(int position)
+    {
+        if (position < 0 || position >= getPositionCount()) {
+            throw new IllegalArgumentException("position is not valid");
+        }
+    }
+}

--- a/pixels-presto/src/main/java/io/pixelsdb/pixels/presto/block/TimeArrayBlockEncoding.java
+++ b/pixels-presto/src/main/java/io/pixelsdb/pixels/presto/block/TimeArrayBlockEncoding.java
@@ -1,0 +1,87 @@
+package io.pixelsdb.pixels.presto.block;
+
+import com.facebook.presto.spi.block.*;
+import com.facebook.presto.spi.type.TypeManager;
+import io.airlift.slice.SliceInput;
+import io.airlift.slice.SliceOutput;
+
+import static io.pixelsdb.pixels.presto.block.EncoderUtil.decodeNullBits;
+import static io.pixelsdb.pixels.presto.block.EncoderUtil.encodeNullsAsBits;
+
+/**
+ * This class is derived from com.facebook.presto.spi.block.IntArrayBlockEncoding.
+ *
+ * Created at: 26/04/2021
+ * Author: hank
+ */
+public class TimeArrayBlockEncoding
+        implements BlockEncoding
+{
+    public static final BlockEncodingFactory<TimeArrayBlockEncoding> FACTORY = new TimeArrayBlockEncoding.TimeArrayBlockEncodingFactory();
+    private static final String NAME = "TIME_ARRAY";
+
+    @Override
+    public String getName()
+    {
+        return NAME;
+    }
+
+    @Override
+    public void writeBlock(SliceOutput sliceOutput, Block block)
+    {
+        int positionCount = block.getPositionCount();
+        sliceOutput.appendInt(positionCount);
+
+        encodeNullsAsBits(sliceOutput, block);
+
+        for (int position = 0; position < positionCount; position++) {
+            if (!block.isNull(position)) {
+                sliceOutput.writeInt(block.getInt(position, 0));
+            }
+        }
+    }
+
+    @Override
+    public Block readBlock(SliceInput sliceInput)
+    {
+        int positionCount = sliceInput.readInt();
+
+        boolean[] valueIsNull = decodeNullBits(sliceInput, positionCount);
+
+        int[] values = new int[positionCount];
+        for (int position = 0; position < positionCount; position++) {
+            if (!valueIsNull[position]) {
+                values[position] = sliceInput.readInt();
+            }
+        }
+
+        return new TimeArrayBlock(positionCount, valueIsNull, values);
+    }
+
+    @Override
+    public BlockEncodingFactory getFactory()
+    {
+        return FACTORY;
+    }
+
+    public static class TimeArrayBlockEncodingFactory
+            implements BlockEncodingFactory<TimeArrayBlockEncoding>
+    {
+        @Override
+        public String getName()
+        {
+            return NAME;
+        }
+
+        @Override
+        public TimeArrayBlockEncoding readEncoding(TypeManager manager, BlockEncodingSerde serde, SliceInput input)
+        {
+            return new TimeArrayBlockEncoding();
+        }
+
+        @Override
+        public void writeEncoding(BlockEncodingSerde serde, SliceOutput output, TimeArrayBlockEncoding blockEncoding)
+        {
+        }
+    }
+}

--- a/proto/pixels.proto
+++ b/proto/pixels.proto
@@ -164,8 +164,8 @@ message TimestampStatistic {
 
 message DateStatistic {
     // min,max values saved as milliseconds since epoch
-    optional sint64 minimum = 1;
-    optional sint64 maximum = 2;
+    optional sint32 minimum = 1;
+    optional sint32 maximum = 2;
 }
 
 message TimeStatistic {

--- a/proto/pixels.proto
+++ b/proto/pixels.proto
@@ -103,6 +103,7 @@ message Type {
         DATE = 15;
         VARCHAR = 16;
         CHAR = 17;
+        TIME = 18;
     }
     optional Kind kind = 1;
     optional string name = 2;
@@ -161,6 +162,18 @@ message TimestampStatistic {
     optional sint64 maximum = 2;
 }
 
+message DateStatistic {
+    // min,max values saved as milliseconds since epoch
+    optional sint64 minimum = 1;
+    optional sint64 maximum = 2;
+}
+
+message TimeStatistic {
+    // min,max values saved as milliseconds since epoch
+    optional sint32 minimum = 1;
+    optional sint32 maximum = 2;
+}
+
 message BinaryStatistic {
     // sum will store the total binary blob length in a stripe
     optional sint64 sum = 1;
@@ -174,6 +187,10 @@ message ColumnStatistic {
     optional BucketStatistic bucketStatistics = 5;
     optional BinaryStatistic binaryStatistics = 6;
     optional TimestampStatistic timestampStatistics = 7;
+    // Date and Time types are added in Issue #94,
+    // use field number 9 and 10 for compatibility.
+    optional DateStatistic dateStatistics = 9;
+    optional TimeStatistic timeStatistics = 10;
     optional bool hasNull = 8;
 }
 


### PR DESCRIPTION
We added Date and Time data types in pixels-core, and tested them from pixels-presto and pixels-load using orders table in TPCH.

For both types, they are represented as 4-byte integer and runlength+delta encoded.

For Date, the 4-byte integer is the number of days from epoch (1970-1-1 0:0:0 UTC). For Time, the 4-byte integer is the number of millis in the day.