### PR TITLE
[Issue #103]: fix and enhance predicate processing.

### DIFF
--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/PixelsPredicate.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/PixelsPredicate.java
@@ -30,16 +30,67 @@ import java.util.Map;
  */
 public interface PixelsPredicate
 {
-    PixelsPredicate TRUE_PREDICATE = (numberOfRows, statisticsByColumnIndex) -> true;
+    PixelsPredicate TRUE_PREDICATE = new PixelsPredicate()
+    {
+        @Override
+        public boolean matches(long numberOfRows, Map<Integer, ColumnStats> statisticsByColumnIndex)
+        {
+            return true;
+        }
 
-    PixelsPredicate FALSE_PREDICATE = ((numberOfRows, statisticsByColumnIndex) -> false);
+        @Override
+        public boolean matchesNone()
+        {
+            return false;
+        }
+
+        @Override
+        public boolean matchesAll()
+        {
+            return true;
+        }
+    };
+
+    PixelsPredicate FALSE_PREDICATE = new PixelsPredicate()
+    {
+        @Override
+        public boolean matches(long numberOfRows, Map<Integer, ColumnStats> statisticsByColumnIndex)
+        {
+            return false;
+        }
+
+        @Override
+        public boolean matchesNone()
+        {
+            return true;
+        }
+
+        @Override
+        public boolean matchesAll()
+        {
+            return false;
+        }
+    };
 
     /**
      * Check if predicate matches statistics
      *
-     * @param numberOfRows            number of rows
+     * @param numberOfRows            number of rows in the corresponding data unit where
+     *                                the statistics come from.
      * @param statisticsByColumnIndex statistics map. key: column index in user specified schema,
      *                                value: column statistic
      */
     boolean matches(long numberOfRows, Map<Integer, ColumnStats> statisticsByColumnIndex);
+
+    /**
+     * Added in Issue #103.
+     * @return true if no value would ever satisfy this predicate.
+     */
+    boolean matchesNone();
+
+    /**
+     * Added in Issue #103.
+     * @return true if any value could satisfy this predicate.
+     */
+    boolean matchesAll();
 }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/PixelsReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/PixelsReader.java
@@ -42,7 +42,7 @@ public interface PixelsReader
      *
      * @return record reader
      */
-    PixelsRecordReader read(PixelsReaderOption option);
+    PixelsRecordReader read(PixelsReaderOption option) throws IOException;
 
     /**
      * Get version of the Pixels file

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/PixelsReaderImpl.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/PixelsReaderImpl.java
@@ -239,7 +239,7 @@ public class PixelsReaderImpl
      * @return record reader
      */
     @Override
-    public PixelsRecordReader read(PixelsReaderOption option)
+    public PixelsRecordReader read(PixelsReaderOption option) throws IOException
     {
         float diceValue = random.nextFloat();
         boolean enableMetrics = false;

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/TupleDomainPixelsPredicate.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/TupleDomainPixelsPredicate.java
@@ -19,21 +19,13 @@
  */
 package io.pixelsdb.pixels.core;
 
-import io.pixelsdb.pixels.core.stats.BooleanColumnStats;
-import io.pixelsdb.pixels.core.stats.ColumnStats;
-import io.pixelsdb.pixels.core.stats.DoubleColumnStats;
-import io.pixelsdb.pixels.core.stats.IntegerColumnStats;
-import io.pixelsdb.pixels.core.stats.RangeStats;
-import io.pixelsdb.pixels.core.stats.StringColumnStats;
-import io.pixelsdb.pixels.core.stats.TimestampColumnStats;
+import com.facebook.presto.spi.type.*;
+import io.pixelsdb.pixels.core.exception.PixelsReaderException;
+import io.pixelsdb.pixels.core.stats.*;
 import com.facebook.presto.spi.predicate.Domain;
 import com.facebook.presto.spi.predicate.Range;
 import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.spi.predicate.ValueSet;
-import com.facebook.presto.spi.type.CharType;
-import com.facebook.presto.spi.type.TimestampType;
-import com.facebook.presto.spi.type.Type;
-import com.facebook.presto.spi.type.VarcharType;
 import com.google.common.collect.ImmutableList;
 
 import java.util.Collection;
@@ -52,6 +44,7 @@ import static java.util.Objects.requireNonNull;
  * pixels
  *
  * @author guodong
+ * @author hank
  */
 public class TupleDomainPixelsPredicate<C>
         implements PixelsPredicate
@@ -66,9 +59,12 @@ public class TupleDomainPixelsPredicate<C>
     }
 
     /**
-     * Check if predicate matches statistics
+     * Check if predicate matches column statistics.
+     * Note that on the same column, onlyNull ('is null') predicate will match hasNull statistics
+     * and vice versa.
      *
-     * @param numberOfRows            number of rows
+     * @param numberOfRows            number of rows in the corresponding horizontal data unit
+     *                                (pixel, row group, file, etc.) where the statistics come from.
      * @param statisticsByColumnIndex statistics map. key: column index in user specified schema,
      *                                value: column statistic
      */
@@ -83,6 +79,12 @@ public class TupleDomainPixelsPredicate<C>
         }
         Map<C, Domain> domains = optionalDomains.get();
 
