### PR TITLE
[Issue #172]: implement record cursor and enhance record reader.

### DIFF
--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/io/PhysicalS3Reader.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/io/PhysicalS3Reader.java
@@ -52,7 +52,7 @@ public class PhysicalS3Reader implements PhysicalReader
     private static final ExecutorService clientService;
     private final static int LEN_1M = 1024*1024;
     private final static int LEN_10M = 1024*1024*10;
-    private final static int ADAPTIVE_READ_TH = 1*1024*1024;
+    private final static int ADAPTIVE_READ_TH = 2*1024*1024;
 
     static
     {

--- a/pixels-common/src/main/resources/pixels.properties
+++ b/pixels-common/src/main/resources/pixels.properties
@@ -41,6 +41,7 @@ presto.user=test_pixels
 presto.password=null
 presto.ssl=false
 presto.query.url=http://localhost:8080/v1/query
+record.cursor.enabled=false
 
 # etcd configuration
 # etcd.hosts=presto00,presto01,presto02,presto03,presto04

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/PixelsRecordReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/PixelsRecordReader.java
@@ -38,7 +38,19 @@ public interface PixelsRecordReader
     int prepareBatch(int batchSize) throws IOException;
 
     /**
-     * Read the next row batch. This method is independent from prepareBatch().
+     * Read the next row batch. This method is thread-safe and independent from prepareBatch().
+     *
+     * @param batchSize the row batch size
+     * @return vectorized row batch
+     * @throws java.io.IOException
+     */
+    VectorizedRowBatch readBatch(int batchSize, boolean reuse)
+            throws IOException;
+
+    /**
+     * Read the next row batch. This method is thread-safe and independent from prepareBatch().
+     * The returned row batch is not reused across multiple calls. It is equivalent
+     * to readBatch(batchSize, false).
      *
      * @param batchSize the row batch size
      * @return vectorized row batch
@@ -48,8 +60,19 @@ public interface PixelsRecordReader
             throws IOException;
 
     /**
-     * Read the next row batch. This method is thread safe, and
-     * is independent from prepareBatch().
+     * Read the next row batch. This method is thread-safe and independent from prepareBatch().
+     * It is equivalent to readBatch(DEFAULT_SIZE, reuse).
+     *
+     * @return row batch
+     * @throws java.io.IOException
+     */
+    VectorizedRowBatch readBatch(boolean reuse)
+            throws IOException;
+
+    /**
+     * Read the next row batch. This method is thread-safe and independent from prepareBatch().
+     * The returned row batch is not reused across multiple calls. It is equivalent
+     * to readBatch(DEFAULT_SIZE, false).
      *
      * @return row batch
      * @throws java.io.IOException

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/TimestampColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/TimestampColumnReader.java
@@ -37,6 +37,7 @@ import java.sql.Timestamp;
  * All timestamp values are translated to the specified time zone after read from file.
  *
  * @author guodong
+ * @author hank
  */
 public class TimestampColumnReader
         extends ColumnReader

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/utils/BitUtils.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/utils/BitUtils.java
@@ -188,7 +188,7 @@ public class BitUtils
     {
         /**
          * Issue #99:
-         * Use as least as variables as possible to reduce stack footprint
+         * Use as least variables as possible to reduce stack footprint
          * and thus improve performance.
          */
         byte bitsLeft = 8, b;

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/TimestampColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/TimestampColumnWriter.java
@@ -51,7 +51,7 @@ public class TimestampColumnWriter extends BaseColumnWriter
             throws IOException
     {
         TimestampColumnVector columnVector = (TimestampColumnVector) vector;
-        long[] times = columnVector.time;
+        long[] times = columnVector.times;
         int curPartLength;
         int curPartOffset = 0;
         int nextPartLength = size;

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestPixelsReaderBasic.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestPixelsReaderBasic.java
@@ -268,10 +268,10 @@ public class TestPixelsReaderBasic
                         System.out.println("[c] size: " + elementSize
                                 + ", expected: " + elementSize * 3.14159d + ", actual: " + ccv.vector[i]);
                     }
-                    if (dcv.time[i] != time)
+                    if (dcv.times[i] != time)
                     {
                         System.out.println("[d] size: " + elementSize
-                                + ", expected: " + time + ", actual: " + dcv.time[i]);
+                                + ", expected: " + time + ", actual: " + dcv.times[i]);
                     }
                     int expectedBool = elementSize > 25 ? 1 : 0;
                     if (expectedBool != ecv.vector[i])
@@ -292,7 +292,7 @@ public class TestPixelsReaderBasic
                     assertEquals(elementSize, acv.vector[i]);
                     assertEquals(elementSize * 3.1415f, bcv.vector[i], 0.000001f);
                     assertEquals(elementSize * 3.14159d, ccv.vector[i], 0.000001d);
-                    assertEquals(time, dcv.time[i]);
+                    assertEquals(time, dcv.times[i]);
                     assertEquals((elementSize > 25 ? 1 : 0), ecv.vector[i]);
                     assertEquals(String.valueOf(elementSize),
                             new String(zcv.vector[i], zcv.start[i], zcv.lens[i]));
@@ -342,10 +342,10 @@ public class TestPixelsReaderBasic
                 {
                     System.out.println("[c] size: " + elementSize + ", null");
                 }
-                if (dcv.time[i] != time)
+                if (dcv.times[i] != time)
                 {
                     System.out.println("[d] size: " + elementSize
-                            + ", expected: " + time + ", actual: " + dcv.time[i]);
+                            + ", expected: " + time + ", actual: " + dcv.times[i]);
                 }
                 if (dcv.isNull[i])
                 {
@@ -382,7 +382,7 @@ public class TestPixelsReaderBasic
                 assertFalse(ccv.isNull[i]);
                 assertEquals(elementSize * 3.14159d, ccv.vector[i], 0.000001f);
                 assertFalse(dcv.isNull[i]);
-                assertEquals(dcv.time[i], 1528901945696L);
+                assertEquals(dcv.times[i], 1528901945696L);
                 assertFalse(ecv.isNull[i]);
                 assertEquals((elementSize > 25000 ? 1 : 0), ecv.vector[i]);
                 assertFalse(zcv.isNull[i]);

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestPixelsReaderOption.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestPixelsReaderOption.java
@@ -166,7 +166,7 @@ public class TestPixelsReaderOption
                 assertEquals(rowId, acv.vector[i]);
                 assertEquals(rowId * 3.1415f, bcv.vector[i], 0.000001f);
                 assertEquals(rowId * 3.14159d, ccv.vector[i], 0.000001d);
-                assertEquals(time, dcv.time[i]);
+                assertEquals(time, dcv.times[i]);
                 assertEquals(rowId > 25 ? 1 : 0, ecv.vector[i]);
                 assertEquals(String.valueOf(rowId),
                         new String(zcv.vector[i], zcv.start[i], zcv.lens[i]));

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/writer/TestPixelsWriter.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/writer/TestPixelsWriter.java
@@ -100,7 +100,7 @@ public class TestPixelsWriter
                     c.isNull[row] = true;
                     c.vector[row] = 0;
                     d.isNull[row] = true;
-                    d.time[row] = 0;
+                    d.times[row] = 0;
                     d.nanos[row] = 0;
                     e.isNull[row] = true;
                     e.vector[row] = 0;

--- a/pixels-presto/src/main/java/io/pixelsdb/pixels/presto/PixelsModule.java
+++ b/pixels-presto/src/main/java/io/pixelsdb/pixels/presto/PixelsModule.java
@@ -59,6 +59,7 @@ public class PixelsModule
         binder.bind(PixelsMetadataProxy.class).in(Scopes.SINGLETON);
         binder.bind(PixelsSplitManager.class).in(Scopes.SINGLETON);
         binder.bind(PixelsPageSourceProvider.class).in(Scopes.SINGLETON);
+        binder.bind(PixelsRecordSetProvider.class).in(Scopes.SINGLETON);
         binder.bind(PixelsSessionProperties.class).in(Scopes.SINGLETON);
         binder.bind(PixelsTableProperties.class).in(Scopes.SINGLETON);
         configBinder(binder).bindConfig(PixelsPrestoConfig.class);

--- a/pixels-presto/src/main/java/io/pixelsdb/pixels/presto/PixelsPageSource.java
+++ b/pixels-presto/src/main/java/io/pixelsdb/pixels/presto/PixelsPageSource.java
@@ -259,7 +259,7 @@ class PixelsPageSource implements ConnectorPageSource
         {
             try
             {
-                rowBatch = recordReader.readBatch(BatchSize, true);
+                rowBatch = recordReader.readBatch(BatchSize, false);
                 rowBatchSize = rowBatch.size;
                 if (rowBatchSize <= 0)
                 {

--- a/pixels-presto/src/main/java/io/pixelsdb/pixels/presto/PixelsPageSource.java
+++ b/pixels-presto/src/main/java/io/pixelsdb/pixels/presto/PixelsPageSource.java
@@ -259,7 +259,7 @@ class PixelsPageSource implements ConnectorPageSource
         {
             try
             {
-                rowBatch = recordReader.readBatch(BatchSize);
+                rowBatch = recordReader.readBatch(BatchSize, true);
                 rowBatchSize = rowBatch.size;
                 if (rowBatchSize <= 0)
                 {

--- a/pixels-presto/src/main/java/io/pixelsdb/pixels/presto/PixelsRecordCursor.java
+++ b/pixels-presto/src/main/java/io/pixelsdb/pixels/presto/PixelsRecordCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 PixelsDB.
+ * Copyright 2022 PixelsDB.
  *
  * This file is part of Pixels.
  *
@@ -19,13 +19,13 @@
  */
 package io.pixelsdb.pixels.presto;
 
-import com.facebook.presto.spi.ConnectorPageSource;
-import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.PrestoException;
-import com.facebook.presto.spi.block.*;
+import com.facebook.presto.spi.RecordCursor;
 import com.facebook.presto.spi.predicate.Domain;
-import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.*;
 import io.airlift.log.Logger;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
 import io.pixelsdb.pixels.cache.MemoryMappedFile;
 import io.pixelsdb.pixels.cache.PixelsCacheReader;
 import io.pixelsdb.pixels.common.physical.Storage;
@@ -37,24 +37,24 @@ import io.pixelsdb.pixels.core.predicate.TupleDomainPixelsPredicate;
 import io.pixelsdb.pixels.core.reader.PixelsReaderOption;
 import io.pixelsdb.pixels.core.reader.PixelsRecordReader;
 import io.pixelsdb.pixels.core.vector.*;
-import io.pixelsdb.pixels.presto.block.TimeArrayBlock;
-import io.pixelsdb.pixels.presto.block.VarcharArrayBlock;
 import io.pixelsdb.pixels.presto.exception.PixelsErrorCode;
 import io.pixelsdb.pixels.presto.impl.PixelsPrestoConfig;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import static com.facebook.presto.spi.type.StandardTypes.*;
-import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 /**
- * @author hank
- * @author guodong
- * @author tao
+ * Created at: 17/02/2022
+ * Author: hank
  */
-class PixelsPageSource implements ConnectorPageSource
+public class PixelsRecordCursor implements RecordCursor
 {
     private static final Logger logger = Logger.get(PixelsPageSource.class);
     private final int BatchSize;
@@ -71,18 +71,35 @@ class PixelsPageSource implements ConnectorPageSource
     private long memoryUsage = 0L;
     private PixelsReaderOption option;
     private final int numColumnToRead;
-    private int batchId;
+    /**
+     * If rowBatch == null && rowBatchSize > 0, numColumnToRead must be 0.
+     * It means that the query is like select count(*) from table, i.e., it
+     * does not read any physical data.
+     *
+     * If rowBatch == null && rowBatchSize == 0, it means that the first row
+     * has not been read.
+     */
+    private VectorizedRowBatch rowBatch;
+    private volatile int rowBatchSize;
+    private volatile int rowIndex;
 
-    public PixelsPageSource(PixelsSplit split, List<PixelsColumnHandle> columnHandles, Storage storage,
-                            MemoryMappedFile cacheFile, MemoryMappedFile indexFile, PixelsFooterCache pixelsFooterCache,
-                            String connectorId)
+    private final Map<Integer, ByteColumnVector> byteColumnVectors = new HashMap<>();
+    private final Map<Integer, BinaryColumnVector> byteArrayColumnVectors = new HashMap<>();
+    private final Map<Integer, DateColumnVector> dateColumnVectors = new HashMap<>();
+    private final Map<Integer, TimeColumnVector> timeColumnVectors = new HashMap<>();
+    private final Map<Integer, TimestampColumnVector> timestampColumnVectors = new HashMap<>();
+    private final Map<Integer, DoubleColumnVector> doubleColumnVectors = new HashMap<>();
+    private final Map<Integer, LongColumnVector> longColumnVectors = new HashMap<>();
+
+    public PixelsRecordCursor(PixelsSplit split, List<PixelsColumnHandle> columnHandles, Storage storage,
+                              MemoryMappedFile cacheFile, MemoryMappedFile indexFile, PixelsFooterCache footerCache,
+                              String connectorId)
     {
         this.split = split;
         this.storage = storage;
         this.columns = columnHandles;
         this.numColumnToRead = columnHandles.size();
-        this.footerCache = pixelsFooterCache;
-        this.batchId = 0;
+        this.footerCache = footerCache;
         this.closed = false;
 
         this.cacheReader = PixelsCacheReader
@@ -90,7 +107,7 @@ class PixelsPageSource implements ConnectorPageSource
                 .setCacheFile(cacheFile)
                 .setIndexFile(indexFile)
                 .build();
-        getPixelsReaderBySchema(split, cacheReader, pixelsFooterCache);
+        getPixelsReaderBySchema(split, cacheReader, footerCache);
 
         try
         {
@@ -103,6 +120,9 @@ class PixelsPageSource implements ConnectorPageSource
             throw new PrestoException(PixelsErrorCode.PIXELS_READER_ERROR, e);
         }
         this.BatchSize = PixelsPrestoConfig.getBatchSize();
+        this.rowIndex = -1;
+        this.rowBatch = null;
+        this.rowBatchSize = 0;
     }
 
     private void getPixelsReaderBySchema(PixelsSplit split, PixelsCacheReader pixelsCacheReader, PixelsFooterCache pixelsFooterCache)
@@ -225,14 +245,6 @@ class PixelsPageSource implements ConnectorPageSource
     @Override
     public long getSystemMemoryUsage()
     {
-        /**
-         * Issue #113:
-         * I am still not sure show the result of this method are used by Presto.
-         * Currently, we return the cumulative memory usage. However this may be
-         * inappropriate.
-         * I tested about ten queries on test_1187, there was no problem, but
-         * TODO: we still need to be careful about this method in the future.
-         */
         if (closed)
         {
             return memoryUsage;
@@ -241,74 +253,193 @@ class PixelsPageSource implements ConnectorPageSource
     }
 
     @Override
-    public boolean isFinished()
+    public Type getType(int field)
     {
-        return this.closed;
+        checkArgument(field >= 0 && field < columns.size(), "Invalid field index");
+        return this.columns.get(field).getColumnType();
     }
 
     @Override
-    public Page getNextPage()
+    public boolean advanceNextPosition()
     {
-        this.batchId++;
-        VectorizedRowBatch rowBatch;
-        int rowBatchSize;
-
-        Block[] blocks = new Block[this.numColumnToRead];
+        if (++this.rowIndex < this.rowBatchSize)
+        {
+            return true;
+        }
 
         if (this.numColumnToRead > 0)
         {
             try
             {
-                rowBatch = recordReader.readBatch(BatchSize);
-                rowBatchSize = rowBatch.size;
-                if (rowBatchSize <= 0)
+                VectorizedRowBatch newRowBatch = this.recordReader.readBatch(BatchSize);
+                if (newRowBatch.size <= 0)
                 {
+                    // reach the end of the file
                     if (readNextPath())
                     {
-                        return getNextPage();
+                        // open and start reading the next file (path).
+                        newRowBatch = this.recordReader.readBatch(BatchSize);
                     } else
                     {
+                        // no more files (paths) to read, close.
                         close();
-                        return null;
+                        return false;
                     }
                 }
-                for (int fieldId = 0; fieldId < blocks.length; ++fieldId)
+                if (this.rowBatch != newRowBatch)
                 {
-                    Type type = columns.get(fieldId).getColumnType();
-                    ColumnVector vector = rowBatch.cols[fieldId];
-                    blocks[fieldId] = new LazyBlock(rowBatchSize, new PixelsBlockLoader(vector, type, rowBatchSize));
+                    // VectorizedRowBatch may be reused by PixelsRecordReader.
+                    this.rowBatch = newRowBatch;
+                    this.setColumnVectors();
                 }
+                this.rowBatchSize = this.rowBatch.size;
+                this.rowIndex = -1;
+                return advanceNextPosition();
             } catch (IOException e)
             {
                 closeWithSuppression(e);
                 throw new PrestoException(PixelsErrorCode.PIXELS_BAD_DATA, e);
             }
-        }
-        else
+        } else
         {
             // No column to read.
             try
             {
-                rowBatchSize = this.recordReader.prepareBatch(BatchSize);
-                if (rowBatchSize <= 0)
+                int size = this.recordReader.prepareBatch(BatchSize);
+                if (size <= 0)
                 {
                     if (readNextPath())
                     {
-                        return getNextPage();
+                        size = this.recordReader.prepareBatch(BatchSize);
                     } else
                     {
                         close();
-                        return null;
+                        return false;
                     }
                 }
+                this.rowBatchSize = size;
+                this.rowIndex = -1;
+                return advanceNextPosition();
             } catch (IOException e)
             {
                 closeWithSuppression(e);
                 throw new PrestoException(PixelsErrorCode.PIXELS_BAD_DATA, e);
             }
         }
+    }
 
-        return new Page(rowBatchSize, blocks);
+    private void setColumnVectors()
+    {
+        requireNonNull(this.rowBatch, "this.rowBatch is null");
+        requireNonNull(this.columns, "this.columns is null");
+
+        this.byteColumnVectors.clear();
+        this.byteArrayColumnVectors.clear();
+        this.dateColumnVectors.clear();
+        this.timeColumnVectors.clear();
+        this.timestampColumnVectors.clear();
+        this.doubleColumnVectors.clear();
+        this.longColumnVectors.clear();
+
+        for (int i = 0; i < this.numColumnToRead; ++i)
+        {
+            Type type = this.columns.get(i).getColumnType();
+            switch (type.getDisplayName())
+            {
+                case INTEGER:
+                case BIGINT:
+                    this.longColumnVectors.put(i, (LongColumnVector) this.rowBatch.cols[i]);
+                    break;
+                case DOUBLE:
+                case REAL:
+                    this.doubleColumnVectors.put(i, (DoubleColumnVector) this.rowBatch.cols[i]);
+                    break;
+                case VARCHAR:
+                    this.byteArrayColumnVectors.put(i, (BinaryColumnVector) this.rowBatch.cols[i]);
+                    break;
+                case BOOLEAN:
+                    this.byteColumnVectors.put(i, (ByteColumnVector) this.rowBatch.cols[i]);
+                    break;
+                case DATE:
+                    this.dateColumnVectors.put(i, (DateColumnVector) this.rowBatch.cols[i]);
+                    break;
+                case TIME:
+                    this.timeColumnVectors.put(i, (TimeColumnVector) this.rowBatch.cols[i]);
+                    break;
+                case TIMESTAMP:
+                    this.timestampColumnVectors.put(i, (TimestampColumnVector) this.rowBatch.cols[i]);
+                    break;
+                default:
+                    throw new PrestoException(PixelsErrorCode.PIXELS_CURSOR_ERROR,
+                            "Column type '" + type.getDisplayName() + "' is not supported.");
+            }
+        }
+    }
+
+    @Override
+    public boolean getBoolean(int field)
+    {
+        return this.byteColumnVectors.get(field).vector[this.rowIndex] > 0;
+    }
+
+    @Override
+    public long getLong(int field)
+    {
+        Type type = this.columns.get(field).getColumnType();
+        if (type.equals(IntegerType.INTEGER) || type.equals(BigintType.BIGINT))
+        {
+            return this.longColumnVectors.get(field).vector[this.rowIndex];
+        }
+        else if (type.equals(DateType.DATE))
+        {
+            return this.dateColumnVectors.get(field).dates[this.rowIndex];
+        }
+        else if (type.equals(TimeType.TIME))
+        {
+            return this.timeColumnVectors.get(field).times[this.rowIndex];
+        }
+        else if (type.equals(TimestampType.TIMESTAMP))
+        {
+            return this.timestampColumnVectors.get(field).times[this.rowIndex];
+        }
+        throw new PrestoException(PixelsErrorCode.PIXELS_CURSOR_ERROR,
+                "Column type '" + type.getDisplayName() + "' is not Long/Integer based.");
+    }
+
+    @Override
+    public double getDouble(int field)
+    {
+        return Double.longBitsToDouble(this.doubleColumnVectors.get(field).vector[this.rowIndex]);
+    }
+
+    @Override
+    public Slice getSlice(int field)
+    {
+        Type type = this.columns.get(field).getColumnType();
+        checkArgument (type.equals(VarcharType.VARCHAR),
+                "Column type '" + type.getDisplayName() + "' is not Slice based.");
+        BinaryColumnVector columnVector = this.byteArrayColumnVectors.get(field);
+        return Slices.wrappedBuffer(columnVector.vector[this.rowIndex],
+                columnVector.start[this.rowIndex], columnVector.lens[this.rowIndex]);
+    }
+
+    @Override
+    public Object getObject(int field)
+    {
+        throw new PrestoException(PixelsErrorCode.PIXELS_CURSOR_ERROR,
+                "Array or Map type is not supported.");
+    }
+
+    @Override
+    public boolean isNull(int field)
+    {
+
+        if (this.rowBatch == null)
+        {
+            return this.rowBatchSize > 0;
+        }
+        checkArgument(field < this.rowBatch.cols.length);
+        return this.rowBatch.cols[field].isNull[this.rowIndex];
     }
 
     @Override
@@ -320,6 +451,14 @@ class PixelsPageSource implements ConnectorPageSource
         }
 
         closeReader();
+
+        this.byteColumnVectors.clear();
+        this.byteArrayColumnVectors.clear();
+        this.longColumnVectors.clear();
+        this.doubleColumnVectors.clear();
+        this.dateColumnVectors.clear();
+        this.timeColumnVectors.clear();
+        this.timeColumnVectors.clear();
 
         closed = true;
     }
@@ -337,11 +476,6 @@ class PixelsPageSource implements ConnectorPageSource
                     this.memoryUsage += recordReader.getMemoryUsage();
                 }
                 pixelsReader.close();
-                /**
-                 * Issue #114:
-                 * Must set pixelsReader and recordReader to null,
-                 * close() may be called multiple times by Presto.
-                 */
                 recordReader = null;
                 pixelsReader = null;
             }
@@ -367,128 +501,6 @@ class PixelsPageSource implements ConnectorPageSource
                 throwable.addSuppressed(e);
             }
             throw new PrestoException(PixelsErrorCode.PIXELS_CLIENT_ERROR, e);
-        }
-    }
-
-    /**
-     * Lazy Block Implementation for the Pixels
-     */
-    private final class PixelsBlockLoader
-            implements LazyBlockLoader<LazyBlock>
-    {
-        private final int expectedBatchId = batchId;
-        private final ColumnVector vector;
-        private final Type type;
-        private final int batchSize;
-
-        public PixelsBlockLoader(ColumnVector vector, Type type, int batchSize)
-        {
-            this.vector = vector;
-            this.type = requireNonNull(type, "type is null");
-            this.batchSize = batchSize;
-        }
-
-        @Override
-        public final void load(LazyBlock lazyBlock)
-        {
-            checkState(batchId == expectedBatchId);
-            Block block;
-
-            switch (type.getDisplayName())
-            {
-                case INTEGER:
-                case BIGINT:
-                    LongColumnVector lcv = (LongColumnVector) vector;
-                    block = new LongArrayBlock(batchSize, Optional.ofNullable(lcv.isNull), lcv.vector);
-                    break;
-                case DOUBLE:
-                case REAL:
-                    /**
-                     * According to TypeDescription.createColumn(),
-                     * both float and double type use DoubleColumnVector, while they use
-                     * FloatColumnReader and DoubleColumnReader respectively according to
-                     * io.pixelsdb.pixels.reader.ColumnReader.newColumnReader().
-                     * TODO: these two column should also support reading to LongColumnVector,
-                     * without conversions like longBitsToDouble, so that we can directly create
-                     * LongArrayBlock here without writeDouble (in which double is converted to long).
-                     * With this optimization, CPU and GC pressure can be greatly reduced.
-                     */
-                    DoubleColumnVector dcv = (DoubleColumnVector) vector;
-                    block = new LongArrayBlock(batchSize, Optional.ofNullable(dcv.isNull), dcv.vector);
-                    break;
-                case VARCHAR:
-                    BinaryColumnVector scv = (BinaryColumnVector) vector;
-                    /*
-                    int vectorContentLen = 0;
-                    byte[] vectorContent;
-                    int[] vectorOffsets = new int[rowBatch.size + 1];
-                    int curVectorOffset = 0;
-                    for (int i = 0; i < rowBatch.size; ++i)
-                    {
-                        vectorContentLen += scv.lens[i];
-                    }
-                    vectorContent = new byte[vectorContentLen];
-                    for (int i = 0; i < rowBatch.size; ++i)
-                    {
-                        int elementLen = scv.lens[i];
-                        if (!scv.isNull[i])
-                        {
-                            System.arraycopy(scv.vector[i], scv.start[i], vectorContent, curVectorOffset, elementLen);
-                        }
-                        vectorOffsets[i] = curVectorOffset;
-                        curVectorOffset += elementLen;
-                    }
-                    vectorOffsets[rowBatch.size] = vectorContentLen;
-                    block = new VariableWidthBlock(rowBatch.size,
-                            Slices.wrappedBuffer(vectorContent, 0, vectorContentLen),
-                            vectorOffsets,
-                            scv.isNull);
-                            */
-                    block = new VarcharArrayBlock(batchSize, scv.vector, scv.start, scv.lens, scv.isNull);
-                    break;
-                case BOOLEAN:
-                    ByteColumnVector bcv = (ByteColumnVector) vector;
-                    block = new ByteArrayBlock(batchSize, Optional.ofNullable(bcv.isNull), bcv.vector);
-                    break;
-                case DATE:
-                    // Issue #94: add date type.
-                    DateColumnVector dtcv = (DateColumnVector) vector;
-                    // In pixels and Presto, date is stored as the number of days from UTC 1970-1-1 0:0:0.
-                    block = new IntArrayBlock(batchSize, Optional.ofNullable(dtcv.isNull), dtcv.dates);
-                    break;
-                case TIME:
-                    // Issue #94: add time type.
-                    TimeColumnVector tcv = (TimeColumnVector) vector;
-                    /**
-                     * In Presto, LongArrayBlock is used for time type. However, in Pixels,
-                     * Time value is stored as int, so here we use TimeArrayBlock, which
-                     * accepts int values but provides getLong method same as LongArrayBlock.
-                     */
-                    block = new TimeArrayBlock(batchSize, tcv.isNull, tcv.times);
-                    break;
-                case TIMESTAMP:
-                    TimestampColumnVector tscv = (TimestampColumnVector) vector;
-                    /**
-                     * Issue #94: we have confirmed that LongArrayBlock is used for timestamp
-                     * type in Presto.
-                     *
-                     * com.facebook.presto.spi.type.TimestampType extends
-                     * com.facebook.presto.spi.type.AbstractLongType, which creates a LongArrayBlockBuilder.
-                     * And this block builder builds a LongArrayBlock.
-                     */
-                    block = new LongArrayBlock(batchSize, Optional.ofNullable(tscv.isNull), tscv.times);
-                    break;
-                default:
-                    BlockBuilder blockBuilder = type.createBlockBuilder(null, batchSize);
-                    for (int i = 0; i < batchSize; ++i)
-                    {
-                        blockBuilder.appendNull();
-                    }
-                    block = blockBuilder.build();
-                    break;
-            }
-
-            lazyBlock.setBlock(block);
         }
     }
 

--- a/pixels-presto/src/main/java/io/pixelsdb/pixels/presto/PixelsRecordSet.java
+++ b/pixels-presto/src/main/java/io/pixelsdb/pixels/presto/PixelsRecordSet.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2022 PixelsDB.
+ *
+ * This file is part of Pixels.
+ *
+ * Pixels is free software: you can redistribute it and/or modify
+ * it under the terms of the Affero GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * Pixels is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Affero GNU General Public License for more details.
+ *
+ * You should have received a copy of the Affero GNU General Public
+ * License along with Pixels.  If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package io.pixelsdb.pixels.presto;
+
+import com.facebook.presto.spi.RecordCursor;
+import com.facebook.presto.spi.RecordSet;
+import com.facebook.presto.spi.type.Type;
+import io.pixelsdb.pixels.cache.MemoryMappedFile;
+import io.pixelsdb.pixels.common.physical.Storage;
+import io.pixelsdb.pixels.core.PixelsFooterCache;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Created at: 17/02/2022
+ * Author: hank
+ */
+public class PixelsRecordSet implements RecordSet
+{
+    private final PixelsSplit split;
+    private final List<PixelsColumnHandle> columnHandles;
+    private final Storage storage;
+    private final MemoryMappedFile cacheFile;
+    private final MemoryMappedFile indexFile;
+    private final PixelsFooterCache footerCache;
+    private final String connectorId;
+    private final List<Type> columnTypes;
+
+    public PixelsRecordSet(PixelsSplit split, List<PixelsColumnHandle> columnHandles, Storage storage,
+                            MemoryMappedFile cacheFile, MemoryMappedFile indexFile, PixelsFooterCache footerCache,
+                            String connectorId)
+    {
+        this.split = requireNonNull(split, "split is null");
+        this. columnHandles = requireNonNull(columnHandles, "columnHandles is null");
+        this.storage = requireNonNull(storage, "storage is null");
+        this.cacheFile = cacheFile;
+        this.indexFile = indexFile;
+        this.footerCache = requireNonNull(footerCache, "footerCache is null");
+        this.connectorId = requireNonNull(connectorId, "connectorId is null");
+        this.columnTypes = new ArrayList<>(columnHandles.size());
+        for (PixelsColumnHandle columnHandle : columnHandles)
+        {
+            this.columnTypes.add(columnHandle.getColumnType());
+        }
+    }
+
+    @Override
+    public List<Type> getColumnTypes()
+    {
+        return this.columnTypes;
+    }
+
+    @Override
+    public RecordCursor cursor()
+    {
+        return new PixelsRecordCursor(this.split, this.columnHandles, this.storage,
+                this.cacheFile, this.indexFile, this.footerCache, this.connectorId);
+    }
+}

--- a/pixels-presto/src/main/java/io/pixelsdb/pixels/presto/PixelsRecordSetProvider.java
+++ b/pixels-presto/src/main/java/io/pixelsdb/pixels/presto/PixelsRecordSetProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 PixelsDB.
+ * Copyright 2022 PixelsDB.
  *
  * This file is part of Pixels.
  *
@@ -20,7 +20,7 @@
 package io.pixelsdb.pixels.presto;
 
 import com.facebook.presto.spi.*;
-import com.facebook.presto.spi.connector.ConnectorPageSourceProvider;
+import com.facebook.presto.spi.connector.ConnectorRecordSetProvider;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.google.inject.Inject;
 import io.pixelsdb.pixels.cache.MemoryMappedFile;
@@ -38,10 +38,10 @@ import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 
 /**
- * Provider Class for Pixels Page Source class.
+ * Created at: 17/02/2022
+ * Author: hank
  */
-public class PixelsPageSourceProvider
-        implements ConnectorPageSourceProvider
+public class PixelsRecordSetProvider implements ConnectorRecordSetProvider
 {
     private final String connectorId;
     private final MemoryMappedFile cacheFile;
@@ -49,7 +49,7 @@ public class PixelsPageSourceProvider
     private final PixelsFooterCache pixelsFooterCache;
 
     @Inject
-    public PixelsPageSourceProvider(PixelsConnectorId connectorId, PixelsPrestoConfig config)
+    public PixelsRecordSetProvider(PixelsConnectorId connectorId, PixelsPrestoConfig config)
             throws Exception
     {
         this.connectorId = requireNonNull(connectorId, "connectorId is null").toString();
@@ -71,8 +71,10 @@ public class PixelsPageSourceProvider
     }
 
     @Override
-    public ConnectorPageSource createPageSource(ConnectorTransactionHandle transactionHandle,
-                                                ConnectorSession session, ConnectorSplit split, List<ColumnHandle> columns) {
+    public RecordSet getRecordSet(ConnectorTransactionHandle transactionHandle,
+                                  ConnectorSession session,
+                                  ConnectorSplit split, List<? extends ColumnHandle> columns)
+    {
         List<PixelsColumnHandle> pixelsColumns = columns.stream()
                 .map(PixelsColumnHandle.class::cast)
                 .collect(toList());
@@ -89,6 +91,6 @@ public class PixelsPageSourceProvider
             throw new PrestoException(PixelsErrorCode.PIXELS_STORAGE_ERROR, e);
         }
 
-        return new PixelsPageSource(pixelsSplit, pixelsColumns, storage, cacheFile, indexFile, pixelsFooterCache, connectorId);
+        return new PixelsRecordSet(pixelsSplit, pixelsColumns, storage, cacheFile, indexFile, pixelsFooterCache, connectorId);
     }
 }


### PR DESCRIPTION
1. Add the PixelsRecordSet and PixelsRecordCusor, which can be enabled/disabled by configuration properties, to pixels-presto.
2. Update PixelsRecordReaderImpl.readBatch, let users specify whether they want to reuse the returned result row batch.

Issue #172 is not completely resolved. Record cursor is much slower than the page source for wide tables (they have similar performance on TPC-H). We also tried to implement a context (buffer) of result row batches to automatically allocate, free, and reuse the result row batches. However, it reduces the query performance a lot. This issue can be solved by implementing the read path in C++ in the future.