### PR TITLE
[Issue #164]: define storage scheme in CREATE statement.

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,8 @@ The file(s) of each table are stored in a separate directory named by the table 
 
 ### Create TPC-H Database
 Log in presto-cli and use the SQL statements in `scripts/sql/tpch_schema.sql` to create the TPC-H database in Pixels.
+Change the value of the `storage` table property in the create-table statement to `hdfs` if HDFS is used as the 
+underlying storage system instead of S3.
 Note that presto-cli can execute only one SQL statement at each time.
 
 Then, use `SHOW SCHEMAS` and `SHOW TABLES` statements to check if the tpch database has been

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/Storage.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/Storage.java
@@ -83,6 +83,7 @@ public interface Storage
 
         public boolean equals(Scheme other)
         {
+            // enums in Java can be compared using '=='.
             return this == other;
         }
     }

--- a/pixels-presto/src/main/java/io/pixelsdb/pixels/presto/PixelsConnector.java
+++ b/pixels-presto/src/main/java/io/pixelsdb/pixels/presto/PixelsConnector.java
@@ -24,12 +24,15 @@ import com.facebook.presto.spi.connector.Connector;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
 import com.facebook.presto.spi.connector.ConnectorSplitManager;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import com.facebook.presto.spi.session.PropertyMetadata;
 import com.facebook.presto.spi.transaction.IsolationLevel;
 import io.airlift.bootstrap.LifeCycleManager;
 import io.airlift.log.Logger;
 import io.pixelsdb.pixels.presto.exception.PixelsErrorCode;
 
 import javax.inject.Inject;
+
+import java.util.List;
 
 import static java.util.Objects.requireNonNull;
 
@@ -41,17 +44,20 @@ public class PixelsConnector
     private final PixelsMetadata metadata;
     private final PixelsSplitManager splitManager;
     private final PixelsPageSourceProvider pageSourceProvider;
+    private final PixelsTableProperties tableProperties;
 
     @Inject
     public PixelsConnector(
             LifeCycleManager lifeCycleManager,
             PixelsMetadata metadata,
             PixelsSplitManager splitManager,
-            PixelsPageSourceProvider pageSourceProvider) {
+            PixelsPageSourceProvider pageSourceProvider,
+            PixelsTableProperties tableProperties) {
         this.lifeCycleManager = requireNonNull(lifeCycleManager, "lifeCycleManager is null");
         this.metadata = requireNonNull(metadata, "metadata is null");
         this.splitManager = requireNonNull(splitManager, "splitManager is null");
         this.pageSourceProvider = requireNonNull(pageSourceProvider, "recordSetProvider is null");
+        this.tableProperties = requireNonNull(tableProperties, "tableProperties is null");
     }
 
     @Override
@@ -82,5 +88,11 @@ public class PixelsConnector
             logger.error(e, "error in shutting down connector");
             throw new PrestoException(PixelsErrorCode.PIXELS_CONNECTOR_ERROR, e);
         }
+    }
+
+    @Override
+    public List<PropertyMetadata<?>> getTableProperties()
+    {
+        return tableProperties.getTableProperties();
     }
 }

--- a/pixels-presto/src/main/java/io/pixelsdb/pixels/presto/PixelsModule.java
+++ b/pixels-presto/src/main/java/io/pixelsdb/pixels/presto/PixelsModule.java
@@ -57,6 +57,7 @@ public class PixelsModule
         binder.bind(PixelsMetadataProxy.class).in(Scopes.SINGLETON);
         binder.bind(PixelsSplitManager.class).in(Scopes.SINGLETON);
         binder.bind(PixelsPageSourceProvider.class).in(Scopes.SINGLETON);
+        binder.bind(PixelsTableProperties.class).in(Scopes.SINGLETON);
         configBinder(binder).bindConfig(PixelsPrestoConfig.class);
 
         jsonBinder(binder).addDeserializerBinding(Type.class).to(TypeDeserializer.class);

