### PR TITLE
[Issue #178]: enable metrics server by configuration parameter.

### DIFF
--- a/pixels-common/src/main/resources/pixels.properties
+++ b/pixels-common/src/main/resources/pixels.properties
@@ -24,6 +24,9 @@ metadata.server.host=node01
 trans.server.port=18889
 trans.server.host=node01
 
+# metrics server
+metrics.server.enabled=false
+
 # pixels-load
 pixel.stride=10000
 # 64M, 256M

--- a/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/DaemonMain.java
+++ b/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/DaemonMain.java
@@ -91,9 +91,14 @@ public class DaemonMain
                 }
                 else
                 {
+                    boolean metricsServerEnabled = Boolean.parseBoolean(
+                            ConfigFactory.Instance().getProperty("metrics.server.enabled"));
                     // start metrics server and cache manager on data node
-                    MetricsServer metricsServer = new MetricsServer();
-                    container.addServer("metrics", metricsServer);
+                    if (metricsServerEnabled)
+                    {
+                        MetricsServer metricsServer = new MetricsServer();
+                        container.addServer("metrics", metricsServer);
+                    }
                     CacheManager cacheManager = new CacheManager();
                     container.addServer("cache_manager", cacheManager);
                 }


### PR DESCRIPTION
Use `metrics.server.enabled` to enable or disable the metrics server.