### PR TITLE
[Issue #142]: fix mbps rate-limit.

### DIFF
--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/scheduler/SortMergeScheduler.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/scheduler/SortMergeScheduler.java
@@ -274,6 +274,10 @@ public class SortMergeScheduler implements Scheduler
     /**
      * The retry policy that retries timeout read requests for a given number of times at most.
      * The timeout is determined by a cost model.
+     * <p>
+     *     Issue #142:
+     *     We future confirm that retry helps keep the large query performance stable.
+     * </p>
      */
     protected class RetryPolicy
     {


### PR DESCRIPTION
Previously, the permit to acquire from the mbps rate limiter may be zero, which is invalid.