### PR TITLE
[Issue #222]: disable mock file locations for storage systems that do not provide data locality.

### DIFF
--- a/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsCacheWriter.java
+++ b/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsCacheWriter.java
@@ -357,9 +357,9 @@ public class PixelsCacheWriter
         outer_loop:
         for (String file : files)
         {
-            if (enableAbsoluteBalancer)
+            if (enableAbsoluteBalancer && storage.hasLocality())
             {
-                // this is used for experimental purpose only.
+                // TODO: this is used for experimental purpose only.
                 // may be removed later.
                 file = ensureLocality(file);
             }
@@ -524,9 +524,9 @@ public class PixelsCacheWriter
         outer_loop:
         for (String file : files)
         {
-            if (enableAbsoluteBalancer)
+            if (enableAbsoluteBalancer && storage.hasLocality())
             {
-                // this is used for experimental purpose only.
+                // TODO: this is used for experimental purpose only.
                 // may be removed later.
                 file = ensureLocality(file);
             }

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/balance/AbsoluteBalancer.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/balance/AbsoluteBalancer.java
@@ -24,6 +24,8 @@ import io.pixelsdb.pixels.common.exception.BalancerException;
 
 import java.util.*;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * Created at: 19-7-28
  * Author: hank
@@ -37,6 +39,8 @@ public class AbsoluteBalancer extends Balancer
     @Override
     public void put(String path, HostAddress address)
     {
+        requireNonNull(path, "path is null");
+        requireNonNull(address, "address is null");
         if (this.nodeCounters.containsKey(address))
         {
             this.nodeCounters.put(address, this.nodeCounters.get(address)+1);
@@ -51,6 +55,12 @@ public class AbsoluteBalancer extends Balancer
 
     @Override
     public void put(String path, Set<HostAddress> addresses)
+    {
+        throw new UnsupportedOperationException("not supported in AbsoluteBalancer");
+    }
+
+    @Override
+    public void autoSelect(String path)
     {
         throw new UnsupportedOperationException("not supported in AbsoluteBalancer");
     }

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/Location.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/Location.java
@@ -22,6 +22,7 @@ package io.pixelsdb.pixels.common.physical;
 import org.apache.hadoop.fs.BlockLocation;
 
 import java.io.IOException;
+import java.net.URI;
 
 /**
  * In Pixels, we assume that each file or object has its locations.
@@ -37,7 +38,7 @@ import java.io.IOException;
 public class Location
 {
     private String[] hosts; // Datanode hostnames
-    private String[] names; // Datanode IP:Port for accessing the block
+    private String[] names; // Datanode IP:Port, i.e., authority, for accessing the block.
     private boolean corrupt;
 
     private static final String[] EMPTY_STR_ARRAY = new String[0];
@@ -65,6 +66,13 @@ public class Location
         this.hosts = blockLocation.getHosts();
         this.names = blockLocation.getNames();
         this.corrupt = blockLocation.isCorrupt();
+    }
+
+    public Location(URI uri)
+    {
+        this.hosts = new String[]{uri.getHost()};
+        this.names = new String[]{uri.getAuthority()};
+        this.corrupt = false;
     }
 
     /**

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/storage/HDFS.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/storage/HDFS.java
@@ -215,6 +215,12 @@ public class HDFS implements Storage
     }
 
     @Override
+    public boolean hasLocality()
+    {
+        return true;
+    }
+
+    @Override
     public List<Location> getLocations(String path) throws IOException
     {
         List<Location> addresses = new ArrayList<>();

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/storage/LocalFS.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/storage/LocalFS.java
@@ -75,7 +75,7 @@ public class LocalFS implements Storage
                 return;
             }
         }
-        logger.debug("Local FS created on host: " + hostName);
+        logger.debug("LocalFS instance is created on host: " + hostName);
     }
 
     private String getPathKey(String path)

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/storage/S3.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/storage/S3.java
@@ -90,7 +90,7 @@ public class S3 implements Storage
             /**
              * Issue #222:
              * The etcd file id is only used for cache coordination.
-             * Thus we do not initialize the id key when cache is disabled.
+             * Thus, we do not initialize the id key when cache is disabled.
              */
 
             InitId(S3_ID_KEY);

--- a/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/cache/CacheCoordinator.java
+++ b/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/cache/CacheCoordinator.java
@@ -411,18 +411,22 @@ public class CacheCoordinator
         Balancer replicaBalancer = new ReplicaBalancer(cacheNodes);
         for (String path : paths)
         {
-            // get a set of nodes where the blocks of the file is located (location_set)
-            Set<HostAddress> addresses = new HashSet<>();
-            List<Location> locations = storage.getLocations(path);
-            for (Location location : locations)
+            if (storage.hasLocality())
             {
-                addresses.addAll(toHostAddress(location.getHosts()));
+                // get a set of nodes where the blocks of the file is located (location_set)
+                Set<HostAddress> addresses = new HashSet<>();
+                List<Location> locations = storage.getLocations(path);
+                for (Location location : locations)
+                {
+                    addresses.addAll(toHostAddress(location.getHosts()));
+                }
+                // addresses should not be empty.
+                replicaBalancer.put(path, addresses);
             }
-            if (addresses.size() == 0)
+            else
             {
-                continue;
+                replicaBalancer.autoSelect(path);
             }
-            replicaBalancer.put(path, addresses);
         }
         try
         {


### PR DESCRIPTION
For storage systems such as S3, which does not provide physical data locations, we do not generate mock file locations using etcd. This optimization helps improve the scalability of Pixels. It is important for scanning data using cloud functions as there might be a large number of CF instances scanning data in parallel.