### PR TITLE
[Issue #139]: stop retrying the request from terminated queries.

### DIFF
--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/Scheduler.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/Scheduler.java
@@ -47,11 +47,13 @@ public interface Scheduler
 
     class Request implements Comparable<Request>
     {
-        public long start;
-        public int length;
+        public final long queryId;
+        public final long start;
+        public final int length;
 
-        public Request(long start, int length)
+        public Request(long queryId, long start, int length)
         {
+            this.queryId = queryId;
             this.start = start;
             this.length = length;
         }
@@ -105,9 +107,14 @@ public interface Scheduler
             this.size = 0;
         }
 
-        public CompletableFuture<ByteBuffer> add(long start, int length)
+        public CompletableFuture<ByteBuffer> add(long queryId, long start, int length)
         {
-            return add(new Request(start, length));
+            Request request = new Request(queryId, start, length);
+            CompletableFuture<ByteBuffer> future = new CompletableFuture<>();
+            requests.add(request);
+            futures.add(future);
+            size++;
+            return future;
         }
 
         public CompletableFuture<ByteBuffer> add(Request request)

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/scheduler/RateLimitedScheduler.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/scheduler/RateLimitedScheduler.java
@@ -103,7 +103,8 @@ public class RateLimitedScheduler extends SortMergeScheduler
         this.enableRetry = Boolean.parseBoolean(ConfigFactory.Instance().getProperty("read.request.enable.retry"));
         if (this.enableRetry)
         {
-            this.retryPolicy = new RetryPolicy(1000);
+            int interval = Integer.parseInt(ConfigFactory.Instance().getProperty("read.request.retry.interval.ms"));
+            this.retryPolicy = new RetryPolicy(interval);
         }
     }
 

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/transaction/QueryTransInfo.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/transaction/QueryTransInfo.java
@@ -20,6 +20,7 @@
 package io.pixelsdb.pixels.common.transaction;
 
 import java.util.Properties;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 
@@ -31,7 +32,7 @@ public class QueryTransInfo
 {
     private long queryId;
     private long queryTimestamp;
-    private Status queryStatus;
+    private AtomicReference<Status> queryStatus;
     private Properties queryProperties;
 
     public enum Status
@@ -43,7 +44,7 @@ public class QueryTransInfo
     {
         this.queryId = queryId;
         this.queryTimestamp = queryTimestamp;
-        this.queryStatus = Status.PENDING;
+        this.queryStatus = new AtomicReference<>(Status.PENDING);
         this.queryProperties = new Properties();
     }
 
@@ -59,12 +60,12 @@ public class QueryTransInfo
 
     public Status getQueryStatus()
     {
-        return queryStatus;
+        return queryStatus.get();
     }
 
     public void setQueryStatus(Status status)
     {
-        this.queryStatus = status;
+        this.queryStatus.set(status);
     }
 
     public Properties getQueryProperties()
@@ -78,7 +79,7 @@ public class QueryTransInfo
         return toStringHelper(this)
                 .add("queryId", queryId)
                 .add("queryTimestamp", queryTimestamp)
-                .add("queryStatus", queryStatus)
+                .add("queryStatus", queryStatus.get())
                 .toString();
     }
 }

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/transaction/TransContext.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/transaction/TransContext.java
@@ -82,4 +82,11 @@ public class TransContext
     {
         return this.queryTransContext.get(queryId);
     }
+
+    public boolean isTerminated(long queryId)
+    {
+        QueryTransInfo info =  this.queryTransContext.get(queryId);
+        return info == null || info.getQueryStatus() == QueryTransInfo.Status.COMMIT ||
+                info.getQueryStatus() == QueryTransInfo.Status.ROLLBACK;
+    }
 }

--- a/pixels-common/src/main/resources/pixels.properties
+++ b/pixels-common/src/main/resources/pixels.properties
@@ -69,6 +69,8 @@ read.request.rate.limit.rps=6000
 read.request.rate.limit.mbps=800
 read.request.enable.retry=true
 read.request.max.retry.num=3
+# the interval in milliseconds of retry queue checks.
+read.request.retry.interval.ms=1000
 projection.read.enabled=true
 s3.enable.async=true
 s3.use.async.client=true

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/PixelsRecordReaderImpl.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/PixelsRecordReaderImpl.java
@@ -444,7 +444,7 @@ public class PixelsRecordReaderImpl
                 long footerOffset = rowGroupInformation.getFooterOffset();
                 long footerLength = rowGroupInformation.getFooterLength();
                 int fi = i;
-                actionFutures.add(requestBatch.add(footerOffset, (int) footerLength).thenAccept(resp ->
+                actionFutures.add(requestBatch.add(queryId, footerOffset, (int) footerLength).thenAccept(resp ->
                 {
                     if (resp != null)
                     {
@@ -728,7 +728,7 @@ public class PixelsRecordReaderImpl
                  * readCost.setMs(readTimeMs);
                  * readPerfMetrics.addSeqRead(readCost);
                  */
-                actionFutures.add(requestBatch.add(new Scheduler.Request(chunk.offset, (int)chunk.length))
+                actionFutures.add(requestBatch.add(queryId, chunk.offset, (int)chunk.length)
                         .thenAccept(resp ->
                 {
                     if (resp != null)


### PR DESCRIPTION
We push down the query id into requests, and check if the query is terminated when retrying the request.