### PR TITLE
[Issue #238]: Add a script to install pixels

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,23 @@ Therefore, we have to configure these credentials using
 [credential files](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html).
 
 ### Install Pixels
+
+To build Pixels from source and install it locally, you can simply run:
+
+```bash 
+# You may also want to append this line into `~/.bashrc`
+export PIXELS_HOME=$HOME/opt/pixels/
+./install.sh
+```
+
+But you still need to:
+- Put the jdbc connector of MySQL into `PIXELS_HOME/lib`.
+- Modify `pixels.properties` to ensure that the URLs, ports, paths, usernames, and passwords are valid.
+
+To install it step-by-step, or to install on EC2, please see the guidance below.
+
+---
+
 Here, we install Pixels and other binary packages into the `~/opt` directory:
 ```bash
 mkdir ~/opt

--- a/README.md
+++ b/README.md
@@ -9,9 +9,7 @@ Thus, it does not affect the maintainability and portability of the storage laye
 Install JDK (8.0 is recommended), and open Pixels as a maven project in Intellij. When the project is fully indexed and the dependencies are successfully downloaded,
 use the maven's `package` command to build it. Some test params are missing for the unit tests, you can simply create arbitrary values for them.
 
-The build may take tens of seconds to complete. After that, find the following jar files that will be used in the installation:
-* `pixels-daemon-*-full.jar` in `pixels-daemon/target`, this is the jar to run Pixels daemons;
-* `pixels-load-*-full.jar` in `pixels-load/target`, this is the jar to load data for Pixels.
+The build may take tens of seconds to complete.
 
 Pixels is compatible with different query engines, such as Presto, Trino, and Hive.
 However, for simplicity, we use Presto as an example here to illustrate how Pixels works with query engines in the data lakes.
@@ -62,34 +60,20 @@ Therefore, we have to configure these credentials using
 
 ### Install Pixels
 Here, we install Pixels and other binary packages into the `~/opt` directory:
-```bash
-mkdir ~/opt
-```
 
-Create the home `~/opt/pixels` for Pixels:
-```bash
-cd ~/opt
-mkdir pixels
-```
 Append this line into `~/.bashrc` and source it:
 ```bash
 export PIXELS_HOME=$HOME/opt/pixels/
 ```
-Create the following directories in `PIXELS_HOME`:
+
+Then in the same directory of the README, run 
 ```bash
-cd $PIXELS_HOME
-mkdir bin
-mkdir lib
-mkdir listener
-mkdir logs
-mkdir sbin
-mkdir var
+./install.sh
 ```
-Put the sh scripts in `scripts/bin` and `scripts/sbin` into `PIXELS_HOME/bin` and `PIXELS_HOME/sbin` respectively.
-Put `pixels-daemon-*-full.jar` into `PIXELS_HOME` and `pixels-load-*-full.jar` into `PIXELS_HOME/sbin`.
-Put the jdbc connector of MySQL into `PIXELS_HOME/lib`.
-Put `pixels-common/src/main/resources/pixels.properties` into `PIXELS_HOME`.
-Modify `pixels.properties` to ensure that the URLs, ports, paths, usernames, and passwords are valid.
+
+You still need to:
+- Put the jdbc connector of MySQL into `PIXELS_HOME/lib`.
+- Modify `pixels.properties` to ensure that the URLs, ports, paths, usernames, and passwords are valid.
 Leave the other config parameters as default.
 
 Optionally, to use the columnar cache in Pixels (i.e., pixels-cache), create and mount an in-memory file system:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ Thus, it does not affect the maintainability and portability of the storage laye
 Install JDK (8.0 is recommended), and open Pixels as a maven project in Intellij. When the project is fully indexed and the dependencies are successfully downloaded,
 use the maven's `package` command to build it. Some test params are missing for the unit tests, you can simply create arbitrary values for them.
 
-The build may take tens of seconds to complete.
+The build may take tens of seconds to complete. After that, find the following jar files that will be used in the installation:
+* `pixels-daemon-*-full.jar` in `pixels-daemon/target`, this is the jar to run Pixels daemons;
+* `pixels-load-*-full.jar` in `pixels-load/target`, this is the jar to load data for Pixels.
 
 Pixels is compatible with different query engines, such as Presto, Trino, and Hive.
 However, for simplicity, we use Presto as an example here to illustrate how Pixels works with query engines in the data lakes.
@@ -60,20 +62,34 @@ Therefore, we have to configure these credentials using
 
 ### Install Pixels
 Here, we install Pixels and other binary packages into the `~/opt` directory:
+```bash
+mkdir ~/opt
+```
 
+Create the home `~/opt/pixels` for Pixels:
+```bash
+cd ~/opt
+mkdir pixels
+```
 Append this line into `~/.bashrc` and source it:
 ```bash
 export PIXELS_HOME=$HOME/opt/pixels/
 ```
-
-Then in the same directory of the README, run 
+Create the following directories in `PIXELS_HOME`:
 ```bash
-./install.sh
+cd $PIXELS_HOME
+mkdir bin
+mkdir lib
+mkdir listener
+mkdir logs
+mkdir sbin
+mkdir var
 ```
-
-You still need to:
-- Put the jdbc connector of MySQL into `PIXELS_HOME/lib`.
-- Modify `pixels.properties` to ensure that the URLs, ports, paths, usernames, and passwords are valid.
+Put the sh scripts in `scripts/bin` and `scripts/sbin` into `PIXELS_HOME/bin` and `PIXELS_HOME/sbin` respectively.
+Put `pixels-daemon-*-full.jar` into `PIXELS_HOME` and `pixels-load-*-full.jar` into `PIXELS_HOME/sbin`.
+Put the jdbc connector of MySQL into `PIXELS_HOME/lib`.
+Put `pixels-common/src/main/resources/pixels.properties` into `PIXELS_HOME`.
+Modify `pixels.properties` to ensure that the URLs, ports, paths, usernames, and passwords are valid.
 Leave the other config parameters as default.
 
 Optionally, to use the columnar cache in Pixels (i.e., pixels-cache), create and mount an in-memory file system:

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+
+#mvn package
+
+if [ $? -ne 0 ]; then
+  echo "ERROR: Maven package failed. Stop installing Pixels."
+  exit 1
+fi
+
+if [ -z "$PIXELS_HOME" ]; then
+  echo "ERROR: PIXELS_HOME is not set. Stop installing Pixels."
+  exit 1
+else
+  echo "PIXELS_HOME is '$PIXELS_HOME'"
+fi
+
+mkdir -p $PIXELS_HOME/bin
+mkdir -p $PIXELS_HOME/lib
+mkdir -p $PIXELS_HOME/listener
+mkdir -p $PIXELS_HOME/logs
+mkdir -p $PIXELS_HOME/sbin
+mkdir -p $PIXELS_HOME/var
+
+echo "Installing scripts..."
+
+CP_SBIN=0
+
+if [ -z "$(ls -A $PIXELS_HOME/sbin)" ]; then
+  CP_SBIN=1
+else
+  read -p "'$PIXELS_HOME/sbin' not empty, override?[y/n]" -n 1 -r
+  echo # move to a new line
+  if [[ $REPLY =~ ^[Yy]$ ]]; then
+    CP_SBIN=1
+  fi
+fi
+
+if [ $CP_SBIN -eq 1 ]; then
+  cp -v ./scripts/sbin/* $PIXELS_HOME/sbin
+fi
+
+CP_BIN=0
+
+if [ -z "$(ls -A $PIXELS_HOME/bin)" ]; then
+  CP_BIN=1
+else
+  read -p "'$PIXELS_HOME/bin' not empty, override?[y/n]" -n 1 -r
+  echo # move to a new line
+  if [[ $REPLY =~ ^[Yy]$ ]]; then
+    CP_BIN=1
+  fi
+fi
+
+if [ $CP_BIN -eq 1 ]; then
+  cp -v ./scripts/bin/* $PIXELS_HOME/bin
+fi
+
+echo "Installing pixels-daemons..."
+cp -v ./pixels-daemon/target/pixels-daemon-*-full.jar $PIXELS_HOME
+echo "Installing pixels-load..."
+cp -v ./pixels-load/target/pixels-load-*-full.jar $PIXELS_HOME/sbin
+
+if [ -z "$(ls -A $PIXELS_HOME/lib)" ]; then
+  echo "$(
+    tput setaf 1
+    tput setab 7
+  )Make sure to put the jdbc connector of MySQL into '$PIXELS_HOME/lib'!$(tput sgr 0)"
+fi
+
+echo "Installing config file..."
+if [ -z "$(find $PIXELS_HOME -name "pixels.properties")" ]; then
+  cp -v ./pixels-common/src/main/resources/pixels.properties $PIXELS_HOME
+  echo "$(
+    tput setaf 1
+    tput setab 7
+  )Make sure to modify '$PIXELS_HOME/pixels.properties'!$(tput sgr 0)"
+else
+  read -p "'$PIXELS_HOME/pixels.properties' exists, override?[y/n]" -n 1 -r
+  echo # move to a new line
+  if [[ $REPLY =~ ^[Yy]$ ]]; then
+    cp -v ./pixels-common/src/main/resources/pixels.properties $PIXELS_HOME
+  fi
+fi
+
+echo "$(
+  tput setaf 1
+  tput setab 7
+)You may need to install and configure MySQL and etcd. Please refer to README.$(tput sgr 0)"
+echo "$(
+  tput setaf 1
+  tput setab 7
+)See the README of pixels-presto/trino/hive to install a query engine.$(tput sgr 0)"

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-#mvn package
+mvn package
 
 if [ $? -ne 0 ]; then
   echo "ERROR: Maven package failed. Stop installing Pixels."

--- a/pixels-common/src/main/resources/pixels.properties
+++ b/pixels-common/src/main/resources/pixels.properties
@@ -73,7 +73,7 @@ read.request.enable.retry=true
 read.request.max.retry.num=3
 # the interval in milliseconds of retry queue checks.
 read.request.retry.interval.ms=1000
-projection.read.enabled=true
+projection.read.enabled=false
 s3.enable.async=true
 s3.use.async.client=true
 s3.connection.timeout.sec=60

--- a/scripts/sbin/pin-cache.sh
+++ b/scripts/sbin/pin-cache.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 
-PIXELS_HOME="$HOME/opt/pixels"
+if [ -z "$PIXELS_HOME" ]; then
+  echo "ERROR: PIXELS_HOME is not set."
+  exit 1
+fi
 
 echo "Starting vmtouch..."
 $PIXELS_HOME/bin/start-vmtouch.sh"

--- a/scripts/sbin/reset-cache.sh
+++ b/scripts/sbin/reset-cache.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
 
+if [ -z "$PIXELS_HOME" ]; then
+  echo "ERROR: PIXELS_HOME is not set."
+  exit 1
+fi
+
 echo "Removing logs of pixels-cache..."
-rm $HOME/opt/pixels/logs/pixels-cache.log
+rm $PIXELS_HOME/logs/pixels-cache.log
 
 echo "Removing backed files of pixels-cache..."
 rm /mnt/ramfs/pixels.cache && rm /mnt/ramfs/pixels.index

--- a/scripts/sbin/start-pixels.sh
+++ b/scripts/sbin/start-pixels.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 
-PIXELS_HOME="$HOME/opt/pixels/"
+if [ -z "$PIXELS_HOME" ]; then
+  echo "ERROR: PIXELS_HOME is not set."
+  exit 1
+fi
 
 # start coodrinator
 echo "Starting Coordinator..."

--- a/scripts/sbin/stop-pixels.sh
+++ b/scripts/sbin/stop-pixels.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 
-PIXELS_HOME="$HOME/opt/pixels/"
+if [ -z "$PIXELS_HOME" ]; then
+  echo "ERROR: PIXELS_HOME is not set."
+  exit 1
+fi
 
 # $PIXELS_HOME/bin/stop-datanode.sh
 

--- a/scripts/sbin/unpin-cache.sh
+++ b/scripts/sbin/unpin-cache.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 
-PIXELS_HOME="$HOME/opt/pixels"
+if [ -z "$PIXELS_HOME" ]; then
+  echo "ERROR: PIXELS_HOME is not set."
+  exit 1
+fi
 
 echo "Stopping vmtouch..."
 $PIXELS_HOME/bin/stop-vmtouch.sh"


### PR DESCRIPTION
close #238 


Part of the installation process is highly mechanized, so we can add a script, which may be more user-friendly.



It will look like this: 

### For new installation:
![image](https://user-images.githubusercontent.com/37948597/160302069-e0c67f27-263a-44bf-bf50-045a24be4cde.png)

### When there's an existing installation:
![image](https://user-images.githubusercontent.com/37948597/160302083-12a84348-ac38-489c-9d4d-b843f477b981.png)


---

Also let `sbin` scripts don't override `PIXELS_HOME` and report missing argument instead.
