### PR TITLE
[Issue #140]: temporary fix for currupt row batch.

### DIFF
--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/PixelsRecordReaderImpl.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/PixelsRecordReaderImpl.java
@@ -904,11 +904,8 @@ public class PixelsRecordReaderImpl
             this.resultRowBatch = resultSchema.createRowBatch(batchSize);
             resultRowBatch.projectionSize = includedColumnNum;
         }
-        else
-        {
-            this.resultRowBatch.reset();
-            this.resultRowBatch.ensureSize(batchSize);
-        }
+        this.resultRowBatch.reset();
+        this.resultRowBatch.ensureSize(batchSize);
 
         int rgRowCount = 0;
         int curBatchSize = 0;

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/BinaryColumnVector.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/BinaryColumnVector.java
@@ -20,7 +20,6 @@
 package io.pixelsdb.pixels.core.vector;
 
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 
 /**
  * BinaryColumnVector derived from org.apache.hadoop.hive.ql.exec.vector.
@@ -101,12 +100,11 @@ public class BinaryColumnVector extends ColumnVector
     {
         super.reset();
         /**
-         * Issue #132:
-         * FIX: column vector is reused in VectorizedRowBatch, so that set all elements in vector
-         * to null 1) help garbage collector to release the old buffers if setVal is used, 2) enable
-         * the column vector users to return values without checking isNull.
+         * Issue #140:
+         * Temporarily comment out this to avoid null pointer exception.
+         * FIXME: use encoded column vectors (i.e. lazy encoding) instead of decoded ones.
          */
-        Arrays.fill(vector, null);
+        // Arrays.fill(vector, null);
         initBuffer(0);
     }
 


### PR DESCRIPTION
The problem is not completely fixed, encoded column vector is needed.