### PR TITLE
[Issue #105]: fix endless execution for `select count(*)`.

### DIFF
--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/predicate/PixelsPredicate.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/predicate/PixelsPredicate.java
@@ -17,7 +17,7 @@
  * License along with Pixels.  If not, see
  * <https://www.gnu.org/licenses/>.
  */
-package io.pixelsdb.pixels.core;
+package io.pixelsdb.pixels.core.predicate;
 
 import io.pixelsdb.pixels.core.stats.ColumnStats;
 
@@ -73,10 +73,14 @@ public interface PixelsPredicate
     };
 
     /**
-     * Check if predicate matches statistics
+     * Check if predicate matches column statistics.
+     * Note that on the same column, onlyNull (e.g. 'is null') predicate will match hasNull statistics
+     * and vice versa.
      *
-     * @param numberOfRows            number of rows in the corresponding data unit where
-     *                                the statistics come from.
+     * TODO: pay attention to the correctness of this method.
+     *
+     * @param numberOfRows            number of rows in the corresponding horizontal data unit
+     *                                (pixel, row group, file, etc.) where the statistics come from.
      * @param statisticsByColumnIndex statistics map. key: column index in user specified schema,
      *                                value: column statistic
      */
@@ -84,13 +88,19 @@ public interface PixelsPredicate
 
     /**
      * Added in Issue #103.
-     * @return true if no value would ever satisfy this predicate.
+     * This method relies on TupleDomain.isNone() in presto spi,
+     * which is mysterious.
+     * TODO: pay attention to the correctness of this method.
+     * @return true if this predicate will never match any values.
      */
     boolean matchesNone();
 
     /**
      * Added in Issue #103.
-     * @return true if any value could satisfy this predicate.
+     * This method relies on TupleDomain.isNone() in presto spi,
+     * which is mysterious.
+     * TODO: pay attention to the correctness of this method.
+     * @return true if this predicate will match any values.
      */
     boolean matchesAll();
 }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/predicate/TupleDomainPixelsPredicate.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/predicate/TupleDomainPixelsPredicate.java
@@ -17,7 +17,7 @@
  * License along with Pixels.  If not, see
  * <https://www.gnu.org/licenses/>.
  */
-package io.pixelsdb.pixels.core;
+package io.pixelsdb.pixels.core.predicate;
 
 import com.facebook.presto.spi.type.*;
 import io.pixelsdb.pixels.core.exception.PixelsReaderException;

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/PixelsReaderOption.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/PixelsReaderOption.java
@@ -19,7 +19,7 @@
  */
 package io.pixelsdb.pixels.core.reader;
 
