### PR TITLE
[Issue #170]: fix discrete filter on string-based columns.

### DIFF
--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/predicate/ColumnFilter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/predicate/ColumnFilter.java
@@ -685,7 +685,8 @@ public class ColumnFilter<T extends Comparable<T>>
                         {
                             continue;
                         }
-                        if (includes.contains(new String(vector[i], StandardCharsets.UTF_8)))
+                        if (includes.contains(new String(vector[i],
+                                starts[i], lens[i], StandardCharsets.UTF_8)))
                         {
                             result.set(i);
                         }
@@ -695,7 +696,8 @@ public class ColumnFilter<T extends Comparable<T>>
                 {
                     for (int i = start; i < start + length; ++i)
                     {
-                        if (includes.contains(new String(vector[i], StandardCharsets.UTF_8)))
+                        if (includes.contains(new String(vector[i],
+                                starts[i], lens[i], StandardCharsets.UTF_8)))
                         {
                             result.set(i);
                         }
@@ -708,7 +710,8 @@ public class ColumnFilter<T extends Comparable<T>>
                 {
                     for (int i = start; i < start + length; ++i)
                     {
-                        if (isNull[i] || !excludes.contains(new String(vector[i], StandardCharsets.UTF_8)))
+                        if (isNull[i] || !excludes.contains(new String(vector[i],
+                                starts[i], lens[i], StandardCharsets.UTF_8)))
                         {
                             result.set(i);
                         }
@@ -718,7 +721,8 @@ public class ColumnFilter<T extends Comparable<T>>
                 {
                     for (int i = start; i < start + length; ++i)
                     {
-                        if (!excludes.contains(new String(vector[i], StandardCharsets.UTF_8)))
+                        if (!excludes.contains(new String(vector[i],
+                                starts[i], lens[i], StandardCharsets.UTF_8)))
                         {
                             result.set(i);
                         }

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/predicate/TestPredicate.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/predicate/TestPredicate.java
@@ -219,4 +219,28 @@ public class TestPredicate
             System.out.println(b);
         }
     }
+
+    @Test
+    public void testParseDiscrete()
+    {
+        String json = "{\"schemaName\":\"tpch\",\"tableName\":\"customer\"," +
+                "\"columnFilters\":{1:{\"columnName\":\"c_mktsegment\"," +
+                "\"columnType\":\"CHAR\",\"filterJson\":\"{\\\"javaType\\\":" +
+                "\\\"java.lang.String\\\",\\\"isAll\\\":false,\\\"isNone\\\":false," +
+                "\\\"allowNull\\\":false,\\\"onlyNull\\\":false,\\\"ranges\\\":[]," +
+                "\\\"discreteValues\\\":[{\\\"type\\\":\\\"INCLUDED\\\"," +
+                "\\\"value\\\":\\\"BUILDING\\\"}]}\"}}}";
+
+        TableScanFilter filter = JSON.parseObject(json, TableScanFilter.class);
+        assert filter.getColumnFilter(1).getFilter().getRangeCount() == 0;
+        assert filter.getColumnFilter(1).getFilter().getDiscreteValueCount() == 1;
+    }
+
+    @Test
+    public void testParseEmptyFilter()
+    {
+        String json = "{\"schemaName\":\"tpch\",\"tableName\":\"part\",\"columnFilters\":{}}";
+        TableScanFilter filter = JSON.parseObject(json, TableScanFilter.class);
+        assert filter.getColumnFilters().isEmpty();
+    }
 }


### PR DESCRIPTION
Previously, the discrete value filter on string-based columns may lead to a timeout, as the values in the column vector were not converted to string correctly.