+        /**
+         * Issue #103:
+         * bugs fixed:
+         * 1. return true if there is a match (origin: return false if there is a mismatch).
+         * 2. finally return false by default (origin: turn true).
+         */
         for (ColumnReference<C> columnReference : columnReferences)
         {
             Domain predicateDomain = domains.get(columnReference.getColumn());
@@ -98,38 +100,96 @@ public class TupleDomainPixelsPredicate<C>
                 continue;
             }
 
-            if (!domainOverlaps(columnReference, predicateDomain, numberOfRows, columnStats))
+            if (domainMatches(columnReference, predicateDomain, numberOfRows, columnStats))
             {
-                return false;
+                return true;
             }
         }
 
-        return true;
+        return false;
     }
 
-    private boolean domainOverlaps(ColumnReference<C> columnReference, Domain predicateDomain,
+    /**
+     * Added in Issue #103.
+     *
+     * @return true if this predicate will never match any values.
+     */
+    @Override
+    public boolean matchesNone()
+    {
+        predicate.getDomains();
+        return predicate.isNone();
+    }
+
+    /**
+     * Added in Issue #103.
+     *
+     * @return true if this predicate will match any values.
+     */
+    @Override
+    public boolean matchesAll()
+    {
+        return predicate.isAll();
+    }
+
+    /**
+     * With query's predicate domain and statistics on the given column, get column domain from the
+     * statistics and check if it matches the predicate domain.
+     * Note that on the same column, onlyNull ('is null') predicate will match hasNull statistics
+     * and vice versa.
+     * @param columnReference the given column.
+     * @param predicateDomain the predicate domain on the column.
+     * @param numberOfRows the total number of rows in this horizontal unit (file, row group, or pixel).
+     * @param columnStats the statistics on the column.
+     * @return
+     */
+    private boolean domainMatches(ColumnReference<C> columnReference, Domain predicateDomain,
                                    long numberOfRows, ColumnStats columnStats)
     {
         Domain columnDomain = getDomain(columnReference.getType(), numberOfRows, columnStats);
         if (!columnDomain.overlaps(predicateDomain))
         {
+            /**
+             * Issue #103:
+             * Even if column domain and predicate domain do not overlap,
+             * they can match if either of them is onlyNull while the other
+             * one is nullAllowed.
+             */
+            if (predicateDomain.isNullAllowed() && columnDomain.isNullAllowed())
+            {
+                return true;
+            }
             return false;
         }
 
-        if (predicateDomain.isNullAllowed() && columnDomain.isNullAllowed())
-        {
-            return true;
-        }
-
-        Optional<Collection<Object>> discreteValues = getDiscreteValues(predicateDomain.getValues());
-        if (!discreteValues.isPresent())
-        {
-            return true;
-        }
+        /**
+         * Issue #103:
+         * 1. No need to process discrete values. Discrete values and ranges will not coexist. However either
+         * of them has been considered in the Domain.overlaps() method above.
+         *
+         * 2. Predicate domain and column domain will always be compatible, i.e. their values are all of the
+         * EquatableValue or SortedRangeSet type.
+         *
+         * Reference: the implementation of com.facebook.presto.spi.predicate.ValueSet.
+         * of and rangesOf method will create the domain values according to the data type.
+         * If predicate domain and the column domain are from the same column, they should have the
+         * same type of values.
+         */
+        // Optional<Collection<Object>> discreteValues = getDiscreteValues(predicateDomain.getValues());
+        // if (!discreteValues.isPresent())
+        // {
+        //     return true;
+        // }
 
         return true;
     }
 
+    /**
+     * Get all the discrete values, including single values from the ordered ranges
+     * and the unordered discrete values.
+     * @param valueSet
+     * @return
+     */
     private Optional<Collection<Object>> getDiscreteValues(ValueSet valueSet)
     {
         return valueSet.getValuesProcessor().transform(
@@ -149,6 +209,14 @@ public class TupleDomainPixelsPredicate<C>
                 allOrNone -> allOrNone.isAll() ? Optional.empty() : Optional.of(ImmutableList.of()));
     }
 
+    /**
+     * Get domain object from column statistics.
+     * @param type the type of this column.
+     * @param rowCount the number of rows in the corresponding horizontal data unit
+     *                 (pixel, row group, file, etc.).
+     * @param columnStats the statistics of this column in the horizontal data unit.
+     * @return
+     */
     private Domain getDomain(Type type, long rowCount, ColumnStats columnStats)
     {
         if (rowCount == 0)
@@ -158,7 +226,9 @@ public class TupleDomainPixelsPredicate<C>
 
         if (columnStats == null)
         {
-            return Domain.all(type);
+            // Issue #103: we have avoided columnStat == null in upper layers of call stack.
+            // return Domain.all(type);
+            throw new PixelsReaderException("column statistic is null");
         }
 
         if (columnStats.getNumberOfValues() == 0)
@@ -166,7 +236,7 @@ public class TupleDomainPixelsPredicate<C>
             return Domain.onlyNull(type);
         }
 
-        boolean hasNullValue = columnStats.getNumberOfValues() != rowCount;
+        boolean hasNullValue = columnStats.getNumberOfValues() != rowCount || columnStats.hasNull();
 
         if (type.getJavaType() == boolean.class)
         {
@@ -198,6 +268,20 @@ public class TupleDomainPixelsPredicate<C>
         {
             return createDomain(type, hasNullValue, (TimestampColumnStats) columnStats);
         }
+        else if (type instanceof DateType)
+        {
+            /**
+             * Issue #103: add Date type predicate.
+             */
+            return createDomain(type, hasNullValue, (DateColumnStats) columnStats);
+        }
+        else if (type instanceof  TimeType)
+        {
+            /**
+             * Issue #103: add Time type predicate.
+             */
+            return createDomain(type, hasNullValue, (TimeColumnStats) columnStats);
+        }
         else if (type.getJavaType() == long.class)
         {
             return createDomain(type, hasNullValue, (IntegerColumnStats) columnStats);
@@ -206,17 +290,50 @@ public class TupleDomainPixelsPredicate<C>
         {
             return createDomain(type, hasNullValue, (DoubleColumnStats) columnStats);
         }
-        return Domain.create(ValueSet.all(type), hasNullValue);
+        /**
+         * Issue #103:
+         * Type unmatched, we should through an exception here instead of returning
+         * a domain that can match any predicate.
+         */
+        // return Domain.create(ValueSet.all(type), hasNullValue);
+        throw new PixelsReaderException("unsupported type, display name=" + type.getDisplayName() +
+                ", java type=" + type.getJavaType().getName());
     }
 
     private <T extends Comparable<T>> Domain createDomain(Type type, boolean hasNullValue,
                                                           RangeStats<T> rangeStats)
     {
-        if (type instanceof VarcharType || type instanceof CharType)
+        // Issue #103: what's the purpose of this if branch?
+        //if (type instanceof VarcharType || type instanceof CharType)
+        //{
+        //    return createDomain(type, hasNullValue, rangeStats, value -> value);
+        //}
+        // return createDomain(type, hasNullValue, rangeStats, value -> value);
+        // Issue #103: avoid additional function call.
+        T min = rangeStats.getMinimum();
+        T max = rangeStats.getMaximum();
+
+        if (min != null && max != null)
         {
-            return createDomain(type, hasNullValue, rangeStats, value -> value);
+            return Domain.create(
+                    ValueSet.ofRanges(
+                            Range.range(type, min, true, max, true)),
+                    hasNullValue);
         }
-        return createDomain(type, hasNullValue, rangeStats, value -> value);
+        if (max != null)
+        {
+            return Domain.create(ValueSet.ofRanges(Range.lessThanOrEqual(type, max)), hasNullValue);
+        }
+        if (min != null)
+        {
+            return Domain.create(ValueSet.ofRanges(Range.greaterThanOrEqual(type, min)), hasNullValue);
+        }
+
+        /**
+         * Comments added in Issue #103:
+         * If no min nor max is defined, we create a column domain to accepted any predicate.
+         */
+        return Domain.create(ValueSet.all(type), hasNullValue);
     }
 
     private <F, T extends Comparable<T>> Domain createDomain(Type type, boolean hasNullValue,
@@ -273,5 +390,43 @@ public class TupleDomainPixelsPredicate<C>
         {
             return type;
         }
+    }
+
+    @Override
+    public String toString()
+    {
+        StringBuilder builder = new StringBuilder("TupleDomainPixelsPredicate{isNone=")
+                .append(predicate.isNone() + ", isAll=")
+                .append(predicate.isAll() + ", ")
+                .append("columnPredicates=[");
+        boolean deleteLast = false;
+        for (TupleDomain.ColumnDomain cd : predicate.getColumnDomains().get())
+        {
+            builder.append("{column=" + cd.getColumn() + ",nullable=" + cd.getDomain().isNullAllowed())
+                    .append(",isSingleValue=" + cd.getDomain().isNullableSingleValue())
+                    .append(",isNone=" + cd.getDomain().getValues().isNone())
+                    .append(",isAll=" + cd.getDomain().getValues().isAll())
+                    .append("},");
+            deleteLast = true;
+        }
+        if (deleteLast)
+        {
+            builder.deleteCharAt(builder.length()-1);
+            deleteLast = false;
+        }
+        builder.append("], columnReferences=[");
+        for (ColumnReference cr : columnReferences)
+        {
+            builder.append("{columnName=" + cr.getColumn())
+                    .append(", columnType=" + cr.getType().getDisplayName())
+                    .append("},");
+            deleteLast = true;
+        }
+        if (deleteLast)
+        {
+            builder.deleteCharAt(builder.length()-1);
+        }
+        builder.append("]}");
+        return builder.toString();
     }
 }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/PixelsRecordReaderImpl.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/PixelsRecordReaderImpl.java
@@ -310,8 +310,7 @@ public class PixelsRecordReaderImpl
                     /**
                      * Issue #103:
                      * 1. matches() is fixed in this issue, but it is not sure if there is
-                     * any further problems with it.
-                     * TODO: pay attention to the correctness of matches().
+                     * any further problems with it, as the related domain APIs in presto spi is mysterious.
                      *
                      * 2. Whenever predicate does not match any column statistics, we should be return
                      * false. Instead, we must make sure that includedRGs will be filled with false values.
@@ -327,7 +326,6 @@ public class PixelsRecordReaderImpl
                 }
                 else
                 {
-                    // Issue #103: put this part in the else block.
                     // columnStatsMap.clear();
                     // second, get row group statistics, if not matches, skip the row group
                     for (int i = 0; i < RGLen; i++)

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/PixelsRecordReaderImpl.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/PixelsRecordReaderImpl.java
@@ -26,6 +26,7 @@ import io.pixelsdb.pixels.common.metrics.ReadPerfMetrics;
 import io.pixelsdb.pixels.common.physical.PhysicalFSReader;
 import io.pixelsdb.pixels.common.utils.ConfigFactory;
 import io.pixelsdb.pixels.core.*;
+import io.pixelsdb.pixels.core.exception.PixelsReaderException;
 import io.pixelsdb.pixels.core.stats.ColumnStats;
 import io.pixelsdb.pixels.core.stats.StatsRecorder;
 import io.pixelsdb.pixels.core.vector.ColumnVector;
@@ -39,6 +40,7 @@ import java.util.*;
 
 /**
  * @author guodong
+ * @author hank
  */
 public class PixelsRecordReaderImpl
         implements PixelsRecordReader
@@ -92,7 +94,7 @@ public class PixelsRecordReaderImpl
                                   boolean enableCache,
                                   List<String> cacheOrder,
                                   PixelsCacheReader cacheReader,
-                                  PixelsFooterCache pixelsFooterCache)
+                                  PixelsFooterCache pixelsFooterCache) throws IOException
     {
         this.physicalFSReader = physicalFSReader;
         this.postScript = postScript;
@@ -111,19 +113,21 @@ public class PixelsRecordReaderImpl
         checkBeforeRead();
     }
 
