### PR TITLE
[Issue #207]: fix the data type metadata in the file footer.

### DIFF
--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/TypeDescription.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/TypeDescription.java
@@ -654,9 +654,10 @@ public final class TypeDescription
         }
         for (int i = 0; i < children.size(); i++)
         {
+            TypeDescription child = children.get(i);
             PixelsProto.Type.Builder tmpType = PixelsProto.Type.newBuilder();
             tmpType.setName(names.get(i));
-            switch (children.get(i).getCategory())
+            switch (child.getCategory())
             {
                 case BOOLEAN:
                     tmpType.setKind(PixelsProto.Type.Kind.BOOLEAN);
@@ -681,27 +682,27 @@ public final class TypeDescription
                     break;
                 case DECIMAL:
                     tmpType.setKind(PixelsProto.Type.Kind.DECIMAL);
-                    tmpType.setPrecision(schema.precision);
-                    tmpType.setScale(schema.scale);
+                    tmpType.setPrecision(child.precision);
+                    tmpType.setScale(child.scale);
                     break;
                 case STRING:
                     tmpType.setKind(PixelsProto.Type.Kind.STRING);
                     break;
                 case CHAR:
                     tmpType.setKind(PixelsProto.Type.Kind.CHAR);
-                    tmpType.setMaximumLength(schema.getMaxLength());
+                    tmpType.setMaximumLength(child.getMaxLength());
                     break;
                 case VARCHAR:
                     tmpType.setKind(PixelsProto.Type.Kind.VARCHAR);
-                    tmpType.setMaximumLength(schema.getMaxLength());
+                    tmpType.setMaximumLength(child.getMaxLength());
                     break;
                 case BINARY:
                     tmpType.setKind(PixelsProto.Type.Kind.BINARY);
-                    tmpType.setMaximumLength(schema.getMaxLength());
+                    tmpType.setMaximumLength(child.getMaxLength());
                     break;
                 case VARBINARY:
                     tmpType.setKind(PixelsProto.Type.Kind.VARBINARY);
-                    tmpType.setMaximumLength(schema.getMaxLength());
+                    tmpType.setMaximumLength(child.getMaxLength());
                     break;
                 case TIMESTAMP:
                     tmpType.setKind(PixelsProto.Type.Kind.TIMESTAMP);

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/stats/StatsRecorder.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/stats/StatsRecorder.java
@@ -196,7 +196,7 @@ public class StatsRecorder
                  * To be compatible with Presto, use IntegerColumnStats for decimal.
                  * Decimal and its statistics in Presto are represented as long. If
                  * needed in other places, integer statistics can be converted to double
-                 * using the precision and scale from the schema in the row group footer.
+                 * using the precision and scale from the schema in the file footer.
                  */
             case DECIMAL:
                 return new IntegerStatsRecorder();

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestPixelsReaderBasic.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestPixelsReaderBasic.java
@@ -21,6 +21,7 @@ package io.pixelsdb.pixels.core.reader;
 
 import io.pixelsdb.pixels.common.physical.Storage;
 import io.pixelsdb.pixels.common.physical.StorageFactory;
+import io.pixelsdb.pixels.core.PixelsFooterCache;
 import io.pixelsdb.pixels.core.PixelsProto;
 import io.pixelsdb.pixels.core.PixelsReader;
 import io.pixelsdb.pixels.core.PixelsReaderImpl;
@@ -53,16 +54,22 @@ public class TestPixelsReaderBasic
     @Test
     public void testMetadata()
     {
-        String path = "hdfs://dbiir10:9000/pixels/pixels/test_105/old3_v_order/20181109162236_1437.pxl";
+        String path = "file:///home/hank/Downloads/pixels/20220306043329_1.pxl";
         PixelsReader reader;
         try
         {
-            Storage storage = StorageFactory.Instance().getStorage("hdfs");
+            Storage storage = StorageFactory.Instance().getStorage("file");
             reader = PixelsReaderImpl.newBuilder()
                     .setStorage(storage)
                     .setPath(path)
+                    .setPixelsFooterCache(new PixelsFooterCache())
                     .build();
             List<PixelsProto.RowGroupInformation> rowGroupInformationList = reader.getFooter().getRowGroupInfosList();
+            List<PixelsProto.Type> types = reader.getFooter().getTypesList();
+            for (PixelsProto.Type type : types)
+            {
+                System.out.println(type);
+            }
             System.out.println(reader.getRowGroupStats().size());
         }
         catch (IOException e)

--- a/pixels-load/src/main/java/io/pixelsdb/pixels/load/multi/Main.java
+++ b/pixels-load/src/main/java/io/pixelsdb/pixels/load/multi/Main.java
@@ -449,7 +449,6 @@ public class Main
                         .setDefault("4").required(true)
                         .help("specify the number of threads used for data compaction");
 
-
                 Namespace ns = null;
                 try
                 {
@@ -511,7 +510,7 @@ public class Main
 
                     // compact
                     long startTime = System.currentTimeMillis();
-                    for (int i = 0; i < statuses.size(); i+=numRowGroupInBlock)
+                    for (int i = 0, thdId = 0; i < statuses.size(); i+=numRowGroupInBlock, thdId++)
                     {
                         if (i + numRowGroupInBlock > statuses.size())
                         {
@@ -533,7 +532,6 @@ public class Main
                         List<String> sourcePaths = new ArrayList<>();
                         for (int j = 0; j < numRowGroupInBlock; ++j)
                         {
-                            //System.out.println(statuses[i+j].getPath().toString());
                             sourcePaths.add(statuses.get(i+j).getPath());
                         }
 
@@ -541,7 +539,7 @@ public class Main
                                 DateUtil.getCurTime() +
                                 ".compact.pxl";
 
-                        System.out.println("(" + i + ") " + sourcePaths.size() +
+                        System.out.println("(" + thdId + ") " + sourcePaths.size() +
                                 " ordered files to be compacted into '" + filePath + "'.");
 
                         PixelsCompactor.Builder compactorBuilder =

--- a/pixels-load/src/test/java/io/pixelsdb/pixels/load/TestPixelsCore.java
+++ b/pixels-load/src/test/java/io/pixelsdb/pixels/load/TestPixelsCore.java
@@ -17,7 +17,7 @@
  * License along with Pixels.  If not, see
  * <https://www.gnu.org/licenses/>.
  */
-package io.pixelsdb.pixels.load.rw;
+package io.pixelsdb.pixels.load;
 
 import io.pixelsdb.pixels.common.physical.Storage;
 import io.pixelsdb.pixels.common.physical.StorageFactory;
@@ -33,7 +33,8 @@ import java.sql.Timestamp;
  * @author: tao
  * @date: Create in 2018-11-07 16:05
  **/
-public class PixelsCoreTest {
+public class TestPixelsCore
+{
 
     String hdfsDir = "/home/tao/data/hadoop-2.7.3/etc/hadoop/"; // dbiir10
 

--- a/pixels-presto/src/main/java/io/pixelsdb/pixels/presto/impl/PixelsTupleDomainPredicate.java
+++ b/pixels-presto/src/main/java/io/pixelsdb/pixels/presto/impl/PixelsTupleDomainPredicate.java
@@ -313,7 +313,7 @@ public class PixelsTupleDomainPredicate<C>
              * Besides integer types, decimal type also goes here as decimal in Presto
              * is backed by long. In Pixels, we also use IntegerColumnStats for decimal
              * columns. If needed in other places, integer statistics can be manually converted
-             * to double using the precision and scale from the schema in the row group footer.
+             * to double using the precision and scale from the schema in the file footer.
              */
             return createDomain(type, hasNullValue, (IntegerColumnStats) columnStats);
         }


### PR DESCRIPTION
Previously, the max length of binary/varbinary/char/varchar, and the precision and scale of decimal, are not persisted correctly in the schema of the file footer.