### PR TITLE
[Issue #175]: enhance transaction info of queries and pass query id into I/O schedulers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ It may take about one minute to complete. After that, find the following jar/zip
 
 ## Installation in AWS
 
-Create an EC2 Ubuntu-20.04 instance with x86 arch and at least 20GB root volume. Memory of 8GB or larger is recommended. Log in the instance as `ubuntu` user, 
+Create an EC2 Ubuntu-20.04 instance with x86 arch and at least 20GB root volume. Memory of 8GB or larger is recommended. Login the instance as `ubuntu` user, 
 and install the following components.
 
 ### Install JDK
@@ -228,6 +228,7 @@ These dashboards can be used to monitor the performance metrics of the instance.
 ## Start Pixels
 Enter `PIXELS_HOME` and start the daemons of Pixels using:
 ```bash
+./sbin/reset-cache.sh
 ./sbin/start-pixels.sh
 ```
 Enter the home of presto-server and start Presto:

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/Scheduler.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/Scheduler.java
@@ -39,9 +39,10 @@ public interface Scheduler
      * all the requests.
      * @param reader
      * @param batch
+     * @param queryId
      * @throws IOException
      */
-    void executeBatch(PhysicalReader reader, RequestBatch batch)
+    void executeBatch(PhysicalReader reader, RequestBatch batch, long queryId)
             throws IOException;
 
     class Request implements Comparable<Request>

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/scheduler/NoopScheduler.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/scheduler/NoopScheduler.java
@@ -55,7 +55,7 @@ public class NoopScheduler implements Scheduler
     protected NoopScheduler() {}
 
     @Override
-    public void executeBatch(PhysicalReader reader, RequestBatch batch) throws IOException
+    public void executeBatch(PhysicalReader reader, RequestBatch batch, long queryId) throws IOException
     {
         if (batch.size() <= 0)
         {

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/scheduler/RateLimitedScheduler.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/scheduler/RateLimitedScheduler.java
@@ -108,14 +108,14 @@ public class RateLimitedScheduler extends SortMergeScheduler
     }
 
     @Override
-    public void executeBatch(PhysicalReader reader, RequestBatch batch) throws IOException
+    public void executeBatch(PhysicalReader reader, RequestBatch batch, long queryId) throws IOException
     {
         if (batch.size() <= 0)
         {
             return;
         }
 
-        List<MergedRequest> mergedRequests = sortMerge(batch);
+        List<MergedRequest> mergedRequests = sortMerge(batch, queryId);
 
         if (reader.supportsAsync())
         {

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/transaction/QueryTransInfo.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/transaction/QueryTransInfo.java
@@ -19,6 +19,8 @@
  */
 package io.pixelsdb.pixels.common.transaction;
 
+import java.util.Properties;
+
 import static com.google.common.base.MoreObjects.toStringHelper;
 
 /**
@@ -30,6 +32,7 @@ public class QueryTransInfo
     private long queryId;
     private long queryTimestamp;
     private Status queryStatus;
+    private Properties queryProperties;
 
     public enum Status
     {
@@ -41,6 +44,7 @@ public class QueryTransInfo
         this.queryId = queryId;
         this.queryTimestamp = queryTimestamp;
         this.queryStatus = Status.PENDING;
+        this.queryProperties = new Properties();
     }
 
     public long getQueryId()
@@ -61,6 +65,11 @@ public class QueryTransInfo
     public void setQueryStatus(Status status)
     {
         this.queryStatus = status;
+    }
+
+    public Properties getQueryProperties()
+    {
+        return this.queryProperties;
     }
 
     @Override


### PR DESCRIPTION
We have also tried gradually increasing the max merge size per query, but it has a 5-10% performance overhead.