### PR TITLE
[Issue #170]: implement broadcast join.

### DIFF
--- a/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/lambda/BroadcastJoinInput.java
+++ b/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/lambda/BroadcastJoinInput.java
@@ -23,7 +23,7 @@ import io.pixelsdb.pixels.executor.join.JoinType;
 import io.pixelsdb.pixels.executor.lambda.ScanInput.InputInfo;
 import io.pixelsdb.pixels.executor.lambda.ScanInput.OutputInfo;
 
-import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author hank
@@ -40,7 +40,7 @@ public class BroadcastJoinInput
     /**
      * The scan inputs of the left table.
      */
-    private ArrayList<InputInfo> leftInputs;
+    private List<InputInfo> leftInputs;
     /**
      * The number of row groups to be scanned in each query split of the left table.
      */
@@ -62,7 +62,7 @@ public class BroadcastJoinInput
     /**
      * The scan inputs of the right table.
      */
-    private ArrayList<InputInfo> rightInputs;
+    private List<InputInfo> rightInputs;
     /**
      * The number of row groups to be scanned in each query split of the right table.
      */
@@ -96,9 +96,9 @@ public class BroadcastJoinInput
     public BroadcastJoinInput() { }
 
     public BroadcastJoinInput(int queryId, String leftTableName, String rightTableName,
-                              ArrayList<InputInfo> leftInputs, int leftSplitSize,
+                              List<InputInfo> leftInputs, int leftSplitSize,
                               String[] leftCols, int[] leftKeyColumnIds, String leftFilter,
-                              ArrayList<InputInfo> rightInputs, int rightSplitSize,
+                              List<InputInfo> rightInputs, int rightSplitSize,
                               String[] rightCols, int[] rightKeyColumnIds, String rightFilter,
                               JoinType joinType, OutputInfo output)
     {
@@ -149,12 +149,12 @@ public class BroadcastJoinInput
         this.rightTableName = rightTableName;
     }
 
-    public ArrayList<InputInfo> getLeftInputs()
+    public List<InputInfo> getLeftInputs()
     {
         return leftInputs;
     }
 
-    public void setLeftInputs(ArrayList<InputInfo> leftInputs)
+    public void setLeftInputs(List<InputInfo> leftInputs)
     {
         this.leftInputs = leftInputs;
     }
@@ -199,12 +199,12 @@ public class BroadcastJoinInput
         this.leftFilter = leftFilter;
     }
 
-    public ArrayList<InputInfo> getRightInputs()
+    public List<InputInfo> getRightInputs()
     {
         return rightInputs;
     }
 
-    public void setRightInputs(ArrayList<InputInfo> rightInputs)
+    public void setRightInputs(List<InputInfo> rightInputs)
     {
         this.rightInputs = rightInputs;
     }

