### PR TITLE
[Issue #124]: refine read path.

### DIFF
--- a/pixels-common/pom.xml
+++ b/pixels-common/pom.xml
@@ -67,6 +67,11 @@
             <optional>true</optional>
         </dependency>
 
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>aws-crt-client</artifactId>
+        </dependency>
+
         <!-- protobuf -->
         <dependency>
             <groupId>com.google.protobuf</groupId>

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/Scheduler.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/Scheduler.java
@@ -154,5 +154,12 @@ public interface Scheduler
             }
             return CompletableFuture.allOf(fs);
         }
+
+        public void clear()
+        {
+            this.futures.clear();
+            this.requests.clear();
+            this.size = 0;
+        }
     }
 }

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/Scheduler.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/Scheduler.java
@@ -39,11 +39,9 @@ public interface Scheduler
      * all the requests.
      * @param reader
      * @param batch
-     * @return should never return null.
      * @throws IOException
      */
-    CompletableFuture<Void> executeBatch(PhysicalReader reader, RequestBatch batch,
-                                         List<CompletableFuture> actionFutures)
+    void executeBatch(PhysicalReader reader, RequestBatch batch)
             throws IOException;
 
     class Request implements Comparable<Request>

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/impl/PhysicalS3Reader.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/impl/PhysicalS3Reader.java
@@ -135,7 +135,7 @@ public class PhysicalS3Reader implements PhysicalReader
         try
         {
             this.position.addAndGet(len);
-            return ByteBuffer.wrap(response.asByteArray());
+            return ByteBuffer.wrap(response.asByteArrayUnsafe());
         } catch (Exception e)
         {
             throw new IOException("Failed to read object.", e);
@@ -192,20 +192,18 @@ public class PhysicalS3Reader implements PhysicalReader
 
         try
         {
-            CompletableFuture<ByteBuffer> futureBuffer = new CompletableFuture<>();
-            future.whenComplete((resp, err) ->
+            return future.thenApply(resp ->
             {
                 if (resp != null)
                 {
-                    futureBuffer.complete(ByteBuffer.wrap(resp.asByteArray()));
+                    return ByteBuffer.wrap(resp.asByteArrayUnsafe());
                 }
                 else
                 {
-                    logger.error("Failed complete the asynchronous read.", err);
-                    err.printStackTrace();
+                    logger.error("Failed complete the asynchronous read.");
+                    return null;
                 }
             });
-            return futureBuffer;
         } catch (Exception e)
         {
             throw new IOException("Failed to read object.", e);

--- a/pixels-common/src/test/java/io/pixelsdb/pixels/common/TestS3.java
+++ b/pixels-common/src/test/java/io/pixelsdb/pixels/common/TestS3.java
@@ -56,6 +56,19 @@ public class TestS3
     }
 
     @Test
+    public void testFuture()
+    {
+        CompletableFuture<ByteBuffer> future = new CompletableFuture<>();
+        ByteBuffer[] buffer = {null};
+        future.thenAccept(resp -> buffer[0] = resp);
+
+        for (int i = 0; i < 1000_000_0; ++i)
+        {
+            ByteBuffer.allocate(1000_00);
+        }
+    }
+
+    @Test
     public void testS3OutputStream() throws IOException
     {
         S3Client s3 = S3Client.builder().build();

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/PixelsRecordReaderImpl.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/PixelsRecordReaderImpl.java
@@ -451,6 +451,8 @@ public class PixelsRecordReaderImpl
         {
             scheduler.executeBatch(physicalReader, requestBatch);
             requestBatch.completeAll(actionFutures).join();
+            requestBatch.clear();
+            actionFutures.clear();
         } catch (Exception e)
         {
             throw new IOException("Failed to read row group footers, " +
@@ -723,6 +725,8 @@ public class PixelsRecordReaderImpl
             {
                 scheduler.executeBatch(physicalReader, requestBatch);
                 requestBatch.completeAll(actionFutures).join();
+                requestBatch.clear();
+                actionFutures.clear();
             } catch (Exception e)
             {
                 throw new IOException("Failed to read chunks block into buffers, " +

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/PixelsRecordReaderImpl.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/PixelsRecordReaderImpl.java
@@ -42,7 +42,6 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.atomic.AtomicReferenceArray;
 
 /**
  * @author guodong
@@ -65,7 +64,7 @@ public class PixelsRecordReaderImpl
     private final boolean enableCache;
     private final List<String> cacheOrder;
     private final PixelsCacheReader cacheReader;
-    private volatile PixelsFooterCache pixelsFooterCache;
+    private PixelsFooterCache pixelsFooterCache;
     private final String fileName;
 
     private TypeDescription fileSchema;
@@ -83,9 +82,9 @@ public class PixelsRecordReaderImpl
     private int curRGIdx = 0;            // index of current reading row group in targetRGs
     private int curRowInRG = 0;          // starting index of values to read by reader in current row group
 
-    private volatile AtomicReferenceArray<PixelsProto.RowGroupFooter> rowGroupFooters;
+    private PixelsProto.RowGroupFooter[] rowGroupFooters;
     // buffers of each chunk in this file, arranged by chunk's row group id and column id
-    private volatile AtomicReferenceArray<ByteBuffer> chunkBuffers;
+    private ByteBuffer[] chunkBuffers;
     private ColumnReader[] readers;      // column readers for each target columns
 
     private long diskReadBytes = 0L;
@@ -402,7 +401,7 @@ public class PixelsRecordReaderImpl
         targetRGNum = targetRGIdx;
 
         // read row group footers
-        rowGroupFooters = new AtomicReferenceArray<>(targetRGNum);
+        rowGroupFooters = new PixelsProto.RowGroupFooter[targetRGNum];
         /**
          * Issue #114:
          * Use request batch and read scheduler to execute the read requests.
@@ -425,14 +424,14 @@ public class PixelsRecordReaderImpl
                 long footerOffset = rowGroupInformation.getFooterOffset();
                 long footerLength = rowGroupInformation.getFooterLength();
                 int fi = i;
-                actionFutures.add(requestBatch.add(footerOffset, (int) footerLength).whenComplete((resp, err) ->
+                actionFutures.add(requestBatch.add(footerOffset, (int) footerLength).thenAccept(resp ->
                 {
                     if (resp != null)
                     {
                         try
                         {
                             PixelsProto.RowGroupFooter parsed = PixelsProto.RowGroupFooter.parseFrom(resp);
-                            rowGroupFooters.set(fi, parsed);
+                            rowGroupFooters[fi] = parsed;
                             pixelsFooterCache.putRGFooter(rgCacheId, parsed);
                         } catch (InvalidProtocolBufferException e)
                         {
@@ -444,13 +443,14 @@ public class PixelsRecordReaderImpl
             // cache hit
             else
             {
-                rowGroupFooters.set(i, rowGroupFooter);
+                rowGroupFooters[i] = rowGroupFooter;
             }
         }
         Scheduler scheduler = SchedulerFactory.Instance().getScheduler();
         try
         {
-            scheduler.executeBatch(physicalReader, requestBatch, actionFutures).get();
+            scheduler.executeBatch(physicalReader, requestBatch);
+            requestBatch.completeAll(actionFutures).join();
         } catch (Exception e)
         {
             throw new IOException("Failed to read row group footers, " +
@@ -515,7 +515,7 @@ public class PixelsRecordReaderImpl
         }
 
         // read chunk offset and length of each target column chunks
-        this.chunkBuffers = new AtomicReferenceArray<>(targetRGNum * includedColumns.length);
+        this.chunkBuffers = new ByteBuffer[targetRGNum * includedColumns.length];
         List<ChunkId> diskChunks = new ArrayList<>(targetRGNum * targetColumns.length);
         // read cached data which are in need
         if (enableCache)
@@ -559,7 +559,7 @@ public class PixelsRecordReaderImpl
                     else
                     {
                         PixelsProto.RowGroupIndex rowGroupIndex =
-                                rowGroupFooters.get(rgIdx).getRowGroupIndexEntry();
+                                rowGroupFooters[rgIdx].getRowGroupIndexEntry();
                         PixelsProto.ColumnChunkIndex chunkIndex =
                                 rowGroupIndex.getColumnChunkIndexEntries(colId);
                         /**
@@ -587,7 +587,7 @@ public class PixelsRecordReaderImpl
                 memoryUsage += columnletId.direct ? 0 : columnlet.capacity();
 //                long getEnd = System.nanoTime();
 //                logger.debug("[cache get]: " + columnlet.length + "," + (getEnd - getBegin));
-                chunkBuffers.set((rgId - RGStart) * includedColumns.length + colId, columnlet);
+                chunkBuffers[(rgId - RGStart) * includedColumns.length + colId] = columnlet;
                 if (columnlet == null || columnlet.capacity() == 0)
                 {
                     /**
@@ -598,7 +598,7 @@ public class PixelsRecordReaderImpl
                      */
                     int rgIdx = rgId - RGStart;
                     PixelsProto.RowGroupIndex rowGroupIndex =
-                            rowGroupFooters.get(rgIdx).getRowGroupIndexEntry();
+                            rowGroupFooters[rgIdx].getRowGroupIndexEntry();
                     PixelsProto.ColumnChunkIndex chunkIndex =
                             rowGroupIndex.getColumnChunkIndexEntries(colId);
                     ChunkId diskChunk = new ChunkId(rgIdx, colId, chunkIndex.getChunkOffset(),
@@ -644,7 +644,7 @@ public class PixelsRecordReaderImpl
             for (int rgIdx = 0; rgIdx < targetRGNum; rgIdx++)
             {
                 PixelsProto.RowGroupIndex rowGroupIndex =
-                        rowGroupFooters.get(rgIdx).getRowGroupIndexEntry();
+                        rowGroupFooters[rgIdx].getRowGroupIndexEntry();
                 for (int colId : targetColumns)
                 {
                     PixelsProto.ColumnChunkIndex chunkIndex =
@@ -706,11 +706,11 @@ public class PixelsRecordReaderImpl
                  * readPerfMetrics.addSeqRead(readCost);
                  */
                 actionFutures.add(requestBatch.add(new Scheduler.Request(chunk.offset, (int)chunk.length))
-                        .whenComplete((resp, err) ->
+                        .thenAccept(resp ->
                 {
                     if (resp != null)
                     {
-                        chunkBuffers.set(rgIdx * numCols + colId, resp);
+                        chunkBuffers[rgIdx * numCols + colId] = resp;
                     }
                 }));
                 // don't update statistics in whenComplete as it may be executed in other threads.
@@ -721,7 +721,8 @@ public class PixelsRecordReaderImpl
             Scheduler scheduler = SchedulerFactory.Instance().getScheduler();
             try
             {
-                scheduler.executeBatch(physicalReader, requestBatch, actionFutures).get();
+                scheduler.executeBatch(physicalReader, requestBatch);
+                requestBatch.completeAll(actionFutures).join();
             } catch (Exception e)
             {
                 throw new IOException("Failed to read chunks block into buffers, " +
@@ -904,7 +905,7 @@ public class PixelsRecordReaderImpl
             {
                 if (!columnVectors[i].duplicated)
                 {
-                    PixelsProto.RowGroupFooter rowGroupFooter = rowGroupFooters.get(curRGIdx);
+                    PixelsProto.RowGroupFooter rowGroupFooter = rowGroupFooters[curRGIdx];
                     PixelsProto.ColumnEncoding encoding = rowGroupFooter.getRowGroupEncoding()
                             .getColumnChunkEncodings(resultColumns[i]);
                     int index = curRGIdx * includedColumns.length + resultColumns[i];
@@ -912,7 +913,7 @@ public class PixelsRecordReaderImpl
                             .getColumnChunkIndexEntries(
                                     resultColumns[i]);
                     // TODO: read chunk buffer lazily when a column block is read by PixelsPageSource.
-                    readers[i].read(chunkBuffers.get(index), encoding, curRowInRG, curBatchSize,
+                    readers[i].read(chunkBuffers[index], encoding, curRowInRG, curBatchSize,
                             postScript.getPixelStride(), resultRowBatch.size, columnVectors[i], chunkIndex);
                 }
             }
@@ -1043,9 +1044,9 @@ public class PixelsRecordReaderImpl
         // release chunk buffer
         if (chunkBuffers != null)
         {
-            for (int i = 0; i < chunkBuffers.length(); i++)
+            for (int i = 0; i < chunkBuffers.length; i++)
             {
-                chunkBuffers.set(i, null);
+                chunkBuffers[i] = null;
             }
         }
         if (readers != null)
@@ -1075,9 +1076,9 @@ public class PixelsRecordReaderImpl
         }
         if (rowGroupFooters != null)
         {
-            for (int i = 0; i < rowGroupFooters.length(); ++i)
+            for (int i = 0; i < rowGroupFooters.length; ++i)
             {
-                rowGroupFooters.set(i, null);
+                rowGroupFooters[i] = null;
             }
         }
         // write out read performance metrics

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/StringColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/StringColumnWriter.java
@@ -201,7 +201,8 @@ public class StringColumnWriter extends BaseColumnWriter
         if (currentUseDictionaryEncoding)
         {
             return PixelsProto.ColumnEncoding.newBuilder()
-                    .setKind(PixelsProto.ColumnEncoding.Kind.DICTIONARY);
+                    .setKind(PixelsProto.ColumnEncoding.Kind.DICTIONARY)
+                    .setDictionarySize(dictionary.size());
         }
         return PixelsProto.ColumnEncoding.newBuilder()
                 .setKind(PixelsProto.ColumnEncoding.Kind.NONE);

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/utils/TestDynamicIntArray.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/utils/TestDynamicIntArray.java
@@ -41,4 +41,26 @@ public class TestDynamicIntArray
             assert i == ints[i];
         }
     }
+
+    @Test
+    public void testPerf()
+    {
+        DynamicIntArray array = new DynamicIntArray(8192);
+        for (int i = 0; i < 256*1024; ++i)
+        {
+            array.add(i);
+        }
+        int[] a = array.toArray();
+        long start = System.nanoTime();
+        for (int i = 0; i < array.size(); ++i)
+        {
+            int b = array.get(i);
+            if (b == -1)
+            {
+                break;
+            }
+            //assert i == array.get(i);
+        }
+        System.out.println(System.nanoTime()-start);
+    }
 }

--- a/pixels-daemon/pom.xml
+++ b/pixels-daemon/pom.xml
@@ -98,6 +98,11 @@
             <optional>true</optional>
         </dependency>
 
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>aws-crt-client</artifactId>
+        </dependency>
+
         <!-- hdfs -->
         <dependency>
             <groupId>org.apache.hadoop</groupId>

--- a/pixels-load/pom.xml
+++ b/pixels-load/pom.xml
@@ -76,6 +76,11 @@
             <optional>true</optional>
         </dependency>
 
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>aws-crt-client</artifactId>
+        </dependency>
+
         <!-- hdfs -->
         <dependency>
             <groupId>org.apache.hadoop</groupId>

--- a/pixels-presto/pom.xml
+++ b/pixels-presto/pom.xml
@@ -51,6 +51,11 @@
             <optional>true</optional>
         </dependency>
 
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>aws-crt-client</artifactId>
+        </dependency>
+
         <!-- hdfs -->
         <dependency>
             <groupId>org.apache.hadoop</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,7 @@
         <dep.junit.platform.version>1.6.2</dep.junit.platform.version>
         <dep.ozone.version>0.5.0-beta</dep.ozone.version>
         <dep.awssdk.version>2.16.60</dep.awssdk.version>
+        <dep.awssdk.preview.version>2.16.60-PREVIEW</dep.awssdk.preview.version>
     </properties>
 
     <dependencyManagement>
@@ -232,6 +233,12 @@
                 <version>${dep.awssdk.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>aws-crt-client</artifactId>
+                <version>${dep.awssdk.preview.version}</version>
             </dependency>
 
             <!-- airlift -->


### PR DESCRIPTION
refine read path, replace AtomicReferenceArray with array to refine gc, reduce memory copy for readFully in S3 reader, try AwsCrtAsyncHttpClient.
add clear to RequestBatch.
refine starts array in StringColumnReader.