-    private void checkBeforeRead()
+    private void checkBeforeRead() throws IOException
     {
         // get file schema
         List<PixelsProto.Type> fileColTypes = footer.getTypesList();
         if (fileColTypes == null || fileColTypes.isEmpty())
         {
             checkValid = false;
+            //throw new IOException("ISSUE-103: type list is empty.");
             return;
         }
         fileSchema = TypeDescription.createSchema(fileColTypes);
         if (fileSchema.getChildren() == null || fileSchema.getChildren().isEmpty())
         {
             checkValid = false;
+            //throw new IOException("ISSUE-103: file schema is empty.");
             return;
         }
 
@@ -132,6 +136,7 @@ public class PixelsRecordReaderImpl
         if (RGStart >= rgNum)
         {
             checkValid = false;
+            //throw new IOException("ISSUE-103: row group start is out of bound.");
             return;
         }
         if (RGStart + RGLen > rgNum)
@@ -151,6 +156,12 @@ public class PixelsRecordReaderImpl
             resultRowBatch.selected = null;
             resultRowBatch.projectionSize = 0;
             checkValid = true;
+            // Issue #103: set the following members to null.
+            this.includedColumns = null;
+            this.resultColumns = null;
+            this.targetColumns = null;
+            this.readers = null;
+            //throw new IOException("ISSUE-103: included columns is empty.");
             return;
         }
         List<Integer> optionColsIndices = new ArrayList<>();
