### PR TITLE
[Issue #183]: fix show columns from information_schema.

### DIFF
--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/error/ErrorCode.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/error/ErrorCode.java
@@ -44,6 +44,7 @@ public class ErrorCode
     public static final int METADATA_UPDATE_LAYOUT_FAILED = (ERROR_BASE_METADATA + 12);
     public static final int METADATA_ADD_LAYOUT_FAILED = (ERROR_BASE_METADATA + 13);
     public static final int METADATA_ADD_SCHEMA_FAILED = (ERROR_BASE_METADATA + 14);
+    public static final int METADATA_GET_SCHEMA_FAILED = (ERROR_BASE_METADATA + 15);
     // end error code for metadata rpc
 
     // begin error code for shared memory message queue


### PR DESCRIPTION
select * from information_schema.columns may pass information schema table names into PixelsMetadata.listTableColumns(), so we should check the existence of the table in this method.