-import io.pixelsdb.pixels.core.PixelsPredicate;
+import io.pixelsdb.pixels.core.predicate.PixelsPredicate;
 
 import java.util.Optional;
 

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/PixelsRecordReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/PixelsRecordReader.java
@@ -57,6 +57,13 @@ public interface PixelsRecordReader
             throws IOException;
 
     /**
+     * This method is valid after calling prepareBatch or readBatch.
+     * Before that, it will always return false.
+     * @return true if reach EOF.
+     */
+    boolean isEndOfFile ();
+
+    /**
      * Get current row number
      *
      * @return number of the row currently being read

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/PixelsRecordReaderImpl.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/PixelsRecordReaderImpl.java
@@ -290,7 +290,8 @@ public class PixelsRecordReaderImpl
                 else
                 {
                     throw new PixelsReaderException(
-                            "predicate does not match none or all while included columns is empty.");
+                            "predicate does not match none or all while included columns is empty. predicate=" +
+                            predicate.toString());
                 }
             }
             else
@@ -390,8 +391,8 @@ public class PixelsRecordReaderImpl
                 }
                 catch (IOException e)
                 {
-                    e.printStackTrace();
-                    return false;
+                    logger.error("failed to read file footer.", e);
+                    throw new IOException("failed to read file footer.", e);
                 }
             }
             // cache hit
@@ -426,7 +427,7 @@ public class PixelsRecordReaderImpl
         {
             if (prepareRead() == false)
             {
-                return false;
+                throw new IOException("failed to prepare for read.");
             }
         }
 
@@ -455,7 +456,7 @@ public class PixelsRecordReaderImpl
             }
             catch (IOException | FSException e)
             {
-                logger.error(e);
+                logger.error("failed to get block id.", e);
                 throw new IOException("failed to get block id.", e);
                 //return false;
             }
@@ -676,7 +677,7 @@ public class PixelsRecordReaderImpl
                 }
             } catch (IOException e)
             {
-                logger.error(e);
+                logger.error("failed to read chunks block into buffers.", e);
                 throw new IOException("failed to read chunks block into buffers.", e);
                 // return false;
             }
@@ -918,7 +919,7 @@ public class PixelsRecordReaderImpl
                 } catch (IOException e)
                 {
                     logger.error("Failed to close column reader.", e);
-                    throw e;
+                    throw new IOException("Failed to close column reader.", e);
                 } finally
                 {
                     readers[i] = null;

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/PixelsRecordReaderImpl.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/PixelsRecordReaderImpl.java
@@ -27,6 +27,7 @@ import io.pixelsdb.pixels.common.physical.PhysicalFSReader;
 import io.pixelsdb.pixels.common.utils.ConfigFactory;
 import io.pixelsdb.pixels.core.*;
 import io.pixelsdb.pixels.core.exception.PixelsReaderException;
+import io.pixelsdb.pixels.core.predicate.PixelsPredicate;
 import io.pixelsdb.pixels.core.stats.ColumnStats;
 import io.pixelsdb.pixels.core.stats.StatsRecorder;
 import io.pixelsdb.pixels.core.vector.ColumnVector;

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/VectorizedRowBatch.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/VectorizedRowBatch.java
@@ -200,7 +200,7 @@ public class VectorizedRowBatch implements AutoCloseable
     }
 
     /**
-     * Resets the row batch to default state
+     * Resets the row batch to default state for the next read.
      * - sets selectedInUse to false
      * - sets size to 0
      * - sets endOfFile to false

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/TestPixelsPredicate.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/TestPixelsPredicate.java
@@ -19,6 +19,7 @@
  */
 package io.pixelsdb.pixels.core;
 
+import io.pixelsdb.pixels.core.predicate.TupleDomainPixelsPredicate;
 import io.pixelsdb.pixels.core.stats.ColumnStats;
 import io.pixelsdb.pixels.core.stats.StatsRecorder;
 import com.facebook.presto.spi.predicate.Domain;

--- a/pixels-presto/src/main/java/io/pixelsdb/pixels/presto/PixelsPageSource.java
+++ b/pixels-presto/src/main/java/io/pixelsdb/pixels/presto/PixelsPageSource.java
@@ -31,6 +31,8 @@ import io.pixelsdb.pixels.cache.PixelsCacheReader;
 import io.pixelsdb.pixels.common.exception.FSException;
 import io.pixelsdb.pixels.common.physical.FSFactory;
 import io.pixelsdb.pixels.core.*;
+import io.pixelsdb.pixels.core.predicate.PixelsPredicate;
+import io.pixelsdb.pixels.core.predicate.TupleDomainPixelsPredicate;
 import io.pixelsdb.pixels.core.reader.PixelsReaderOption;
 import io.pixelsdb.pixels.core.reader.PixelsRecordReader;
 import io.pixelsdb.pixels.core.vector.*;

--- a/pixels-presto/src/main/java/io/pixelsdb/pixels/presto/PixelsPageSource.java
+++ b/pixels-presto/src/main/java/io/pixelsdb/pixels/presto/PixelsPageSource.java
@@ -270,6 +270,17 @@ class PixelsPageSource implements ConnectorPageSource
         }
         sizeOfData += batchSize;
 
+        /**
+         * Issue #105:
+         * For select count(*) from t, EOF is set here.
+         * Because this.numColumnToRead is 0 and blocks is empty, thus
+         * this.recordReader.readBatch will never be called to get the row batch.
+         */
+        if (this.recordReader.isEndOfFile())
+        {
+            this.endOfFile = true;
+        }
+
         return new Page(batchSize, blocks);
     }
 


### PR DESCRIPTION
Fix the endless execution of `select count(*) from t` and queries with predicate '=null' (although such predicate is meaningless).

Query with '=null' predicate will return 0 rows in Presto, while the number of scanned rows is the same as result of `select count(*) from t`, which is the total number of rows in `t`.

`select count(*) from t` will only touch the file footers.