### PR TITLE
[Issue #100]: refine type management and add varchar/char support.

### DIFF
--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/compactor/PixelsCompactor.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/compactor/PixelsCompactor.java
@@ -19,6 +19,7 @@
  */
 package io.pixelsdb.pixels.core.compactor;
 
+import com.google.common.collect.ImmutableList;
 import io.pixelsdb.pixels.common.physical.PhysicalFSReader;
 import io.pixelsdb.pixels.common.physical.PhysicalFSWriter;
 import io.pixelsdb.pixels.common.physical.PhysicalReaderUtil;
@@ -26,12 +27,10 @@ import io.pixelsdb.pixels.common.physical.PhysicalWriterUtil;
 import io.pixelsdb.pixels.common.utils.Constants;
 import io.pixelsdb.pixels.core.PixelsProto;
 import io.pixelsdb.pixels.core.PixelsVersion;
-import io.pixelsdb.pixels.core.PixelsWriterImpl;
 import io.pixelsdb.pixels.core.TypeDescription;
 import io.pixelsdb.pixels.core.exception.PixelsFileMagicInvalidException;
 import io.pixelsdb.pixels.core.exception.PixelsFileVersionInvalidException;
 import io.pixelsdb.pixels.core.stats.StatsRecorder;
-import com.google.common.collect.ImmutableList;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.logging.log4j.LogManager;
@@ -446,7 +445,7 @@ public class PixelsCompactor
     {
         PixelsProto.Footer.Builder footerBuilder =
                 PixelsProto.Footer.newBuilder();
-        PixelsWriterImpl.writeTypes(footerBuilder, schema);
+        TypeDescription.writeTypes(footerBuilder, schema);
         for (StatsRecorder recorder : fileColStatRecorders)
         {
             footerBuilder.addColumnStats(recorder.serialize().build());

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/CharColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/CharColumnReader.java
@@ -19,55 +19,21 @@
  */
 package io.pixelsdb.pixels.core.reader;
 
-import io.pixelsdb.pixels.core.PixelsProto;
 import io.pixelsdb.pixels.core.TypeDescription;
-import io.pixelsdb.pixels.core.vector.ColumnVector;
-
-import java.io.IOException;
-import java.nio.ByteBuffer;
 
 /**
+ * This class is the same as String and Varchar column reader.
+ * It does not pad zeros at the end of a value for performance reasons.
  * @author guodong
+ * @author hank
  */
 public class CharColumnReader
-        extends ColumnReader
+        extends StringColumnReader
 {
+    // This class is implemented in Issue #100.
+
     CharColumnReader(TypeDescription type)
     {
         super(type);
-    }
-
-    /**
-     * Closes this column reader and releases any resources associated
-     * with it. If the column reader is already closed then invoking this
-     * method has no effect.
-     * <p>
-     * <p> As noted in {@link AutoCloseable#close()}, cases where the
-     * close may fail require careful attention. It is strongly advised
-     * to relinquish the underlying resources and to internally
-     * <em>mark</em> the {@code Closeable} as closed, prior to throwing
-     * the {@code IOException}.
-     *
-     * @throws IOException if an I/O error occurs
-     */
-    @Override
-    public void close() throws IOException
-    {
-
-    }
-
-    /**
-     * Read input buffer.
-     *
-     * @param input    input buffer
-     * @param encoding encoding type
-     * @param size     number of values to read
-     * @param vector   vector to read into
-     */
-    @Override
-    public void read(ByteBuffer input, PixelsProto.ColumnEncoding encoding,
-                     int offset, int size, int pixelStride, final int vectorIndex,
-                     ColumnVector vector, PixelsProto.ColumnChunkIndex chunkIndex)
-    {
     }
 }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/VarcharColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/VarcharColumnReader.java
@@ -19,57 +19,20 @@
  */
 package io.pixelsdb.pixels.core.reader;
 
-import io.pixelsdb.pixels.core.PixelsProto;
 import io.pixelsdb.pixels.core.TypeDescription;
-import io.pixelsdb.pixels.core.vector.ColumnVector;
-
-import java.io.IOException;
-import java.nio.ByteBuffer;
 
 /**
+ * pixels column reader for <code>Varchar</code>
  * @author guodong
+ * @author hank
  */
 public class VarcharColumnReader
-        extends ColumnReader
+        extends StringColumnReader
 {
+    // This class is implemented in Issue #100.
+
     VarcharColumnReader(TypeDescription type)
     {
         super(type);
-    }
-
-    /**
-     * Closes this column reader and releases any resources associated
-     * with it. If the column reader is already closed then invoking this
-     * method has no effect.
-     * <p>
-     * <p> As noted in {@link AutoCloseable#close()}, cases where the
-     * close may fail require careful attention. It is strongly advised
-     * to relinquish the underlying resources and to internally
-     * <em>mark</em> the {@code Closeable} as closed, prior to throwing
-     * the {@code IOException}.
-     *
-     * @throws IOException if an I/O error occurs
-     */
-    @Override
-    public void close() throws IOException
-    {
-
-    }
-
-    /**
-     * Read values from input buffer.
-     *
-     * @param input    input buffer
-     * @param encoding encoding type
-     * @param size     number of values to read
-     * @param vector   vector to read into
-     * @throws IOException
-     */
-    @Override
-    public void read(ByteBuffer input, PixelsProto.ColumnEncoding encoding,
-                     int offset, int size, int pixelStride, final int vectorIndex,
-                     ColumnVector vector, PixelsProto.ColumnChunkIndex chunkIndex)
-            throws IOException
-    {
     }
 }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/CharColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/CharColumnWriter.java
@@ -20,24 +20,18 @@
 package io.pixelsdb.pixels.core.writer;
 
 import io.pixelsdb.pixels.core.TypeDescription;
-import io.pixelsdb.pixels.core.vector.ColumnVector;
 
 /**
  * pixels column writer for <code>Char</code>
- *
+ * It is the same as VarcharColumnWriter, which means it never pads zero
+ * at the end when writing a value. This is for performance reasons.
  * @author guodong
+ * @author hank
  */
-// todo char column writer. basically the same as string column writer.
-public class CharColumnWriter extends BaseColumnWriter
+public class CharColumnWriter extends VarcharColumnWriter
 {
-    public CharColumnWriter(TypeDescription schema, int pixelStride, boolean isEncoding)
+    public CharColumnWriter(TypeDescription schema, int pixelStride, boolean isEncoding, int maxLength)
     {
-        super(schema, pixelStride, isEncoding);
-    }
-
-    @Override
-    public int write(ColumnVector vector, int length)
-    {
-        return 0;
+        super(schema, pixelStride, isEncoding, maxLength);
     }
 }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/ColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/ColumnWriter.java
@@ -20,6 +20,7 @@
 package io.pixelsdb.pixels.core.writer;
 
 import io.pixelsdb.pixels.core.PixelsProto;
+import io.pixelsdb.pixels.core.TypeDescription;
 import io.pixelsdb.pixels.core.stats.StatsRecorder;
 import io.pixelsdb.pixels.core.vector.ColumnVector;
 
@@ -32,6 +33,48 @@ import java.io.IOException;
  */
 public interface ColumnWriter
 {
+    /**
+     * Create a column writer according to the data type.
+     * @param schema the data type.
+     * @param pixelStride
+     * @param isEncoding set true if enable data encoding.
+     * @return
+     */
+    public static ColumnWriter newColumnWriter(TypeDescription schema, int pixelStride, boolean isEncoding)
+    {
+        switch (schema.getCategory())
+        {
+            case BOOLEAN:
+                return new BooleanColumnWriter(schema, pixelStride, isEncoding);
+            case BYTE:
+                return new ByteColumnWriter(schema, pixelStride, isEncoding);
+            case SHORT:
+            case INT:
+            case LONG:
+                return new IntegerColumnWriter(schema, pixelStride, isEncoding);
+            case FLOAT:
+                return new FloatColumnWriter(schema, pixelStride, isEncoding);
+            case DOUBLE:
+                return new DoubleColumnWriter(schema, pixelStride, isEncoding);
+            case STRING:
+                return new StringColumnWriter(schema, pixelStride, isEncoding);
+            case CHAR:
+                return new CharColumnWriter(schema, pixelStride, isEncoding, schema.getMaxLength());
+            case VARCHAR:
+                return new VarcharColumnWriter(schema, pixelStride, isEncoding, schema.getMaxLength());
+            case BINARY:
+                return new BinaryColumnWriter(schema, pixelStride, isEncoding);
+            case DATE:
+                return new DateColumnWriter(schema, pixelStride, isEncoding);
+            case TIME:
+                return new TimeColumnWriter(schema, pixelStride, isEncoding);
+            case TIMESTAMP:
+                return new TimestampColumnWriter(schema, pixelStride, isEncoding);
+            default:
+                throw new IllegalArgumentException("Bad schema type: " + schema.getCategory());
+        }
+    }
+
     int write(ColumnVector vector, int length)
             throws IOException;
 

--- a/pixels-load/src/main/java/io/pixelsdb/pixels/load/multi/Config.java
+++ b/pixels-load/src/main/java/io/pixelsdb/pixels/load/multi/Config.java
@@ -155,11 +155,19 @@ public class Config
             } else if (type.equals("long"))
             {
                 type = "bigint";
-            } else if (type.equals("varchar"))
+            } else if (type.equals("varchar") ||
+                    type.equals("char"))
             {
                 type = "string";
             }
-            // TODO: support varchar(n).
+            /**
+             * Issue #100:
+             * For varchar/char without max length, we use string instead of varchar.
+             * For varchar/char with max length and other data types, there is no need
+             * to change the type name. Pixels core will parse them correctly.
+             * Refer TypeDescription, ColumnReader, and ColumnWriter for how Pixels
+             * deals with data types.
+             */
             schemaBuilder.append(name).append(":").append(type)
                     .append(",");
         }


### PR DESCRIPTION
1. Varchar and char are implemented based on string type. They only truncate oversized values but not pad zeros/spaces.

2. Data type related methods in PixelsWriterImpl are moved to TypeDescription and ColumnWriter.