@@ -173,6 +184,8 @@ public class PixelsRecordReaderImpl
         if (includedColumnsNum != optionIncludedCols.length && !option.isTolerantSchemaEvolution())
         {
             checkValid = false;
+            //throw new IOException("ISSUE-103: includedColumnsNum is " + includedColumnsNum +
+            //        " while optionIncludedCols.length is " + optionIncludedCols.length);
             return;
         }
 
@@ -221,7 +234,14 @@ public class PixelsRecordReaderImpl
         checkValid = true;
     }
 
-    private boolean prepareRead()
+    /**
+     * This method is to prepare the internal status for read operations.
+     * It should only return false when there is an error. Special cases
+     * must be processed correctly and return true.
+     * @return
+     * @throws IOException
+     */
+    private boolean prepareRead() throws IOException
     {
         if (!checkValid)
         {
@@ -242,38 +262,89 @@ public class PixelsRecordReaderImpl
             return false;
         }
 
-        Map<Integer, ColumnStats> columnStatsMap = new HashMap<>();
         // read row group statistics and find target row groups
         if (option.getPredicate().isPresent())
         {
-            List<TypeDescription> columnSchemas = fileSchema.getChildren();
             PixelsPredicate predicate = option.getPredicate().get();
-
-            // first, get file level column statistic, if not matches, skip this file
-            List<PixelsProto.ColumnStatistic> fileColumnStatistics = footer.getColumnStatsList();
-            for (int id : targetColumns)
+            if (option.getIncludedCols().length == 0)
             {
-                columnStatsMap.put(id,
-                        StatsRecorder.create(columnSchemas.get(id), fileColumnStatistics.get(id)));
+                /**
+                 * Issue #103:
+                 * If there is no included columns while predicate is present,
+                 * The predicate(s) should be constant expressions.
+                 */
+                if (predicate.matchesAll())
+                {
+                    for (int i = 0; i < RGLen; i++)
+                    {
+                        includedRGs[i] = true;
+                    }
+                }
+                else if (predicate.matchesNone())
+                {
+                    for (int i = 0; i < RGLen; i++)
+                    {
+                        includedRGs[i] = false;
+                    }
+                }
+                else
+                {
+                    throw new PixelsReaderException(
+                            "predicate does not match none or all while included columns is empty.");
+                }
             }
-            if (!predicate.matches(postScript.getNumberOfRows(), columnStatsMap))
+            else
             {
-                return false;
-            }
-            columnStatsMap.clear();
+                Map<Integer, ColumnStats> columnStatsMap = new HashMap<>();
+                List<TypeDescription> columnSchemas = fileSchema.getChildren();
 
-            // second, get row group statistics, if not matches, skip the row group
-            for (int i = 0; i < RGLen; i++)
-            {
-                PixelsProto.RowGroupStatistic rowGroupStatistic = rowGroupStatistics.get(i + RGStart);
-                List<PixelsProto.ColumnStatistic> rgColumnStatistics =
-                        rowGroupStatistic.getColumnChunkStatsList();
+                // first, get file level column statistic, if not matches, skip this file
+                List<PixelsProto.ColumnStatistic> fileColumnStatistics = footer.getColumnStatsList();
                 for (int id : targetColumns)
                 {
                     columnStatsMap.put(id,
-                            StatsRecorder.create(columnSchemas.get(id), rgColumnStatistics.get(id)));
+                            StatsRecorder.create(columnSchemas.get(id), fileColumnStatistics.get(id)));
                 }
-                includedRGs[i] = predicate.matches(footer.getRowGroupInfos(i).getNumberOfRows(), columnStatsMap);
+                if (!predicate.matches(postScript.getNumberOfRows(), columnStatsMap))
+                {
+                    /**
+                     * Issue #103:
+                     * 1. matches() is fixed in this issue, but it is not sure if there is
+                     * any further problems with it.
+                     * TODO: pay attention to the correctness of matches().
+                     *
+                     * 2. Whenever predicate does not match any column statistics, we should be return
+                     * false. Instead, we must make sure that includedRGs will be filled with false values.
+                     * By this way, the subsequent methods such as read() an readBatch() can skip all row
+                     * groups in this file without additional overheads, as targetRGs would be empty and
+                     * targetRGNum would be 0.
+                     */
+                    //return false;
+                    for (int i = 0; i < RGLen; i++)
+                    {
+                        includedRGs[i] = false;
+                    }
+                }
+                else
+                {
+                    // Issue #103: put this part in the else block.
+                    // columnStatsMap.clear();
+                    // second, get row group statistics, if not matches, skip the row group
+                    for (int i = 0; i < RGLen; i++)
+                    {
+                        // Issue #103: columnStatsMap should be cleared for each row group.
+                        columnStatsMap.clear();
+                        PixelsProto.RowGroupStatistic rowGroupStatistic = rowGroupStatistics.get(i + RGStart);
+                        List<PixelsProto.ColumnStatistic> rgColumnStatistics =
+                                rowGroupStatistic.getColumnChunkStatsList();
+                        for (int id : targetColumns)
+                        {
+                            columnStatsMap.put(id,
+                                    StatsRecorder.create(columnSchemas.get(id), rgColumnStatistics.get(id)));
+                        }
+                        includedRGs[i] = predicate.matches(footer.getRowGroupInfos(i).getNumberOfRows(), columnStatsMap);
+                    }
+                }
             }
         }
         else