--- a/pixels-presto/src/main/java/io/pixelsdb/pixels/presto/PixelsTableProperties.java
+++ b/pixels-presto/src/main/java/io/pixelsdb/pixels/presto/PixelsTableProperties.java
@@ -1,0 +1,47 @@
+package io.pixelsdb.pixels.presto;
+
+import com.facebook.presto.spi.session.PropertyMetadata;
+import com.google.common.collect.ImmutableList;
+
+import javax.inject.Inject;
+import java.util.List;
+
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+
+/**
+ * Class contains all table properties for the Pixels connector. Used when creating a table:
+ * <p>
+ * CREATE TABLE foo (a VARCHAR, b INT)
+ * WITH (storage = 'hdfs');
+ * </p>
+ *
+ * Created at: 14/02/2022
+ * Author: hank
+ */
+public class PixelsTableProperties
+{
+    public static final String STORAGE = "storage";
+
+    private final List<PropertyMetadata<?>> tableProperties;
+
+    @Inject
+    public PixelsTableProperties()
+    {
+        PropertyMetadata<String> s1 = new PropertyMetadata<>(
+                STORAGE,
+                "The storage scheme of the table.",
+                VARCHAR,
+                String.class,
+                "hdfs",
+                false,
+            String.class::cast,
+            object -> object);
+
+        tableProperties = ImmutableList.of(s1);
+    }
+
+    public List<PropertyMetadata<?>> getTableProperties()
+    {
+        return tableProperties;
+    }
+}

--- a/scripts/sql/tpch_schema.sql
+++ b/scripts/sql/tpch_schema.sql
@@ -13,7 +13,7 @@ CREATE TABLE IF NOT EXISTS customer (
   c_acctbal double,
   c_mktsegment varchar(10),
   c_comment varchar(117)
-);
+) WITH (storage='s3');
 
 CREATE TABLE IF NOT EXISTS lineitem (
   l_orderkey bigint,
@@ -32,14 +32,14 @@ CREATE TABLE IF NOT EXISTS lineitem (
   l_shipinstruct varchar(25),
   l_shipmode varchar(10),
   l_comment varchar(44)
-);
+) WITH (storage='s3');
 
 CREATE TABLE IF NOT EXISTS nation (
   n_nationkey bigint,
   n_name varchar(25),
   n_regionkey bigint,
   n_comment varchar(152)
-);
+) WITH (storage='s3');
 
 CREATE TABLE IF NOT EXISTS orders (
   o_orderkey bigint,
@@ -51,7 +51,7 @@ CREATE TABLE IF NOT EXISTS orders (
   o_clerk varchar(15),
   o_shippriority integer,
   o_comment varchar(79)
-);
+) WITH (storage='s3');
 
 CREATE TABLE IF NOT EXISTS part (
   p_partkey bigint,
@@ -63,7 +63,7 @@ CREATE TABLE IF NOT EXISTS part (
   p_container varchar(10),
   p_retailprice double,
   p_comment varchar(23)
-);
+) WITH (storage='s3');
 
 CREATE TABLE IF NOT EXISTS partsupp (
   ps_partkey bigint,
@@ -71,13 +71,13 @@ CREATE TABLE IF NOT EXISTS partsupp (
   ps_availqty integer,
   ps_supplycost double,
   ps_comment varchar(199)
-);
+) WITH (storage='s3');
 
 CREATE TABLE IF NOT EXISTS region (
   r_regionkey bigint,
   r_name varchar(25),
   r_comment varchar(152)
-);
+) WITH (storage='s3');
 
 CREATE TABLE IF NOT EXISTS supplier (
   s_suppkey bigint,
@@ -87,4 +87,4 @@ CREATE TABLE IF NOT EXISTS supplier (
   s_phone varchar(15),
   s_acctbal double,
   s_comment varchar(101)
-);
+) WITH (storage='s3');


### PR DESCRIPTION
Add table properties to pixels-presto, so that we can use the table property to specify the storage scheme when creating tables.