### PR TITLE
[Issue #170]: disable left full outer broadcast join.

### DIFF
--- a/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/join/JoinAlgorithm.java
+++ b/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/join/JoinAlgorithm.java
@@ -28,5 +28,6 @@ public enum JoinAlgorithm
     UNKNOWN, // The first enum value is the default value.
     BROADCAST,
     PARTITIONED,
-    CHAIN
+    BROADCAST_CHAIN,
+    PARTITIONED_CHAIN
 }

--- a/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/lambda/BroadcastChainJoinInvoker.java
+++ b/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/lambda/BroadcastChainJoinInvoker.java
@@ -20,7 +20,7 @@
 package io.pixelsdb.pixels.executor.lambda;
 
 import com.alibaba.fastjson.JSON;
-import io.pixelsdb.pixels.executor.lambda.input.ChainJoinInput;
+import io.pixelsdb.pixels.executor.lambda.input.BroadcastChainJoinInput;
 import io.pixelsdb.pixels.executor.lambda.output.JoinOutput;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.lambda.model.InvocationType;
@@ -33,13 +33,13 @@ import java.util.concurrent.CompletableFuture;
  * @author hank
  * @date 03/06/2022
  */
-public class ChainJoinInvoker
+public class BroadcastChainJoinInvoker
 {
-    private static final String CHAIN_JOIN_WORKER_NAME = "ChainJoinWorker";
+    private static final String CHAIN_JOIN_WORKER_NAME = "BroadcastChainJoinWorker";
 
-    private ChainJoinInvoker() { }
+    private BroadcastChainJoinInvoker() { }
 
-    public static CompletableFuture<JoinOutput> invoke(ChainJoinInput input)
+    public static CompletableFuture<JoinOutput> invoke(BroadcastChainJoinInput input)
     {
         String inputJson = JSON.toJSONString(input);
         SdkBytes payload = SdkBytes.fromUtf8String(inputJson);

--- a/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/lambda/SingleStageJoinOperator.java
+++ b/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/lambda/SingleStageJoinOperator.java
@@ -22,7 +22,7 @@ package io.pixelsdb.pixels.executor.lambda;
 import com.google.common.collect.ImmutableList;
 import io.pixelsdb.pixels.executor.join.JoinAlgorithm;
 import io.pixelsdb.pixels.executor.lambda.input.BroadcastJoinInput;
-import io.pixelsdb.pixels.executor.lambda.input.ChainJoinInput;
+import io.pixelsdb.pixels.executor.lambda.input.BroadcastChainJoinInput;
 import io.pixelsdb.pixels.executor.lambda.input.JoinInput;
 import io.pixelsdb.pixels.executor.lambda.output.JoinOutput;
 
@@ -99,9 +99,9 @@ public class SingleStageJoinOperator implements JoinOperator
             {
                 joinOutputs[i] = BroadcastJoinInvoker.invoke((BroadcastJoinInput) joinInputs.get(i));
             }
-            else if (joinAlgo == JoinAlgorithm.CHAIN)
+            else if (joinAlgo == JoinAlgorithm.BROADCAST_CHAIN)
             {
-                joinOutputs[i] = ChainJoinInvoker.invoke((ChainJoinInput) joinInputs.get(i));
+                joinOutputs[i] = BroadcastChainJoinInvoker.invoke((BroadcastChainJoinInput) joinInputs.get(i));
             }
             else
             {

--- a/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/lambda/input/BroadcastChainJoinInput.java
+++ b/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/lambda/input/BroadcastChainJoinInput.java
@@ -32,7 +32,7 @@ import java.util.List;
  * @author hank
  * @date 03/06/2022
  */
-public class ChainJoinInput implements JoinInput
+public class BroadcastChainJoinInput implements JoinInput
 {
     private long queryId;
     /**
@@ -44,7 +44,7 @@ public class ChainJoinInput implements JoinInput
      */
     private BroadCastJoinTableInfo largeTable;
     /**
-     * The information of the chain joins. If there is N left tables and 1 right table,
+     * The information of the chain joins. If there are N small tables and 1 right table,
      * there should be N-1 chain join infos.
      */
     private List<ChainJoinInfo> chainJoinInfos;
@@ -52,6 +52,19 @@ public class ChainJoinInput implements JoinInput
      * The information of the last join with the right table.
      */
     private JoinInfo joinInfo;
+    /**
+     * Whether there are post chain joins.
+     */
+    protected boolean postChainJoinsExist;
+    /**
+     * The information of the post small tables that are broadcast in the chain join.
+     */
+    private List<BroadCastJoinTableInfo> postSmallTables;
+    /**
+     * The information of the post chain joins. If there is M post small tables,
+     * there should be M post chain join infos.
+     */
+    private List<ChainJoinInfo> postChainJoinInfos;
     /**
      * The information of the join output files.<br/>
      * <b>Note: </b>for inner, right-outer, and natural joins, the number of output files
@@ -63,17 +76,25 @@ public class ChainJoinInput implements JoinInput
     /**
      * Default constructor for Jackson.
      */
-    public ChainJoinInput() { }
+    public BroadcastChainJoinInput() { }
 
-    public ChainJoinInput(long queryId, List<BroadCastJoinTableInfo> smallTables,
-                          BroadCastJoinTableInfo largeTable, List<ChainJoinInfo> chainJoinInfos,
-                          JoinInfo joinInfo, MultiOutputInfo output)
+    public BroadcastChainJoinInput(long queryId,
+                                   List<BroadCastJoinTableInfo> smallTables,
+                                   List<ChainJoinInfo> chainJoinInfos,
+                                   BroadCastJoinTableInfo largeTable,
+                                   JoinInfo joinInfo, boolean postChainJoinsExist,
+                                   List<BroadCastJoinTableInfo> postSmallTables,
+                                   List<ChainJoinInfo> postChainJoinInfos,
+                                   MultiOutputInfo output)
     {
         this.queryId = queryId;
         this.smallTables = smallTables;
         this.largeTable = largeTable;
         this.chainJoinInfos = chainJoinInfos;
         this.joinInfo = joinInfo;
+        this.postChainJoinsExist = postChainJoinsExist;
+        this.postSmallTables = postSmallTables;
+        this.postChainJoinInfos = postChainJoinInfos;
         this.output = output;
     }
 
@@ -127,6 +148,36 @@ public class ChainJoinInput implements JoinInput
         this.joinInfo = joinInfo;
     }
 
+    public boolean isPostChainJoinsExist()
+    {
+        return postChainJoinsExist;
+    }
+
+    public void setPostChainJoinsExist(boolean postChainJoinsExist)
+    {
+        this.postChainJoinsExist = postChainJoinsExist;
+    }
+
+    public List<BroadCastJoinTableInfo> getPostSmallTables()
+    {
+        return postSmallTables;
+    }
+
+    public void setPostSmallTables(List<BroadCastJoinTableInfo> postSmallTables)
+    {
+        this.postSmallTables = postSmallTables;
+    }
+
+    public List<ChainJoinInfo> getPostChainJoinInfos()
+    {
+        return postChainJoinInfos;
+    }
+
+    public void setPostChainJoinInfos(List<ChainJoinInfo> postChainJoinInfos)
+    {
+        this.postChainJoinInfos = postChainJoinInfos;
+    }
+
     @Override
     public MultiOutputInfo getOutput()
     {
@@ -145,13 +196,14 @@ public class ChainJoinInput implements JoinInput
 
     public static class Builder
     {
-        private final ChainJoinInput builderInstance;
+        private final BroadcastChainJoinInput builderInstance;
 
-        private Builder(ChainJoinInput instance)
+        private Builder(BroadcastChainJoinInput instance)
         {
-            this.builderInstance = new ChainJoinInput(
-                    instance.queryId, instance.smallTables, instance.largeTable,
-                    instance.chainJoinInfos, instance.joinInfo, instance.output);
+            this.builderInstance = new BroadcastChainJoinInput(
+                    instance.queryId, instance.smallTables, instance.chainJoinInfos,
+                    instance.largeTable, instance.joinInfo, instance.postChainJoinsExist,
+                    instance.postSmallTables, instance.postChainJoinInfos, instance.output);
         }
 
         public Builder setLargeTable(BroadCastJoinTableInfo largeTable)
@@ -172,7 +224,7 @@ public class ChainJoinInput implements JoinInput
             return this;
         }
 
-        public ChainJoinInput build()
+        public BroadcastChainJoinInput build()
         {
             return this.builderInstance;
         }

--- a/pixels-executor/src/test/java/io/pixelsdb/pixels/executor/join/TestBroadcastChainJoinInvoker.java
+++ b/pixels-executor/src/test/java/io/pixelsdb/pixels/executor/join/TestBroadcastChainJoinInvoker.java
@@ -21,9 +21,9 @@ package io.pixelsdb.pixels.executor.join;
 
 import com.alibaba.fastjson.JSON;
 import io.pixelsdb.pixels.common.physical.Storage;
-import io.pixelsdb.pixels.executor.lambda.ChainJoinInvoker;
+import io.pixelsdb.pixels.executor.lambda.BroadcastChainJoinInvoker;
 import io.pixelsdb.pixels.executor.lambda.domain.*;
-import io.pixelsdb.pixels.executor.lambda.input.ChainJoinInput;
+import io.pixelsdb.pixels.executor.lambda.input.BroadcastChainJoinInput;
 import io.pixelsdb.pixels.executor.lambda.output.JoinOutput;
 import org.junit.Test;
 
@@ -36,7 +36,7 @@ import java.util.concurrent.ExecutionException;
  * @author hank
  * @date 15/05/2022
  */
-public class TestChainJoinInvoker
+public class TestBroadcastChainJoinInvoker
 {
     @Test
     public void testRegionNationSupplierLineitem() throws ExecutionException, InterruptedException
@@ -46,7 +46,7 @@ public class TestChainJoinInvoker
         String supplierFilter = "{\"schemaName\":\"tpch\",\"tableName\":\"supplier\",\"columnFilters\":{}}";
         String lineitemFilter = "{\"schemaName\":\"tpch\",\"tableName\":\"lineitem\",\"columnFilters\":{}}";
 
-        ChainJoinInput joinInput = new ChainJoinInput();
+        BroadcastChainJoinInput joinInput = new BroadcastChainJoinInput();
         joinInput.setQueryId(123456);
 
         List<BroadCastJoinTableInfo> leftTables = new ArrayList<>();
@@ -131,7 +131,7 @@ public class TestChainJoinInvoker
                         "chain-join-4","chain-join-5","chain-join-6","chain-join-7")));
 
         System.out.println(JSON.toJSONString(joinInput));
-        JoinOutput output = ChainJoinInvoker.invoke(joinInput).get();
+        JoinOutput output = BroadcastChainJoinInvoker.invoke(joinInput).get();
         System.out.println(output.getOutputs().size());
         for (int i = 0; i < output.getOutputs().size(); ++i)
         {


### PR DESCRIPTION
Disable left outer join and full outer join if the join algorithm is broadcast join.
Rename chain-join as broadcast chain-join, and prepare for partitioned chain-join.
Add post chain join information into broadcast chain-join input.