@@ -343,9 +414,10 @@ public class PixelsRecordReaderImpl
      * By optimizations in this method in Issue #67 (patch), end-to-end query
      * performance on full cache is improved by about 5% - 10%.
      *
-     * @return if the row groups are read successfully.
+     * @return true if there is row group to read and the row groups are read
+     * successfully.
      */
-    private boolean read()
+    private boolean read() throws IOException
     {
         if (!checkValid)
         {
@@ -362,6 +434,16 @@ public class PixelsRecordReaderImpl
 
         everRead = true;
 
+        if (targetRGNum == 0)
+        {
+            /**
+             * Issue #103:
+             * No row groups to read, return false, and then resultRowBatch.endOfFile
+             * will be set in readBatch().
+             */
+            return false;
+        }
+
         // read chunk offset and length of each target column chunks
         this.chunkBuffers = new ByteBuffer[targetRGNum * includedColumns.length];
         List<ChunkId> diskChunks = new ArrayList<>(targetRGNum * targetColumns.length);
@@ -375,8 +457,9 @@ public class PixelsRecordReaderImpl
             }
             catch (IOException | FSException e)
             {
-                e.printStackTrace();
-                return false;
+                logger.error(e);
+                throw new IOException("failed to get block id.", e);
+                //return false;
             }
             List<ColumnletId> cacheChunks = new ArrayList<>(targetRGNum * targetColumns.length);
             // find cached chunks
@@ -387,7 +470,12 @@ public class PixelsRecordReaderImpl
                 boolean direct = Boolean.parseBoolean(ConfigFactory.Instance().getProperty("cache.read.direct"));
                 for (int rgIdx = 0; rgIdx < targetRGNum; rgIdx++)
                 {
-                    int rgId = rgIdx + RGStart;
+                    /**
+                     * Issue #103:
+                     * rgId should be targetRGs[rgIdx] instead of (rgIdx + RGStart).
+                     */
+                    // int rgId = rgIdx + RGStart;
+                    int rgId = targetRGs[rgIdx];
                     // TODO: not only columnlets in cacheOrder are cached.
                     String cacheIdentifier = rgId + ":" + colId;
                     // if cached, read from cache files
@@ -404,6 +492,12 @@ public class PixelsRecordReaderImpl
                                 rowGroupFooters[rgIdx].getRowGroupIndexEntry();
                         PixelsProto.ColumnChunkIndex chunkIndex =
                                 rowGroupIndex.getColumnChunkIndexEntries(colId);
+                        /**
+                         * Comments added in Issue #103:
+                         * It is not a bug to use rgIdx as the rowGroupId of ChunkId.
+                         * ChunkId is to index the column chunk content in chunkBuffers
+                         * but not the column chunk in Pixels file.
+                         */
                         ChunkId chunk = new ChunkId(rgIdx, colId,
                                 chunkIndex.getChunkOffset(),
                                 chunkIndex.getChunkLength());
@@ -414,12 +508,12 @@ public class PixelsRecordReaderImpl
             }
             // read cached chunks
             long cacheReadStartNano = System.nanoTime();
-            for (ColumnletId chunkId : cacheChunks)
+            for (ColumnletId columnletId : cacheChunks)
             {
-                short rgId = chunkId.rowGroupId;
-                short colId = chunkId.columnId;
+                short rgId = columnletId.rowGroupId;
+                short colId = columnletId.columnId;
 //                long getBegin = System.nanoTime();
-                ByteBuffer columnlet = cacheReader.get(blockId, rgId, colId, chunkId.direct);
+                ByteBuffer columnlet = cacheReader.get(blockId, rgId, colId, columnletId.direct);
 //                long getEnd = System.nanoTime();
 //                logger.debug("[cache get]: " + columnlet.length + "," + (getEnd - getBegin));
                 chunkBuffers[(rgId - RGStart) * includedColumns.length + colId] = columnlet;
@@ -566,6 +660,13 @@ public class PixelsRecordReaderImpl
                     for (ChunkId chunkId : chunkIds)
                     {
                         int chunkLength = (int) chunkId.length;
+                        /**
+                         * Comments added in Issue #103:
+                         * chunkId.rowGroupId does not mean the row group id in the Pixels file,
+                         * it is the index of group that is to be read (some row groups in the file
+                         * may be filtered out by the predicate and will not be read) and it is
+                         * used to calculate the index of chunkBuffers.
+                         */
                         int rgIdx = chunkId.rowGroupId;
                         int colId = chunkId.columnId;
                         chunkBlockBuffer.position(chunkSliceOffset);
@@ -577,8 +678,9 @@ public class PixelsRecordReaderImpl
                 }
             } catch (IOException e)
             {
-                e.printStackTrace();
-                return false;
+                logger.error(e);
+                throw new IOException("failed to read chunks block into buffers.", e);
+                // return false;
             }
         }
 