--- a/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/lambda/ScanInput.java
+++ b/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/lambda/ScanInput.java
@@ -132,7 +132,7 @@ public class ScanInput
 
     public static class InputInfo
     {
-        private String filePath;
+        private String path;
         private int rgStart;
         private int rgLength;
 
@@ -141,21 +141,21 @@ public class ScanInput
          */
         public InputInfo() { }
 
-        public InputInfo(String filePath, int rgStart, int rgLength)
+        public InputInfo(String path, int rgStart, int rgLength)
         {
-            this.filePath = filePath;
+            this.path = path;
             this.rgStart = rgStart;
             this.rgLength = rgLength;
         }
 
-        public String getFilePath()
+        public String getPath()
         {
-            return filePath;
+            return path;
         }
 
-        public void setFilePath(String filePath)
+        public void setPath(String path)
         {
-            this.filePath = filePath;
+            this.path = path;
         }
 
         public int getRgStart()

--- a/pixels-executor/src/test/java/io/pixelsdb/pixels/executor/predicate/TestBroadcastJoinInvoker.java
+++ b/pixels-executor/src/test/java/io/pixelsdb/pixels/executor/predicate/TestBroadcastJoinInvoker.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2022 PixelsDB.
+ *
+ * This file is part of Pixels.
+ *
+ * Pixels is free software: you can redistribute it and/or modify
+ * it under the terms of the Affero GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * Pixels is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Affero GNU General Public License for more details.
+ *
+ * You should have received a copy of the Affero GNU General Public
+ * License along with Pixels.  If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package io.pixelsdb.pixels.executor.predicate;
+
+import com.alibaba.fastjson.JSON;
+import io.pixelsdb.pixels.core.TypeDescription;
+import io.pixelsdb.pixels.executor.join.JoinType;
+import io.pixelsdb.pixels.executor.lambda.BroadcastJoinInput;
+import io.pixelsdb.pixels.executor.lambda.BroadcastJoinInvoker;
+import io.pixelsdb.pixels.executor.lambda.JoinOutput;
+import io.pixelsdb.pixels.executor.lambda.ScanInput;
+import org.junit.Test;
+
+import java.util.*;
+import java.util.concurrent.ExecutionException;
+
+import static io.pixelsdb.pixels.executor.predicate.Bound.Type.INCLUDED;
+
+/**
+ * @author hank
+ * @date 15/05/2022
+ */
+public class TestBroadcastJoinInvoker
+{
+    @Test
+    public void testPartLineitem() throws ExecutionException, InterruptedException
+    {
+        String leftFilter = "{\"schemaName\":\"tpch\",\"tableName\":\"lineitem\"," +
+                "\"columnFilters\":{2:{\"columnName\":\"p_size\",\"columnType\":\"INT\"," +
+                "\"filterJson\":\"{\\\"javaType\\\":\\\"long\\\",\\\"isAll\\\":false," +
+                "\\\"isNone\\\":false,\\\"allowNull\\\":false,\\\"onlyNull\\\":false," +
+                "\\\"ranges\\\":[],\\\"discreteValues\\\":[{" +
+                "\\\"type\\\":\\\"INCLUDED\\\",\\\"value\\\":49}," +
+                "{\\\"type\\\":\\\"INCLUDED\\\",\\\"value\\\":14}," +
+                "{\\\"type\\\":\\\"INCLUDED\\\",\\\"value\\\":23}," +
+                "{\\\"type\\\":\\\"INCLUDED\\\",\\\"value\\\":45}," +
+                "{\\\"type\\\":\\\"INCLUDED\\\",\\\"value\\\":19}," +
+                "{\\\"type\\\":\\\"INCLUDED\\\",\\\"value\\\":3}," +
+                "{\\\"type\\\":\\\"INCLUDED\\\",\\\"value\\\":36}," +
+                "{\\\"type\\\":\\\"INCLUDED\\\",\\\"value\\\":9}]}\"}}}";
+
+        // leftFilter = "{\"schemaName\":\"tpch\",\"tableName\":\"part\",\"columnFilters\":{}}";
+        String rightFilter = "{\"schemaName\":\"tpch\",\"tableName\":\"lineitem\",\"columnFilters\":{}}";
+
+        BroadcastJoinInput joinInput = new BroadcastJoinInput();
+        joinInput.setQueryId(123456);
+
+        joinInput.setLeftCols(new String[]{"p_partkey", "p_name", "p_size"});
+        joinInput.setLeftKeyColumnIds(new int[]{0});
+        joinInput.setLeftTableName("part");
+        joinInput.setLeftInputs(Arrays.asList(
+                new ScanInput.InputInfo("pixels-tpch/part/v-0-compact/20220313172545_0.compact.pxl", 0, 4),
+                new ScanInput.InputInfo("pixels-tpch/part/v-0-compact/20220313172545_0.compact.pxl", 4, 4),
+                new ScanInput.InputInfo("pixels-tpch/part/v-0-compact/20220313172545_0.compact.pxl", 8, 4),
+                new ScanInput.InputInfo("pixels-tpch/part/v-0-compact/20220313172545_0.compact.pxl", 12, 4),
+                new ScanInput.InputInfo("pixels-tpch/part/v-0-compact/20220313172545_0.compact.pxl", 16, 4),
+                new ScanInput.InputInfo("pixels-tpch/part/v-0-compact/20220313172545_0.compact.pxl", 20, 4),
+                new ScanInput.InputInfo("pixels-tpch/part/v-0-compact/20220313172545_0.compact.pxl", 24, 4),
+                new ScanInput.InputInfo("pixels-tpch/part/v-0-compact/20220313172545_0.compact.pxl", 28, 4)
+        ));
+        joinInput.setLeftSplitSize(4);
+        joinInput.setLeftFilter(leftFilter);
+
+        joinInput.setRightCols(new String[]{"l_orderkey", "l_partkey", "l_extendedprice", "l_discount"});
+        joinInput.setRightKeyColumnIds(new int[]{1});
+        joinInput.setRightTableName("lineitem");
+        joinInput.setRightInputs(Arrays.asList(
+                new ScanInput.InputInfo("pixels-tpch/lineitem/v-0-compact/20220313102020_0.compact.pxl", 0, 4),
+                new ScanInput.InputInfo("pixels-tpch/lineitem/v-0-compact/20220313102020_0.compact.pxl", 4, 4),
+                new ScanInput.InputInfo("pixels-tpch/lineitem/v-0-compact/20220313102020_0.compact.pxl", 8, 4),
+                new ScanInput.InputInfo("pixels-tpch/lineitem/v-0-compact/20220313102020_0.compact.pxl", 12, 4),
+                new ScanInput.InputInfo("pixels-tpch/lineitem/v-0-compact/20220313102020_0.compact.pxl", 16, 4),
+                new ScanInput.InputInfo("pixels-tpch/lineitem/v-0-compact/20220313102020_0.compact.pxl", 20, 4),
+                new ScanInput.InputInfo("pixels-tpch/lineitem/v-0-compact/20220313102020_0.compact.pxl", 24, 4),
+                new ScanInput.InputInfo("pixels-tpch/lineitem/v-0-compact/20220313102020_0.compact.pxl", 28, 4)
+        ));
+        joinInput.setRightSplitSize(4);
+        joinInput.setRightFilter(rightFilter);
+
+        joinInput.setJoinType(JoinType.EQUI_INNER);
+        joinInput.setOutput(new ScanInput.OutputInfo("pixels-lambda/",
+                "http://172.31.32.193:9000", "lambda", "password", true));
+
+        System.out.println(JSON.toJSONString(joinInput));
+        JoinOutput output = BroadcastJoinInvoker.invoke(joinInput).get();
+        System.out.println(output.getOutputs().size());
+        for (int i = 0; i < output.getOutputs().size(); ++i)
+        {
+            System.out.println(output.getOutputs().get(i));
+            System.out.println(output.getRowGroupNums().get(i));
+            System.out.println();
+        }
+    }
+
+    @Test
+    public void testSerFilter()
+    {
+        ArrayList<Bound<Long>> discreteValues = new ArrayList<>();
+        discreteValues.add(new Bound<>(INCLUDED, 49L));
+        discreteValues.add(new Bound<>(INCLUDED, 14L));
+        discreteValues.add(new Bound<>(INCLUDED, 23L));
+        discreteValues.add(new Bound<>(INCLUDED, 45L));
+        discreteValues.add(new Bound<>(INCLUDED, 19L));
+        discreteValues.add(new Bound<>(INCLUDED, 3L));
+        discreteValues.add(new Bound<>(INCLUDED, 36L));
+        discreteValues.add(new Bound<>(INCLUDED, 9L));
+        ColumnFilter<Long> columnFilter = new ColumnFilter<Long>("p_size", TypeDescription.Category.INT,
+                new Filter<>(Long.TYPE, new ArrayList<>(), discreteValues, false, false, false, false));
+        SortedMap<Integer, ColumnFilter> columnFilters = new TreeMap<>();
+        columnFilters.put(2, columnFilter);
+        TableScanFilter filter = new TableScanFilter("tpch", "lineitem", columnFilters);
+        System.out.println(JSON.toJSONString(filter));
+    }
+
+    @Test
+    public void testDeFilter()
+    {
+        String filter = "{\"schemaName\":\"tpch\",\"tableName\":\"lineitem\"," +
+                "\"columnFilters\":{2:{\"columnName\":\"p_size\",\"columnType\":\"INT\"," +
+                "\"filterJson\":\"{\\\"javaType\\\":\\\"long\\\",\\\"isAll\\\":false," +
+                "\\\"isNone\\\":false,\\\"allowNull\\\":false,\\\"onlyNull\\\":false," +
+                "\\\"ranges\\\":[],\\\"discreteValues\\\":[{" +
+                "\\\"type\\\":\\\"INCLUDED\\\",\\\"value\\\":49}," +
+                "{\\\"type\\\":\\\"INCLUDED\\\",\\\"value\\\":14}," +
+                "{\\\"type\\\":\\\"INCLUDED\\\",\\\"value\\\":23}," +
+                "{\\\"type\\\":\\\"INCLUDED\\\",\\\"value\\\":45}," +
+                "{\\\"type\\\":\\\"INCLUDED\\\",\\\"value\\\":19}," +
+                "{\\\"type\\\":\\\"INCLUDED\\\",\\\"value\\\":3}," +
+                "{\\\"type\\\":\\\"INCLUDED\\\",\\\"value\\\":36}," +
+                "{\\\"type\\\":\\\"INCLUDED\\\",\\\"value\\\":9}]}\"}}}";
+        TableScanFilter tableScanFilter = JSON.parseObject(filter, TableScanFilter.class);
+        assert tableScanFilter.getColumnFilter(2).getFilter().getDiscreteValueCount() == 8;
+    }
+}

--- a/pixels-executor/src/test/java/io/pixelsdb/pixels/executor/predicate/TestPartitionInvoker.java
+++ b/pixels-executor/src/test/java/io/pixelsdb/pixels/executor/predicate/TestPartitionInvoker.java
@@ -40,7 +40,7 @@ public class TestPartitionInvoker
     {
         String filter = 
                 "{\"schemaName\":\"tpch\",\"tableName\":\"orders\"," +
-                "\"columnFilters\":{1:{\"columnName\":\"o_orderkey\",\"columnType\":\"LONG\"," +
+                "\"columnFilters\":{1:{\"columnName\":\"o_custkey\",\"columnType\":\"LONG\"," +
                 "\"filterJson\":\"{\\\"javaType\\\":\\\"long\\\",\\\"isAll\\\":false," +
                 "\\\"isNone\\\":false,\\\"allowNull\\\":false,\\\"ranges\\\":[{" +
                 "\\\"lowerBound\\\":{\\\"type\\\":\\\"UNBOUNDED\\\"}," +

--- a/pixels-executor/src/test/java/io/pixelsdb/pixels/executor/predicate/TestScanFile.java
+++ b/pixels-executor/src/test/java/io/pixelsdb/pixels/executor/predicate/TestScanFile.java
@@ -53,7 +53,7 @@ public class TestScanFile
         {
             String filter =
                     "{\"schemaName\":\"tpch\",\"tableName\":\"orders\"," +
-                            "\"columnFilters\":{1:{\"columnName\":\"o_orderkey\",\"columnType\":\"LONG\"," +
+                            "\"columnFilters\":{1:{\"columnName\":\"o_custkey\",\"columnType\":\"LONG\"," +
                             "\"filterJson\":\"{\\\"javaType\\\":\\\"long\\\",\\\"isAll\\\":false," +
                             "\\\"isNone\\\":false,\\\"allowNull\\\":false,\\\"ranges\\\":[{" +
                             "\\\"lowerBound\\\":{\\\"type\\\":\\\"UNBOUNDED\\\"}," +

--- a/pixels-lambda/src/main/java/io/pixelsdb/pixels/lambda/BroadcastJoinWorker.java
+++ b/pixels-lambda/src/main/java/io/pixelsdb/pixels/lambda/BroadcastJoinWorker.java
@@ -19,10 +19,353 @@
  */
 package io.pixelsdb.pixels.lambda;
 
+import com.alibaba.fastjson.JSON;
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import io.pixelsdb.pixels.common.physical.Storage;
+import io.pixelsdb.pixels.common.physical.StorageFactory;
+import io.pixelsdb.pixels.core.PixelsReader;
+import io.pixelsdb.pixels.core.PixelsWriter;
+import io.pixelsdb.pixels.core.TypeDescription;
+import io.pixelsdb.pixels.core.reader.PixelsReaderOption;
+import io.pixelsdb.pixels.core.reader.PixelsRecordReader;
+import io.pixelsdb.pixels.core.utils.Bitmap;
+import io.pixelsdb.pixels.core.vector.VectorizedRowBatch;
+import io.pixelsdb.pixels.executor.join.JoinType;
+import io.pixelsdb.pixels.executor.join.Joiner;
+import io.pixelsdb.pixels.executor.lambda.BroadcastJoinInput;
+import io.pixelsdb.pixels.executor.lambda.JoinOutput;
+import io.pixelsdb.pixels.executor.lambda.ScanInput;
+import io.pixelsdb.pixels.executor.predicate.TableScanFilter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.pixelsdb.pixels.common.physical.storage.MinIO.ConfigMinIO;
+import static io.pixelsdb.pixels.lambda.WorkerCommon.*;
+
 /**
  * @author hank
  * @date 07/05/2022
  */
-public class BroadcastJoinWorker
+public class BroadcastJoinWorker implements RequestHandler<BroadcastJoinInput, JoinOutput>
 {
+    private static final Logger logger = LoggerFactory.getLogger(PartitionedJoinWorker.class);
+    private static Storage s3;
+    private static Storage minio;
+
+    static
+    {
+        try
+        {
+            s3 = StorageFactory.Instance().getStorage(Storage.Scheme.s3);
+
+        } catch (Exception e)
+        {
+            logger.error("failed to initialize AWS S3 storage", e);
+        }
+    }
+
+    @Override
+    public JoinOutput handleRequest(BroadcastJoinInput event, Context context)
+    {
+        try
+        {
+            int cores = Runtime.getRuntime().availableProcessors();
+            logger.info("Number of cores available: " + cores);
+            ExecutorService threadPool = Executors.newFixedThreadPool(cores * 2);
+            String requestId = context.getAwsRequestId();
+
+            long queryId = event.getQueryId();
+
+            String leftPrefix = event.getLeftTableName() + ".";
+            List<ScanInput.InputInfo> leftInputs = event.getLeftInputs();
+            checkArgument(leftInputs.size() > 0, "leftPartitioned is empty");
+            String[] leftCols = event.getLeftCols();
+            int[] leftKeyColumnIds = event.getLeftKeyColumnIds();
+            int leftSplitSize = event.getLeftSplitSize();
+            TableScanFilter leftFilter = JSON.parseObject(event.getLeftFilter(), TableScanFilter.class);
+
+            String rightPrefix = event.getRightTableName() + ".";
+            List<ScanInput.InputInfo> rightInputs = event.getRightInputs();
+            checkArgument(rightInputs.size() > 0, "rightPartitioned is empty");
+            String[] rightCols = event.getRightCols();
+            int[] rightKeyColumnIds = event.getRightKeyColumnIds();
+            int rightSplitSize = event.getRightSplitSize();
+            TableScanFilter rightFilter = JSON.parseObject(event.getRightFilter(), TableScanFilter.class);
+
+            JoinType joinType = event.getJoinType();
+            ScanInput.OutputInfo outputInfo = event.getOutput();
+            String outputFolder = outputInfo.getFolder();
+            if (!outputFolder.endsWith("/"))
+            {
+                outputFolder += "/";
+            }
+            boolean encoding = outputInfo.isEncoding();
+            try
+            {
+                if (minio == null)
+                {
+                    ConfigMinIO(outputInfo.getEndpoint(), outputInfo.getAccessKey(), outputInfo.getSecretKey());
+                    minio = StorageFactory.Instance().getStorage(Storage.Scheme.minio);
+                }
+            } catch (Exception e)
+            {
+                logger.error("failed to initialize MinIO storage", e);
+            }
+            // build the joiner.
+            AtomicReference<TypeDescription> leftSchema = new AtomicReference<>();
+            AtomicReference<TypeDescription> rightSchema = new AtomicReference<>();
+            getSchema(threadPool, s3, leftSchema, rightSchema,
+                    leftInputs.get(0).getPath(), rightInputs.get(0).getPath());
+            Joiner joiner = new Joiner(joinType,
+                    leftPrefix, leftSchema.get(), leftKeyColumnIds,
+                    rightPrefix, rightSchema.get(), rightKeyColumnIds);
+            // build the hash table for the left table.
+            List<Future> leftFutures = new ArrayList<>(leftInputs.size());
+            for (int i = 0; i < leftInputs.size();)
+            {
+                List<ScanInput.InputInfo> inputs = new ArrayList<>();
+                int numRg = 0;
+                while (numRg < leftSplitSize)
+                {
+                    ScanInput.InputInfo info = leftInputs.get(i++);
+                    inputs.add(info);
+                    numRg += info.getRgLength();
+                }
+                leftFutures.add(threadPool.submit(() -> {
+                    try
+                    {
+                        buildHashTable(queryId, joiner, inputs, leftCols, leftFilter);
+                    }
+                    catch (Exception e)
+                    {
+                        logger.error("error during hash table construction", e);
+                    }
+                }));
+            }
+            for (Future future : leftFutures)
+            {
+                future.get();
+            }
+            logger.info("hash table size: " + joiner.getLeftTableSize());
+            // scan the right table and do the join.
+            JoinOutput joinOutput = new JoinOutput();
+            for (int i = 0, outputId = 0; i < rightInputs.size(); ++outputId)
+            {
+                List<ScanInput.InputInfo> inputs = new ArrayList<>();
+                int numRg = 0;
+                while (numRg < leftSplitSize)
+                {
+                    ScanInput.InputInfo info = rightInputs.get(i++);
+                    inputs.add(info);
+                    numRg += info.getRgLength();
+                }
+                String outputPath = outputFolder + requestId + "_join_" + outputId;
+                threadPool.execute(() -> {
+                    try
+                    {
+                        int rowGroupNum = joinWithRightTable(queryId, joiner, inputs, rightCols,
+                                rightFilter, outputPath, encoding);
+                        if (rowGroupNum > 0)
+                        {
+                            joinOutput.addOutput(outputPath, rowGroupNum);
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        logger.error("error during broadcast join", e);
+                    }
+                });
+            }
+            threadPool.shutdown();
+            try
+            {
+                while (!threadPool.awaitTermination(60, TimeUnit.SECONDS));
+            } catch (InterruptedException e)
+            {
+                logger.error("interrupted while waiting for the termination of join", e);
+            }
+
+            if (joinType == JoinType.EQUI_LEFT)
+            {
+                // output the left-outer tail.
+                String outputPath = outputFolder + requestId + "_join_left_outer";
+                PixelsWriter pixelsWriter = getWriter(joiner.getJoinedSchema(), minio, outputPath,
+                        encoding, false, null);
+                joiner.writeLeftOuter(pixelsWriter, rowBatchSize);
+                pixelsWriter.close();
+                joinOutput.addOutput(outputPath, pixelsWriter.getRowGroupNum());
+            }
+
+            return joinOutput;
+        } catch (Exception e)
+        {
+            logger.error("error during join", e);
+            return null;
+        }
+    }
+
+    /**
+     * Scan the input files of the left table and populate the hash table for the join.
+     *
+     * @param queryId the query id used by I/O scheduler
+     * @param joiner the joiner for which the hash table is built
+     * @param leftInputs the information of input files of the left table
+     * @param leftCols the column names of the left table
+     * @param leftFilter the table scan filter on the left table
+     */
+    private void buildHashTable(long queryId, Joiner joiner, List<ScanInput.InputInfo> leftInputs,
+                                String[] leftCols, TableScanFilter leftFilter)
+    {
+        for (ScanInput.InputInfo input : leftInputs)
+        {
+            try (PixelsReader pixelsReader = getReader(input.getPath(), s3))
+            {
+                checkArgument(pixelsReader.isPartitioned(), "pixels file is not partitioned");
+                if (input.getRgLength() >= pixelsReader.getRowGroupNum())
+                {
+                    continue;
+                }
+                if (input.getRgStart() + input.getRgLength() >= pixelsReader.getRowGroupNum())
+                {
+                    input.setRgLength(pixelsReader.getRowGroupNum() - input.getRgStart());
+                }
+                PixelsReaderOption option = getReaderOption(queryId, leftCols, input);
+                VectorizedRowBatch rowBatch;
+                PixelsRecordReader recordReader = pixelsReader.read(option);
+                checkArgument(recordReader.isValid(), "failed to get record reader");
+                Bitmap filtered = new Bitmap(rowBatchSize, true);
+                Bitmap tmp = new Bitmap(rowBatchSize, false);
+                do
+                {
+                    rowBatch = recordReader.readBatch(rowBatchSize);
+                    leftFilter.doFilter(rowBatch, filtered, tmp);
+                    rowBatch.applyFilter(filtered);
+                    if (rowBatch.size > 0)
+                    {
+                        joiner.populateLeftTable(rowBatch);
+                    }
+                } while (!rowBatch.endOfFile);
+            } catch (Exception e)
+            {
+                logger.error("failed to scan the left table input file '" +
+                        input.getPath() + "' and build the hash table", e);
+            }
+        }
+    }
+
+    /**
+     * Scan the input files of the right table and do the join.
+     *
+     * @param queryId the query id used by I/O scheduler
+     * @param joiner the joiner for which the hash table is built
+     * @param rightInputs the information of input files of the right table
+     * @param rightCols the column names of the right table
+     * @param rightFilter the table scan filter on the right table
+     * @param outputPath fileName on s3 to store the scan results
+     * @param encoding whether encode the scan results or not
+     * @return the number of row groups that have been written into the output.
+     */
+    private int joinWithRightTable(long queryId, Joiner joiner, List<ScanInput.InputInfo> rightInputs,
+                                   String[] rightCols, TableScanFilter rightFilter,
+                                   String outputPath, boolean encoding)
+    {
+        PixelsWriter pixelsWriter = getWriter(joiner.getJoinedSchema(), minio, outputPath,
+                encoding, false, null);
+        for (ScanInput.InputInfo input : rightInputs)
+        {
+            try (PixelsReader pixelsReader = getReader(input.getPath(), s3))
+            {
+                checkArgument(pixelsReader.isPartitioned(), "pixels file is not partitioned");
+                if (input.getRgLength() >= pixelsReader.getRowGroupNum())
+                {
+                    continue;
+                }
+                if (input.getRgStart() + input.getRgLength() >= pixelsReader.getRowGroupNum())
+                {
+                    input.setRgLength(pixelsReader.getRowGroupNum() - input.getRgStart());
+                }
+                PixelsReaderOption option = getReaderOption(queryId, rightCols, input);
+                VectorizedRowBatch rowBatch;
+                PixelsRecordReader recordReader = pixelsReader.read(option);
+                checkArgument(recordReader.isValid(), "failed to get record reader");
+                int scannedRows = 0, joinedRows = 0;
+                Bitmap filtered = new Bitmap(rowBatchSize, true);
+                Bitmap tmp = new Bitmap(rowBatchSize, false);
+                do
+                {
+                    rowBatch = recordReader.readBatch(rowBatchSize);
+                    rightFilter.doFilter(rowBatch, filtered, tmp);
+                    rowBatch.applyFilter(filtered);
+                    scannedRows += rowBatch.size;
+                    if (rowBatch.size > 0)
+                    {
+                        VectorizedRowBatch joined = joiner.join(rowBatch);
+                        if (!joined.isEmpty())
+                        {
+                            pixelsWriter.addRowBatch(joined);
+                            joinedRows += joined.size;
+                        }
+                    }
+                } while (!rowBatch.endOfFile);
+                logger.info("number of scanned rows: " + scannedRows +
+                        ", number of joined rows: " + joinedRows);
+            } catch (Exception e)
+            {
+                logger.error("failed to scan the right table input file '" +
+                        input.getPath() + "' and do the join", e);
+            }
+        }
+        try
+        {
+            pixelsWriter.close();
+            while (true)
+            {
+                try
+                {
+                    if (minio.getStatus(outputPath) != null)
+                    {
+                        break;
+                    }
+                }
+                catch (Exception e)
+                {
+                    // Wait for 10ms and see if the output file is visible.
+                    TimeUnit.MILLISECONDS.sleep(10);
+                }
+            }
+        } catch (Exception e)
+        {
+            logger.error("failed to finish writing and close the join result file '" + outputPath + "'", e);
+        }
+        return pixelsWriter.getRowGroupNum();
+    }
+
+    /**
+     * Create the reader option for a record reader of the given input file.
+     *
+     * @param queryId the query id
+     * @param cols the column names in the partitioned file
+     * @param input the information of the input file
+     * @return the reader option
+     */
+    private PixelsReaderOption getReaderOption(long queryId, String[] cols, ScanInput.InputInfo input)
+    {
+        PixelsReaderOption option = new PixelsReaderOption();
+        option.skipCorruptRecords(true);
+        option.tolerantSchemaEvolution(true);
+        option.queryId(queryId);
+        option.includeCols(cols);
+        option.rgRange(input.getRgStart(), input.getRgLength());
+        return option;
+    }
 }

--- a/pixels-lambda/src/main/java/io/pixelsdb/pixels/lambda/PartitionedJoinWorker.java
+++ b/pixels-lambda/src/main/java/io/pixelsdb/pixels/lambda/PartitionedJoinWorker.java
@@ -119,7 +119,7 @@ public class PartitionedJoinWorker implements RequestHandler<PartitionedJoinInpu
             // build the joiner.
             AtomicReference<TypeDescription> leftSchema = new AtomicReference<>();
             AtomicReference<TypeDescription> rightSchema = new AtomicReference<>();
-            getSchema(threadPool, s3, leftSchema, rightSchema,
+            getFileSchema(threadPool, s3, leftSchema, rightSchema,
                     leftPartitioned.get(0).getPath(), rightPartitioned.get(0).getPath());
             Joiner joiner = new Joiner(joinInfo.getJoinType(),
                     leftPrefix, leftSchema.get(), leftKeyColumnIds,

--- a/pixels-lambda/src/main/java/io/pixelsdb/pixels/lambda/PartitionedJoinWorker.java
+++ b/pixels-lambda/src/main/java/io/pixelsdb/pixels/lambda/PartitionedJoinWorker.java
@@ -23,8 +23,10 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import io.pixelsdb.pixels.common.physical.Storage;
 import io.pixelsdb.pixels.common.physical.StorageFactory;
-import io.pixelsdb.pixels.common.utils.ConfigFactory;
-import io.pixelsdb.pixels.core.*;
+import io.pixelsdb.pixels.core.PixelsProto;
+import io.pixelsdb.pixels.core.PixelsReader;
+import io.pixelsdb.pixels.core.PixelsWriter;
+import io.pixelsdb.pixels.core.TypeDescription;
 import io.pixelsdb.pixels.core.reader.PixelsReaderOption;
 import io.pixelsdb.pixels.core.reader.PixelsRecordReader;
 import io.pixelsdb.pixels.core.vector.VectorizedRowBatch;
@@ -37,14 +39,17 @@ import io.pixelsdb.pixels.executor.lambda.ScanInput;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.*;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.pixelsdb.pixels.common.physical.storage.MinIO.ConfigMinIO;
+import static io.pixelsdb.pixels.lambda.WorkerCommon.*;
 
 /**
  * @author hank
@@ -53,20 +58,11 @@ import static io.pixelsdb.pixels.common.physical.storage.MinIO.ConfigMinIO;
 public class PartitionedJoinWorker implements RequestHandler<PartitionedJoinInput, JoinOutput>
 {
     private static final Logger logger = LoggerFactory.getLogger(PartitionedJoinWorker.class);
-    private static final PixelsFooterCache footerCache = new PixelsFooterCache();
-    private static final ConfigFactory configFactory = ConfigFactory.Instance();
-    private static final int rowBatchSize;
-    private static final int pixelStride;
-    private static final int rowGroupSize;
     private static Storage s3;
     private static Storage minio;
 
     static
     {
-        rowBatchSize = Integer.parseInt(configFactory.getProperty("row.batch.size"));
-        pixelStride = Integer.parseInt(configFactory.getProperty("pixel.stride"));
-        rowGroupSize = Integer.parseInt(configFactory.getProperty("row.group.size"));
-
         try
         {
             s3 = StorageFactory.Instance().getStorage(Storage.Scheme.s3);
@@ -123,7 +119,7 @@ public class PartitionedJoinWorker implements RequestHandler<PartitionedJoinInpu
             // build the joiner.
             AtomicReference<TypeDescription> leftSchema = new AtomicReference<>();
             AtomicReference<TypeDescription> rightSchema = new AtomicReference<>();
-            getSchema(threadPool, leftSchema, rightSchema,
+            getSchema(threadPool, s3, leftSchema, rightSchema,
                     leftPartitioned.get(0).getPath(), rightPartitioned.get(0).getPath());
             Joiner joiner = new Joiner(joinInfo.getJoinType(),
                     leftPrefix, leftSchema.get(), leftKeyColumnIds,
@@ -166,14 +162,14 @@ public class PartitionedJoinWorker implements RequestHandler<PartitionedJoinInpu
             {
                 rightSplitSize = 1;
             }
-            for (int i = 0; i < rightPartitioned.size(); i += rightSplitSize)
+            for (int i = 0, outputId = 0; i < rightPartitioned.size(); i += rightSplitSize, ++outputId)
             {
                 List<PartitionOutput> parts = new ArrayList<>(rightSplitSize);
                 for (int j = i; j < i + rightSplitSize && j < rightPartitioned.size(); ++j)
                 {
                     parts.add(rightPartitioned.get(i));
                 }
-                String outputPath = outputFolder + requestId + "_join_" + i;
+                String outputPath = outputFolder + requestId + "_join_" + outputId;
                 threadPool.execute(() -> {
                     try
                     {
@@ -197,14 +193,15 @@ public class PartitionedJoinWorker implements RequestHandler<PartitionedJoinInpu
                 while (!threadPool.awaitTermination(60, TimeUnit.SECONDS));
             } catch (InterruptedException e)
             {
-                logger.error("interrupted while waiting for the termination of scan", e);
+                logger.error("interrupted while waiting for the termination of join", e);
             }
 
             if (joinInfo.getJoinType() == JoinType.EQUI_LEFT)
             {
                 // output the left-outer tail.
                 String outputPath = outputFolder + requestId + "_join_left_outer";
-                PixelsWriter pixelsWriter = getWriter(joiner.getJoinedSchema(), outputPath, encoding);
+                PixelsWriter pixelsWriter = getWriter(joiner.getJoinedSchema(), minio, outputPath,
+                        encoding, false, null);
                 joiner.writeLeftOuter(pixelsWriter, rowBatchSize);
                 pixelsWriter.close();
                 joinOutput.addOutput(outputPath, pixelsWriter.getRowGroupNum());
@@ -213,39 +210,8 @@ public class PartitionedJoinWorker implements RequestHandler<PartitionedJoinInpu
             return joinOutput;
         } catch (Exception e)
         {
-            logger.error("error during scan", e);
+            logger.error("error during join", e);
             return null;
-        }
-    }
-
-    private void getSchema(ExecutorService executor, AtomicReference<TypeDescription> leftSchema,
-                           AtomicReference<TypeDescription> rightSchema, String leftPath, String rightPath)
-    {
-        Future<?> leftFuture = executor.submit(() -> {
-            try
-            {
-                leftSchema.set(getReader(leftPath).getFileSchema());
-            } catch (IOException e)
-            {
-                logger.error("failed to read the schema of the left table");
-            }
-        });
-        Future<?> rightFuture = executor.submit(() -> {
-            try
-            {
-                rightSchema.set(getReader(rightPath).getFileSchema());
-            } catch (IOException e)
-            {
-                logger.error("failed to read the schema of the right table");
-            }
-        });
-        try
-        {
-            leftFuture.get();
-            rightFuture.get();
-        } catch (Exception e)
-        {
-            logger.error("interrupted while waiting for the termination of schema read", e);
         }
     }
 
@@ -264,7 +230,7 @@ public class PartitionedJoinWorker implements RequestHandler<PartitionedJoinInpu
     {
         for (PartitionOutput leftPartitioned : leftParts)
         {
-            try (PixelsReader pixelsReader = getReader(leftPartitioned.getPath()))
+            try (PixelsReader pixelsReader = getReader(leftPartitioned.getPath(), s3))
             {
                 checkArgument(pixelsReader.isPartitioned(), "pixels file is not partitioned");
                 checkArgument(leftPartitioned.getHashValues().size() == pixelsReader.getRowGroupNum(),
@@ -315,10 +281,11 @@ public class PartitionedJoinWorker implements RequestHandler<PartitionedJoinInpu
                                     String[] rightCols, List<Integer> hashValues, int numPartition,
                                     String outputPath, boolean encoding)
     {
-        PixelsWriter pixelsWriter = getWriter(joiner.getJoinedSchema(), outputPath, encoding);
+        PixelsWriter pixelsWriter = getWriter(joiner.getJoinedSchema(), minio, outputPath,
+                encoding, false, null);
         for (PartitionOutput rightPartitioned : rightParts)
         {
-            try (PixelsReader pixelsReader = getReader(rightPartitioned.getPath()))
+            try (PixelsReader pixelsReader = getReader(rightPartitioned.getPath(), s3))
             {
                 checkArgument(pixelsReader.isPartitioned(), "pixels file is not partitioned");
                 checkArgument(rightPartitioned.getHashValues().size() == pixelsReader.getRowGroupNum(),
@@ -392,7 +359,7 @@ public class PartitionedJoinWorker implements RequestHandler<PartitionedJoinInpu
      * @param pixelsReader the reader of the partitioned file
      * @param hashValue the hash value of the given hash partition
      * @param numPartition the total number of partitions
-     * @return
+     * @return the reader option
      */
     private PixelsReaderOption getReaderOption(long queryId, String[] cols, PixelsReader pixelsReader,
                                                int hashValue, int numPartition)
@@ -418,32 +385,5 @@ public class PartitionedJoinWorker implements RequestHandler<PartitionedJoinInpu
             }
         }
         return option;
-    }
-
-    private PixelsReader getReader(String fileName) throws IOException
-    {
-        PixelsReaderImpl.Builder builder = PixelsReaderImpl.newBuilder()
-                .setStorage(s3)
-                .setPath(fileName)
-                .setEnableCache(false)
-                .setCacheOrder(new ArrayList<>())
-                .setPixelsCacheReader(null)
-                .setPixelsFooterCache(footerCache);
-        PixelsReader pixelsReader = builder.build();
-        return pixelsReader;
-    }
-
-    private PixelsWriter getWriter(TypeDescription schema, String filePath, boolean encoding)
-    {
-        PixelsWriter pixelsWriter = PixelsWriterImpl.newBuilder()
-                .setSchema(schema)
-                .setPixelStride(pixelStride)
-                .setRowGroupSize(rowGroupSize)
-                .setStorage(minio)
-                .setPath(filePath)
-                .setOverwrite(true) // set overwrite to true to avoid existence checking.
-                .setEncoding(encoding)
-                .build();
-        return pixelsWriter;
     }
 }

--- a/pixels-lambda/src/main/java/io/pixelsdb/pixels/lambda/ScanWorker.java
+++ b/pixels-lambda/src/main/java/io/pixelsdb/pixels/lambda/ScanWorker.java
@@ -24,8 +24,9 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import io.pixelsdb.pixels.common.physical.Storage;
 import io.pixelsdb.pixels.common.physical.StorageFactory;
-import io.pixelsdb.pixels.common.utils.ConfigFactory;
-import io.pixelsdb.pixels.core.*;
+import io.pixelsdb.pixels.core.PixelsReader;
+import io.pixelsdb.pixels.core.PixelsWriter;
+import io.pixelsdb.pixels.core.TypeDescription;
 import io.pixelsdb.pixels.core.reader.PixelsReaderOption;
 import io.pixelsdb.pixels.core.reader.PixelsRecordReader;
 import io.pixelsdb.pixels.core.utils.Bitmap;
@@ -43,6 +44,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import static io.pixelsdb.pixels.common.physical.storage.MinIO.ConfigMinIO;
+import static io.pixelsdb.pixels.lambda.WorkerCommon.*;
 
 /**
  * The response is a list of files read and then written to s3.
@@ -54,20 +56,11 @@ import static io.pixelsdb.pixels.common.physical.storage.MinIO.ConfigMinIO;
 public class ScanWorker implements RequestHandler<ScanInput, ScanOutput>
 {
     private static final Logger logger = LoggerFactory.getLogger(ScanWorker.class);
-    private static final PixelsFooterCache footerCache = new PixelsFooterCache();
-    private static final ConfigFactory configFactory = ConfigFactory.Instance();
-    private static final int rowBatchSize;
-    private static final int pixelStride;
-    private static final int rowGroupSize;
     private static Storage s3;
     private static Storage minio;
 
     static
     {
-        rowBatchSize = Integer.parseInt(configFactory.getProperty("row.batch.size"));
-        pixelStride = Integer.parseInt(configFactory.getProperty("pixel.stride"));
-        rowGroupSize = Integer.parseInt(configFactory.getProperty("row.group.size"));
-
         try
         {
             s3 = StorageFactory.Instance().getStorage(Storage.Scheme.s3);
@@ -182,7 +175,7 @@ public class ScanWorker implements RequestHandler<ScanInput, ScanOutput>
             option.rgRange(inputInfo.getRgStart(), inputInfo.getRgLength());
             VectorizedRowBatch rowBatch;
 
-            try (PixelsReader pixelsReader = getReader(inputInfo.getFilePath());
+            try (PixelsReader pixelsReader = getReader(inputInfo.getPath(), s3);
                  PixelsRecordReader recordReader = pixelsReader.read(option))
             {
                 if (!recordReader.isValid())
@@ -199,7 +192,8 @@ public class ScanWorker implements RequestHandler<ScanInput, ScanOutput>
 
                 if (pixelsWriter == null)
                 {
-                    pixelsWriter = getWriter(rowBatchSchema, outputPath, encoding);
+                    pixelsWriter = getWriter(rowBatchSchema, minio, outputPath,
+                            encoding, false, null);
                 }
                 Bitmap filtered = new Bitmap(rowBatchSize, true);
                 Bitmap tmp = new Bitmap(rowBatchSize, false);
@@ -216,7 +210,7 @@ public class ScanWorker implements RequestHandler<ScanInput, ScanOutput>
             } catch (Exception e)
             {
                 logger.error("failed to scan the file '" +
-                        inputInfo.getFilePath() + "' and output the result", e);
+                        inputInfo.getPath() + "' and output the result", e);
             }
         }
         // Finished scanning all the files in the split.
@@ -242,40 +236,5 @@ public class ScanWorker implements RequestHandler<ScanInput, ScanOutput>
             logger.error("failed finish writing and close the output file '" + outputPath + "'", e);
         }
         return pixelsWriter.getRowGroupNum();
-    }
-
-    private PixelsReader getReader(String fileName)
-    {
-        PixelsReader pixelsReader = null;
-        try
-        {
-            PixelsReaderImpl.Builder builder = PixelsReaderImpl.newBuilder()
-                    .setStorage(s3)
-                    .setPath(fileName)
-                    .setEnableCache(false)
-                    .setCacheOrder(new ArrayList<>())
-                    .setPixelsCacheReader(null)
-                    .setPixelsFooterCache(footerCache);
-            pixelsReader = builder.build();
-        } catch (Exception e)
-        {
-            logger.error("failed to create pixels reader", e);
-        }
-        return pixelsReader;
-    }
-
-    private PixelsWriter getWriter(TypeDescription schema, String filePath, boolean encoding)
-    {
-        PixelsWriter pixelsWriter =
-                PixelsWriterImpl.newBuilder()
-                        .setSchema(schema)
-                        .setPixelStride(pixelStride)
-                        .setRowGroupSize(rowGroupSize)
-                        .setStorage(minio)
-                        .setPath(filePath)
-                        .setOverwrite(true) // set overwrite to true to avoid existence checking.
-                        .setEncoding(encoding)
-                        .build();
-        return pixelsWriter;
     }
 }

--- a/pixels-lambda/src/main/java/io/pixelsdb/pixels/lambda/WorkerCommon.java
+++ b/pixels-lambda/src/main/java/io/pixelsdb/pixels/lambda/WorkerCommon.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2022 PixelsDB.
+ *
+ * This file is part of Pixels.
+ *
+ * Pixels is free software: you can redistribute it and/or modify
+ * it under the terms of the Affero GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * Pixels is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Affero GNU General Public License for more details.
+ *
+ * You should have received a copy of the Affero GNU General Public
+ * License along with Pixels.  If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package io.pixelsdb.pixels.lambda;
+
+import io.pixelsdb.pixels.common.physical.Storage;
+import io.pixelsdb.pixels.common.utils.ConfigFactory;
+import io.pixelsdb.pixels.core.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Some common functions for the lambda workers.
+ * @author hank
+ * @date 15/05/2022
+ */
+public class WorkerCommon
+{
+    private static final Logger logger = LoggerFactory.getLogger(WorkerCommon.class);
+    private static final PixelsFooterCache footerCache = new PixelsFooterCache();
+    private static final ConfigFactory configFactory = ConfigFactory.Instance();
+    public static final int rowBatchSize;
+    private static final int pixelStride;
+    private static final int rowGroupSize;
+
+    static
+    {
+        rowBatchSize = Integer.parseInt(configFactory.getProperty("row.batch.size"));
+        pixelStride = Integer.parseInt(configFactory.getProperty("pixel.stride"));
+        rowGroupSize = Integer.parseInt(configFactory.getProperty("row.group.size"));
+    }
+
+    public static void getSchema(ExecutorService executor, Storage storage,
+                                 AtomicReference<TypeDescription> leftSchema,
+                                 AtomicReference<TypeDescription> rightSchema,
+                                 String leftPath, String rightPath)
+    {
+        Future<?> leftFuture = executor.submit(() -> {
+            try
+            {
+                leftSchema.set(getReader(leftPath, storage).getFileSchema());
+            } catch (IOException e)
+            {
+                logger.error("failed to read the schema of the left table");
+            }
+        });
+        Future<?> rightFuture = executor.submit(() -> {
+            try
+            {
+                rightSchema.set(getReader(rightPath, storage).getFileSchema());
+            } catch (IOException e)
+            {
+                logger.error("failed to read the schema of the right table");
+            }
+        });
+        try
+        {
+            leftFuture.get();
+            rightFuture.get();
+        } catch (Exception e)
+        {
+            logger.error("interrupted while waiting for the termination of schema read", e);
+        }
+    }
+
+    public static PixelsReader getReader(String fileName, Storage storage) throws IOException
+    {
+        PixelsReaderImpl.Builder builder = PixelsReaderImpl.newBuilder()
+                .setStorage(storage)
+                .setPath(fileName)
+                .setEnableCache(false)
+                .setCacheOrder(new ArrayList<>())
+                .setPixelsCacheReader(null)
+                .setPixelsFooterCache(footerCache);
+        PixelsReader pixelsReader = builder.build();
+        return pixelsReader;
+    }
+
+    public static PixelsWriter getWriter(TypeDescription schema, Storage storage,
+                                         String filePath, boolean encoding,
+                                         boolean isPartitioned, List<Integer> keyColumnIds)
+    {
+        PixelsWriterImpl.Builder builder = PixelsWriterImpl.newBuilder()
+                .setSchema(schema)
+                .setPixelStride(pixelStride)
+                .setRowGroupSize(rowGroupSize)
+                .setStorage(storage)
+                .setPath(filePath)
+                .setOverwrite(true) // set overwrite to true to avoid existence checking.
+                .setEncoding(encoding)
+                .setPartitioned(isPartitioned);
+        if (isPartitioned)
+        {
+            builder.setPartKeyColumnIds(keyColumnIds);
+        }
+        return builder.build();
+    }
+}


### PR DESCRIPTION
Implementation broadcast join base-on lambda, and fix the following bugs:
1. key column id can only be ascending;
2. NullTuple does not support includeKey=false;
3. column vector type cast error in Tuple.equals().