@@ -601,6 +703,7 @@ public class PixelsRecordReaderImpl
                 throw new IOException("Failed to prepare for read.");
             }
         }
+        // curBatchSize is the available size of the next batch.
         int curBatchSize = -curRowInRG;
         for (int rgIdx = curRGIdx; rgIdx < targetRGNum; ++rgIdx)
         {
@@ -652,6 +755,7 @@ public class PixelsRecordReaderImpl
             long start = System.nanoTime();
             if (!read())
             {
+                resultRowBatch.size = 0; // added in Issue #103.
                 resultRowBatch.endOfFile = true;
                 return resultRowBatch;
             }

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/TestPixelsPredicate.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/TestPixelsPredicate.java
@@ -58,9 +58,11 @@ public class TestPixelsPredicate
     {
         Domain testingColumnDomain = Domain.singleValue(BIGINT, TEST_INT);
         TupleDomain.ColumnDomain<String> cola = new TupleDomain.ColumnDomain<>(COLUMN_A_NAME, testingColumnDomain);
-
         TupleDomain<String> effectivePredicate = TupleDomain.fromColumnDomains(Optional.of(ImmutableList.of(cola)));
-        TupleDomain<String> emptyEffectivePredicate = TupleDomain.all();
+
+        Domain emptyColumnDomain = Domain.onlyNull(testingColumnDomain.getType());
+        TupleDomain.ColumnDomain<String> colEmpty = new TupleDomain.ColumnDomain<>(COLUMN_A_NAME, emptyColumnDomain);
+        TupleDomain<String> emptyEffectivePredicate = TupleDomain.fromColumnDomains(Optional.of(ImmutableList.of(colEmpty)));
 
         List<TupleDomainPixelsPredicate.ColumnReference<String>> columnReferences = ImmutableList.<TupleDomainPixelsPredicate.ColumnReference<String>>builder()
                 .add(new TupleDomainPixelsPredicate.ColumnReference<>(COLUMN_A_NAME, COLUMN_A_ORDINAL, BIGINT))
@@ -80,8 +82,12 @@ public class TestPixelsPredicate
         statsRecorder.updateInteger(100L, 1);
         Map<Integer, ColumnStats> unMatchingStatsMap = ImmutableMap.of(0, statsRecorder);
 
+        System.out.println(predicate);
+        System.out.println(emptyPredicate);
+
         assertTrue(predicate.matches(1L, matchingStatsMap));
-        assertTrue(emptyPredicate.matches(1L, matchingStatsMap));
+        assertTrue(emptyPredicate.matches(2L, matchingStatsMap));
+        assertFalse(emptyPredicate.matches(1L, matchingStatsMap));
         assertFalse(predicate.matches(1L, unMatchingStatsMap));
     }
 

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestPixelsReaderOption.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestPixelsReaderOption.java
@@ -206,4 +206,15 @@ public class TestPixelsReaderOption
 
         return pixelsReader;
     }
+
+    int[] a;
+    @Test
+    public void testArrayDefinition()
+    {
+
+        for (int i = 0; i < a.length; ++i)
+        {
+            System.out.println(a[i]);
+        }
+    }
 }

--- a/pixels-hive/src/main/java/io/pixelsdb/pixels/hive/mapred/PixelsInputFormat.java
+++ b/pixels-hive/src/main/java/io/pixelsdb/pixels/hive/mapred/PixelsInputFormat.java
@@ -377,7 +377,7 @@ public class PixelsInputFormat
     }
 
     /**
-     * TODO: reload input paths so that LOCACTION in a hive table can be empty or any path.
+     * TODO: reload input paths so that LOCATION in a hive table can be empty or any path.
      * @param job
      */
     protected void init(JobConf job) throws IOException

--- a/pixels-load/src/main/java/io/pixelsdb/pixels/load/multi/Main.java
+++ b/pixels-load/src/main/java/io/pixelsdb/pixels/load/multi/Main.java
@@ -63,9 +63,9 @@ import java.util.concurrent.LinkedBlockingQueue;
  * LOAD -f orc -o hdfs://dbiir10:9000/pixels/pixels/test_105/source -d pixels -t test_105 -n 220000 -r \t -c 16
  * -l hdfs://dbiir10:9000/pixels/pixels/test_105/v_0_order_orc/
  * </p>
- * [-l] is optimal, assign a path not the 'OrderPath' in db(Defined in Config.java)
+ * [-l] is optional, assign a path not the 'OrderPath' in db(Defined in Config.java)
  *
- * <br>This shall be run under root user to execute cache cleaning commands
+ * <br>This should be run under root user to execute cache cleaning commands
  * <p>
  * QUERY -t pixels -w /home/iir/opt/pixels/1187_dedup_query.txt -l /home/iir/opt/pixels/pixels_duration_1187_v_1_compact_cache_2020.01.10-2.csv -c /home/iir/opt/presto-server/sbin/drop-caches.sh
  * </p>

--- a/pixels-presto/src/main/java/io/pixelsdb/pixels/presto/PixelsSplitManager.java
+++ b/pixels-presto/src/main/java/io/pixelsdb/pixels/presto/PixelsSplitManager.java
@@ -345,7 +345,8 @@ public class PixelsSplitManager
                             PixelsSplit pixelsSplit = new PixelsSplit(connectorId,
                                     tableHandle.getSchemaName(), tableHandle.getTableName(),
                                     Arrays.asList(path.toString()), curFileRGIdx, splitSize,
-                                    false, fsFactory.getBlockLocations(path, 0, Long.MAX_VALUE), order.getColumnOrder(), new ArrayList<>(0), constraint);
+                                    false, fsFactory.getBlockLocations(path, 0, Long.MAX_VALUE),
+                                    order.getColumnOrder(), new ArrayList<>(0), constraint);
                             pixelsSplits.add(pixelsSplit);
                             curFileRGIdx += splitSize;
                         }


### PR DESCRIPTION
1. fix predicate processing in `PixelsRecordReaderImpl` and `TupleDomainPixelsPredicate`.
2. correctly support 'is null' and constant predicates.
3. for '=null', the query would still be endless, but this is not due to predicate processing.