### PR TITLE
[Issue #258]: support multi-pipeline join and fix bugs.

### DIFF
--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/storage/AbstractS3.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/storage/AbstractS3.java
@@ -510,20 +510,26 @@ public abstract class AbstractS3 implements Storage
                 HeadBucketRequest request = HeadBucketRequest.builder()
                         .bucket(path.bucket).build();
                 s3.headBucket(request);
+                return true;
             }
-            else
+            else if (path.isFolder)
             {
                 ListObjectsV2Request request = ListObjectsV2Request.builder()
                         .bucket(path.bucket).prefix(path.key).maxKeys(1).build();
                 return s3.listObjectsV2(request).keyCount() > 0;
             }
-            return true;
+            else
+            {
+                HeadObjectRequest request = HeadObjectRequest.builder()
+                        .bucket(path.bucket).key(path.key).build();
+                s3.headObject(request);
+                return true;
+            }
         } catch (Exception e)
         {
             if (e instanceof NoSuchKeyException ||
             e instanceof NoSuchBucketException)
             {
-
                 return false;
             }
             throw new IOException("Failed to check the existence of '" + path + "'", e);

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/BinaryColumnVector.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/BinaryColumnVector.java
@@ -131,6 +131,10 @@ public class BinaryColumnVector extends ColumnVector
         this.start[elementNum] = start;
         this.lens[elementNum] = length;
         this.isNull[elementNum] = sourceBuf == null;
+        if (sourceBuf == null)
+        {
+            this.noNulls = false;
+        }
     }
 
     /**
@@ -514,8 +518,8 @@ public class BinaryColumnVector extends ColumnVector
         {
             isNull[index] = false;
             BinaryColumnVector in = (BinaryColumnVector) inputVector;
-            setVal(index, in.vector[inputIndex],
-                    in.start[inputIndex], in.lens[inputIndex]);
+            // We do not change the content of the elements in the vector, thus it is safe to setRef.
+            setRef(index, in.vector[inputIndex], in.start[inputIndex], in.lens[inputIndex]);
         }
         else
         {
@@ -541,6 +545,7 @@ public class BinaryColumnVector extends ColumnVector
             }
             else
             {
+                // We do not change the content of the elements in the vector, thus it is safe to setRef.
                 this.setRef(thisIndex, source.vector[srcIndex], source.start[srcIndex],
                         source.lens[srcIndex]);
             }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/VarcharColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/VarcharColumnWriter.java
@@ -66,6 +66,13 @@ public class VarcharColumnWriter extends StringColumnWriter
         return super.write(vector, length);
     }
 
+    @Override
+    public void reset()
+    {
+        super.reset();
+        this.numTruncated = 0;
+    }
+
     /**
      * Get the number of truncated values.
      * TODO: report it as a warning in Pixels and other query engines.

--- a/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/LambdaJoinExecutor.java
+++ b/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/LambdaJoinExecutor.java
@@ -207,7 +207,12 @@ public class LambdaJoinExecutor
 
                     joinInputs.add(complete);
                 }
-                return new SingleStageJoinOperator(joinInputs.build(), JoinAlgorithm.BROADCAST_CHAIN);
+
+                SingleStageJoinOperator joinOperator = new SingleStageJoinOperator(
+                        joinInputs.build(), JoinAlgorithm.BROADCAST_CHAIN);
+                // The right operator must be set as the large child.
+                joinOperator.setLargeChild(rightOperator);
+                return joinOperator;
             }
             else
             {
@@ -415,6 +420,7 @@ public class LambdaJoinExecutor
 
                         joinInputs.add(complete);
                     }
+
                     return new SingleStageJoinOperator(joinInputs.build(), JoinAlgorithm.BROADCAST_CHAIN);
                 }
             }

--- a/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/LambdaJoinExecutor.java
+++ b/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/LambdaJoinExecutor.java
@@ -322,8 +322,6 @@ public class LambdaJoinExecutor
 
                 BroadcastChainJoinInput broadcastChainJoinInput = new BroadcastChainJoinInput();
                 broadcastChainJoinInput.setQueryId(queryId);
-
-
                 broadcastChainJoinInput.setSmallTables(smallTableInfos);
                 List<ChainJoinInfo> chainJoinInfos = new ArrayList<>();
                 chainJoinInfos.add(chainJoinInfo);

--- a/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/lambda/JoinOperator.java
+++ b/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/lambda/JoinOperator.java
@@ -35,18 +35,22 @@ public interface JoinOperator
 
     JoinAlgorithm getJoinAlgo();
 
-    void setChild(JoinOperator child, boolean smallChild);
+    void setSmallChild(JoinOperator child);
+
+    void setLargeChild(JoinOperator child);
 
     /**
      * Execute this join operator recursively.
      *
-     * @return the join outputs.
+     * @return the completable futures of the join outputs.
      */
     CompletableFuture<?>[] execute();
 
     /**
-     * Only execute the previous stages (if any) before the last stage recursively.
-     * @return empty array if the previous stages do not exist
+     * Execute the previous stages (if any) before the last stage, recursively.
+     * And return the completable futures of the outputs of the previous states that
+     * we should wait for completion.
+     * @return empty array if the previous stages do not exist or do not need to be wait for
      */
     CompletableFuture<?>[] executePrev();
 }

--- a/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/lambda/JoinOperator.java
+++ b/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/lambda/JoinOperator.java
@@ -39,6 +39,10 @@ public interface JoinOperator
 
     void setLargeChild(JoinOperator child);
 
+    JoinOperator getSmallChild();
+
+    JoinOperator getLargeChild();
+
     /**
      * Execute this join operator recursively.
      *

--- a/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/lambda/PartitionedChainJoinInvoker.java
+++ b/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/lambda/PartitionedChainJoinInvoker.java
@@ -20,7 +20,7 @@
 package io.pixelsdb.pixels.executor.lambda;
 
 import com.alibaba.fastjson.JSON;
-import io.pixelsdb.pixels.executor.lambda.input.BroadcastChainJoinInput;
+import io.pixelsdb.pixels.executor.lambda.input.PartitionedChainJoinInput;
 import io.pixelsdb.pixels.executor.lambda.output.JoinOutput;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.lambda.model.InvocationType;
@@ -29,23 +29,23 @@ import software.amazon.awssdk.services.lambda.model.InvokeRequest;
 import java.util.concurrent.CompletableFuture;
 
 /**
- * The lambda invoker for broadcast chain join operator.
+ * The lambda invoker for partitioned chain join operator.
  * @author hank
- * @date 03/06/2022
+ * @date 25/06/2022
  */
-public class BroadcastChainJoinInvoker
+public class PartitionedChainJoinInvoker
 {
-    private static final String BROADCAST_CHAIN_JOIN_WORKER_NAME = "BroadcastChainJoinWorker";
+    private static final String PARTITIONED_CHAIN_JOIN_WORKER_NAME = "PartitionedChainJoinWorker";
 
-    private BroadcastChainJoinInvoker() { }
+    private PartitionedChainJoinInvoker() { }
 
-    public static CompletableFuture<JoinOutput> invoke(BroadcastChainJoinInput input)
+    public static CompletableFuture<JoinOutput> invoke(PartitionedChainJoinInput input)
     {
         String inputJson = JSON.toJSONString(input);
         SdkBytes payload = SdkBytes.fromUtf8String(inputJson);
 
         InvokeRequest request = InvokeRequest.builder()
-                .functionName(BROADCAST_CHAIN_JOIN_WORKER_NAME)
+                .functionName(PARTITIONED_CHAIN_JOIN_WORKER_NAME)
                 .payload(payload)
                 // using RequestResponse for higher function concurrency.
                 .invocationType(InvocationType.REQUEST_RESPONSE)

--- a/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/lambda/PartitionedJoinOperator.java
+++ b/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/lambda/PartitionedJoinOperator.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableList;
 import io.pixelsdb.pixels.executor.join.JoinAlgorithm;
 import io.pixelsdb.pixels.executor.lambda.input.JoinInput;
 import io.pixelsdb.pixels.executor.lambda.input.PartitionInput;
+import io.pixelsdb.pixels.executor.lambda.input.PartitionedChainJoinInput;
 import io.pixelsdb.pixels.executor.lambda.input.PartitionedJoinInput;
 
 import java.util.List;
@@ -106,7 +107,18 @@ public class PartitionedJoinOperator extends SingleStageJoinOperator
         CompletableFuture<?>[] joinOutputs = new CompletableFuture[joinInputs.size()];
         for (int i = 0; i < joinInputs.size(); ++i)
         {
-            joinOutputs[i] = PartitionedJoinInvoker.invoke((PartitionedJoinInput) joinInputs.get(i));
+            if (joinAlgo == JoinAlgorithm.PARTITIONED)
+            {
+                joinOutputs[i] = PartitionedJoinInvoker.invoke((PartitionedJoinInput) joinInputs.get(i));
+            }
+            else if (joinAlgo == JoinAlgorithm.PARTITIONED_CHAIN)
+            {
+                joinOutputs[i] = PartitionedChainJoinInvoker.invoke((PartitionedChainJoinInput) joinInputs.get(i));
+            }
+            else
+            {
+                throw new UnsupportedOperationException("join algorithm '" + joinAlgo + "' is unsupported");
+            }
         }
         return joinOutputs;
     }

--- a/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/lambda/PartitionedJoinOperator.java
+++ b/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/lambda/PartitionedJoinOperator.java
@@ -66,8 +66,22 @@ public class PartitionedJoinOperator extends SingleStageJoinOperator
         {
             this.largePartitionInputs = ImmutableList.copyOf(largePartitionInputs);
         }
-        checkArgument(!this.smallPartitionInputs.isEmpty() || !this.largePartitionInputs.isEmpty(),
-                "both smallPartitionInputs and largePartitionInputs are empty");
+    }
+
+    @Override
+    public void setSmallChild(JoinOperator child)
+    {
+        checkArgument(this.smallPartitionInputs.isEmpty(),
+                "smallPartitionInputs must be empty if smallChild is set");
+        this.smallChild = child;
+    }
+
+    @Override
+    public void setLargeChild(JoinOperator child)
+    {
+        checkArgument(this.largePartitionInputs.isEmpty(),
+                "largePartitionInputs must be empty if largeChild is set");
+        this.largeChild = child;
     }
 
     public List<PartitionInput> getSmallPartitionInputs()
@@ -88,7 +102,7 @@ public class PartitionedJoinOperator extends SingleStageJoinOperator
     @Override
     public CompletableFuture<?>[] execute()
     {
-        executePrev();
+        waitForCompletion(executePrev());
         CompletableFuture<?>[] joinOutputs = new CompletableFuture[joinInputs.size()];
         for (int i = 0; i < joinInputs.size(); ++i)
         {
@@ -100,40 +114,45 @@ public class PartitionedJoinOperator extends SingleStageJoinOperator
     @Override
     public CompletableFuture<?>[] executePrev()
     {
-        if (child != null)
+        if (smallChild != null && largeChild != null)
         {
-            if (smallChild)
+            // both children exist, we should execute both children and wait for the small child.
+            checkArgument(smallPartitionInputs.isEmpty(), "smallPartitionInputs is not empty");
+            checkArgument(largePartitionInputs.isEmpty(), "largePartitionInputs is not empty");
+            CompletableFuture<?>[] childOutputs = smallChild.execute();
+            largeChild.execute();
+            return childOutputs;
+        }
+        else if (smallChild != null)
+        {
+            // only small child exists, we should invoke the large table partitioning and wait for the small child.
+            checkArgument(smallPartitionInputs.isEmpty(), "smallPartitionInputs is not empty");
+            checkArgument(!largePartitionInputs.isEmpty(), "largePartitionInputs is empty");
+            CompletableFuture<?>[] childOutputs = smallChild.execute();
+            for (PartitionInput partitionInput : largePartitionInputs)
             {
-                // child is on the small side, we should invoke the large table partitioning and wait for the child.
-                checkArgument(smallPartitionInputs.isEmpty(), "smallPartitionInputs is not empty");
-                checkArgument(!largePartitionInputs.isEmpty(), "largePartitionInputs is empty");
-                CompletableFuture<?>[] childOutputs = child.execute();
-                for (PartitionInput partitionInput : largePartitionInputs)
-                {
-                    PartitionInvoker.invoke((partitionInput));
-                }
-                waitForCompletion(childOutputs);
-                return childOutputs;
+                PartitionInvoker.invoke((partitionInput));
             }
-            else
+            return childOutputs;
+        }
+        else if (largeChild != null)
+        {
+            // only large child exists, we should invoke and wait for the small table partitioning.
+            checkArgument(!smallPartitionInputs.isEmpty(), "smallPartitionInputs is empty");
+            checkArgument(largePartitionInputs.isEmpty(), "largePartitionInputs is not empty");
+            CompletableFuture<?>[] smallPartitionOutputs =
+                    new CompletableFuture[smallPartitionInputs.size()];
+            int i = 0;
+            for (PartitionInput partitionInput : smallPartitionInputs)
             {
-                // child is on the large side, we should invoke and wait for the small table partitioning.
-                checkArgument(!smallPartitionInputs.isEmpty(), "smallPartitionInputs is empty");
-                checkArgument(largePartitionInputs.isEmpty(), "largePartitionInputs is not empty");
-                CompletableFuture<?>[] smallPartitionOutputs =
-                        new CompletableFuture[smallPartitionInputs.size()];
-                int i = 0;
-                for (PartitionInput partitionInput : smallPartitionInputs)
-                {
-                    smallPartitionOutputs[i++] = PartitionInvoker.invoke((partitionInput));
-                }
-                child.execute();
-                waitForCompletion(smallPartitionOutputs);
-                return smallPartitionOutputs;
+                smallPartitionOutputs[i++] = PartitionInvoker.invoke((partitionInput));
             }
+            largeChild.execute();
+            return smallPartitionOutputs;
         }
         else
         {
+            // no children exist, partition both tables and wait for the small table partitioning.
             CompletableFuture<?>[] smallPartitionOutputs =
                     new CompletableFuture[smallPartitionInputs.size()];
             int i = 0;
@@ -145,7 +164,6 @@ public class PartitionedJoinOperator extends SingleStageJoinOperator
             {
                 PartitionInvoker.invoke((partitionInput));
             }
-            waitForCompletion(smallPartitionOutputs);
             return smallPartitionOutputs;
         }
     }

--- a/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/lambda/SingleStageJoinOperator.java
+++ b/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/lambda/SingleStageJoinOperator.java
@@ -122,7 +122,7 @@ public class SingleStageJoinOperator implements JoinOperator
             }
             else
             {
-                throw new UnsupportedOperationException("join algorithm '" + joinAlgo + "' is unknown");
+                throw new UnsupportedOperationException("join algorithm '" + joinAlgo + "' is unsupported");
             }
         }
         return joinOutputs;

--- a/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/lambda/SingleStageJoinOperator.java
+++ b/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/lambda/SingleStageJoinOperator.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
 
 /**
  * The executor of a single-stage join.
@@ -87,6 +88,18 @@ public class SingleStageJoinOperator implements JoinOperator
         this.largeChild = child;
     }
 
+    @Override
+    public JoinOperator getSmallChild()
+    {
+        return this.smallChild;
+    }
+
+    @Override
+    public JoinOperator getLargeChild()
+    {
+        return this.largeChild;
+    }
+
     /**
      * Execute this join operator.
      *
@@ -136,6 +149,13 @@ public class SingleStageJoinOperator implements JoinOperator
 
     protected static void waitForCompletion(CompletableFuture<?>[] childOutputs)
     {
+        requireNonNull(childOutputs, "childOutputs is null");
+
+        if (childOutputs.length == 0)
+        {
+            return;
+        }
+
         while (true)
         {
             double completed = 0;

--- a/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/lambda/domain/PartitionInfo.java
+++ b/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/lambda/domain/PartitionInfo.java
@@ -33,17 +33,17 @@ public class PartitionInfo
     /**
      * The number of partitions in the output.
      */
-    private int numParition;
+    private int numPartition;
 
     /**
      * Default constructor for Jackson.
      */
     public PartitionInfo() { }
 
-    public PartitionInfo(int[] keyColumnIds, int numParition)
+    public PartitionInfo(int[] keyColumnIds, int numPartition)
     {
         this.keyColumnIds = keyColumnIds;
-        this.numParition = numParition;
+        this.numPartition = numPartition;
     }
 
     public int[] getKeyColumnIds()
@@ -56,13 +56,13 @@ public class PartitionInfo
         this.keyColumnIds = keyColumnIds;
     }
 
-    public int getNumParition()
+    public int getNumPartition()
     {
-        return numParition;
+        return numPartition;
     }
 
-    public void setNumParition(int numParition)
+    public void setNumPartition(int numPartition)
     {
-        this.numParition = numParition;
+        this.numPartition = numPartition;
     }
 }

--- a/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/lambda/input/BroadcastChainJoinInput.java
+++ b/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/lambda/input/BroadcastChainJoinInput.java
@@ -36,18 +36,18 @@ public class BroadcastChainJoinInput implements JoinInput
 {
     private long queryId;
     /**
-     * The information of the small tables that are broadcast in the chain join.
+     * The information of the chain tables that are broadcast in the chain join.
      */
-    private List<BroadCastJoinTableInfo> smallTables;
+    private List<BroadCastJoinTableInfo> chainTables;
+    /**
+     * The information of the chain joins. If there are N chain tables and 1 right table,
+     * there should be N-1 chain join infos.
+     */
+    private List<ChainJoinInfo> chainJoinInfos;
     /**
      * The information of the large table.
      */
     private BroadCastJoinTableInfo largeTable;
-    /**
-     * The information of the chain joins. If there are N small tables and 1 right table,
-     * there should be N-1 chain join infos.
-     */
-    private List<ChainJoinInfo> chainJoinInfos;
     /**
      * The information of the last join with the right table.
      */
@@ -79,18 +79,17 @@ public class BroadcastChainJoinInput implements JoinInput
     public BroadcastChainJoinInput() { }
 
     public BroadcastChainJoinInput(long queryId,
-                                   List<BroadCastJoinTableInfo> smallTables,
+                                   List<BroadCastJoinTableInfo> chainTables,
                                    List<ChainJoinInfo> chainJoinInfos,
                                    BroadCastJoinTableInfo largeTable,
                                    JoinInfo joinInfo, boolean postChainJoinsExist,
                                    List<BroadCastJoinTableInfo> postSmallTables,
-                                   List<ChainJoinInfo> postChainJoinInfos,
-                                   MultiOutputInfo output)
+                                   List<ChainJoinInfo> postChainJoinInfos, MultiOutputInfo output)
     {
         this.queryId = queryId;
-        this.smallTables = smallTables;
-        this.largeTable = largeTable;
+        this.chainTables = chainTables;
         this.chainJoinInfos = chainJoinInfos;
+        this.largeTable = largeTable;
         this.joinInfo = joinInfo;
         this.postChainJoinsExist = postChainJoinsExist;
         this.postSmallTables = postSmallTables;
@@ -108,24 +107,14 @@ public class BroadcastChainJoinInput implements JoinInput
         this.queryId = queryId;
     }
 
-    public List<BroadCastJoinTableInfo> getSmallTables()
+    public List<BroadCastJoinTableInfo> getChainTables()
     {
-        return smallTables;
+        return chainTables;
     }
 
-    public void setSmallTables(List<BroadCastJoinTableInfo> smallTables)
+    public void setChainTables(List<BroadCastJoinTableInfo> chainTables)
     {
-        this.smallTables = smallTables;
-    }
-
-    public BroadCastJoinTableInfo getLargeTable()
-    {
-        return largeTable;
-    }
-
-    public void setLargeTable(BroadCastJoinTableInfo largeTable)
-    {
-        this.largeTable = largeTable;
+        this.chainTables = chainTables;
     }
 
     public List<ChainJoinInfo> getChainJoinInfos()
@@ -136,6 +125,16 @@ public class BroadcastChainJoinInput implements JoinInput
     public void setChainJoinInfos(List<ChainJoinInfo> chainJoinInfos)
     {
         this.chainJoinInfos = chainJoinInfos;
+    }
+
+    public BroadCastJoinTableInfo getLargeTable()
+    {
+        return largeTable;
+    }
+
+    public void setLargeTable(BroadCastJoinTableInfo largeTable)
+    {
+        this.largeTable = largeTable;
     }
 
     public JoinInfo getJoinInfo()
@@ -202,7 +201,7 @@ public class BroadcastChainJoinInput implements JoinInput
         private Builder(BroadcastChainJoinInput instance)
         {
             this.builderInstance = new BroadcastChainJoinInput(
-                    instance.queryId, instance.smallTables, instance.chainJoinInfos,
+                    instance.queryId, instance.chainTables, instance.chainJoinInfos,
                     instance.largeTable, instance.joinInfo, instance.postChainJoinsExist,
                     instance.postSmallTables, instance.postChainJoinInfos, instance.output);
         }

--- a/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/lambda/input/PartitionedChainJoinInput.java
+++ b/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/lambda/input/PartitionedChainJoinInput.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2022 PixelsDB.
+ *
+ * This file is part of Pixels.
+ *
+ * Pixels is free software: you can redistribute it and/or modify
+ * it under the terms of the Affero GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * Pixels is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Affero GNU General Public License for more details.
+ *
+ * You should have received a copy of the Affero GNU General Public
+ * License along with Pixels.  If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package io.pixelsdb.pixels.executor.lambda.input;
+
+import io.pixelsdb.pixels.executor.lambda.domain.*;
+
+import java.util.List;
+
+/**
+ * The input format of the chained partitioned join.
+ * @author hank
+ * @date 25/06/2022
+ */
+public class PartitionedChainJoinInput implements JoinInput
+{
+    /**
+     * The unique id of the query.
+     */
+    private long queryId;
+    /**
+     * The information of the chain tables that are broadcast in the chain join.
+     */
+    private List<BroadCastJoinTableInfo> chainTables;
+    /**
+     * The information of the chain joins. If there are N chain tables and 1 right table,
+     * there should be N-1 chain join infos.
+     */
+    private List<ChainJoinInfo> chainJoinInfos;
+    /**
+     * The information of the small partitioned table.
+     */
+    private PartitionedTableInfo smallTable;
+    /**
+     * The information of the large partitioned table.
+     */
+    private PartitionedTableInfo largeTable;
+    /**
+     * The information of the partitioned join.
+     */
+    private PartitionedJoinInfo joinInfo;
+    /**
+     * The information of the join output files.<br/>
+     * <b>Note: </b>for inner, right-outer, and natural joins, the number of output files
+     * should be consistent with the parallelism of the right table. For left-outer and
+     * full-outer joins, there is an additional output file for the left-outer records.
+     */
+    private MultiOutputInfo output;
+
+    /**
+     * Default constructor for Jackson.
+     */
+    public PartitionedChainJoinInput() { }
+
+    public PartitionedChainJoinInput(long queryId,
+                                     List<BroadCastJoinTableInfo> chainTables,
+                                     List<ChainJoinInfo> chainJoinInfos,
+                                     PartitionedTableInfo smallTable,
+                                     PartitionedTableInfo largeTable,
+                                     PartitionedJoinInfo joinInfo,
+                                     MultiOutputInfo output)
+    {
+        this.queryId = queryId;
+        this.chainTables = chainTables;
+        this.chainJoinInfos = chainJoinInfos;
+        this.smallTable = smallTable;
+        this.largeTable = largeTable;
+        this.joinInfo = joinInfo;
+        this.output = output;
+    }
+
+    public long getQueryId()
+    {
+        return queryId;
+    }
+
+    public void setQueryId(long queryId)
+    {
+        this.queryId = queryId;
+    }
+
+    public List<BroadCastJoinTableInfo> getChainTables()
+    {
+        return chainTables;
+    }
+
+    public void setChainTables(List<BroadCastJoinTableInfo> chainTables)
+    {
+        this.chainTables = chainTables;
+    }
+
+    public List<ChainJoinInfo> getChainJoinInfos()
+    {
+        return chainJoinInfos;
+    }
+
+    public void setChainJoinInfos(List<ChainJoinInfo> chainJoinInfos)
+    {
+        this.chainJoinInfos = chainJoinInfos;
+    }
+
+    public PartitionedTableInfo getSmallTable()
+    {
+        return smallTable;
+    }
+
+    public void setSmallTable(PartitionedTableInfo smallTable)
+    {
+        this.smallTable = smallTable;
+    }
+
+    public PartitionedTableInfo getLargeTable()
+    {
+        return largeTable;
+    }
+
+    public void setLargeTable(PartitionedTableInfo largeTable)
+    {
+        this.largeTable = largeTable;
+    }
+
+    public PartitionedJoinInfo getJoinInfo()
+    {
+        return joinInfo;
+    }
+
+    public void setJoinInfo(PartitionedJoinInfo joinInfo)
+    {
+        this.joinInfo = joinInfo;
+    }
+
+    @Override
+    public MultiOutputInfo getOutput()
+    {
+        return output;
+    }
+
+    @Override
+    public void setOutput(MultiOutputInfo output)
+    {
+        this.output = output;
+    }
+
+    public Builder toBuilder()
+    {
+        return new Builder(this);
+    }
+
+    public static class Builder
+    {
+        private final PartitionedChainJoinInput builderInstance;
+
+        private Builder(PartitionedChainJoinInput instance)
+        {
+            this.builderInstance = new PartitionedChainJoinInput(
+                    instance.queryId, instance.chainTables, instance.chainJoinInfos,
+                    instance.smallTable, instance.largeTable, instance.joinInfo, instance.output);
+        }
+
+        public Builder setLargeTable(PartitionedTableInfo largeTable)
+        {
+            this.builderInstance.setLargeTable(largeTable);
+            return this;
+        }
+
+        public Builder setJoinInfo(PartitionedJoinInfo joinInfo)
+        {
+            this.builderInstance.setJoinInfo(joinInfo);
+            return this;
+        }
+
+        public Builder setOutput(MultiOutputInfo output)
+        {
+            this.builderInstance.setOutput(output);
+            return this;
+        }
+
+        public PartitionedChainJoinInput build()
+        {
+            return this.builderInstance;
+        }
+    }
+}

--- a/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/predicate/ColumnFilter.java
+++ b/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/predicate/ColumnFilter.java
@@ -278,7 +278,7 @@ public class ColumnFilter<T extends Comparable<T>>
                 }
                 byte upperBound = range.upperBound.type != Bound.Type.UNBOUNDED ?
                         (Byte) range.upperBound.value : Byte.MAX_VALUE;
-                if (range.lowerBound.type == Bound.Type.EXCLUDED)
+                if (range.upperBound.type == Bound.Type.EXCLUDED)
                 {
                     upperBound--;
                 }
@@ -371,7 +371,7 @@ public class ColumnFilter<T extends Comparable<T>>
                 }
                 long upperBound = range.upperBound.type != Bound.Type.UNBOUNDED ?
                         (Long) range.upperBound.value : Long.MAX_VALUE;
-                if (range.lowerBound.type == Bound.Type.EXCLUDED)
+                if (range.upperBound.type == Bound.Type.EXCLUDED)
                 {
                     upperBound--;
                 }
@@ -481,9 +481,9 @@ public class ColumnFilter<T extends Comparable<T>>
                 Decimal upperBound = range.upperBound.type != Bound.Type.UNBOUNDED ?
                         new Decimal((Long) range.upperBound.value, precision, scale) :
                         new Decimal(Long.MAX_VALUE, 18, 0);
-                if (range.lowerBound.type == Bound.Type.EXCLUDED)
+                if (range.upperBound.type == Bound.Type.EXCLUDED)
                 {
-                    upperBound.value --;
+                    upperBound.value--;
                 }
                 if (this.filter.allowNull && !noNulls)
                 {
@@ -722,7 +722,7 @@ public class ColumnFilter<T extends Comparable<T>>
                 }
                 int upperBound = range.upperBound.type != Bound.Type.UNBOUNDED ?
                         (Integer) range.upperBound.value : Integer.MAX_VALUE;
-                if (range.lowerBound.type == Bound.Type.EXCLUDED)
+                if (range.upperBound.type == Bound.Type.EXCLUDED)
                 {
                     upperBound--;
                 }

--- a/pixels-executor/src/test/java/io/pixelsdb/pixels/executor/join/TestBroadcastChainJoinInvoker.java
+++ b/pixels-executor/src/test/java/io/pixelsdb/pixels/executor/join/TestBroadcastChainJoinInvoker.java
@@ -99,7 +99,7 @@ public class TestBroadcastChainJoinInvoker
         chainJoinInfo1.setKeyColumnIds(new int[]{2});
         chainJoinInfos.add(chainJoinInfo1);
         
-        joinInput.setSmallTables(leftTables);
+        joinInput.setChainTables(leftTables);
         joinInput.setChainJoinInfos(chainJoinInfos);
 
         BroadCastJoinTableInfo lineitem = new BroadCastJoinTableInfo();

--- a/pixels-executor/src/test/java/io/pixelsdb/pixels/executor/join/TestPartitionInvoker.java
+++ b/pixels-executor/src/test/java/io/pixelsdb/pixels/executor/join/TestPartitionInvoker.java
@@ -66,7 +66,7 @@ public class TestPartitionInvoker
         tableInfo.setFilter(filter);
         input.setTableInfo(tableInfo);
         PartitionInfo partitionInfo = new PartitionInfo();
-        partitionInfo.setNumParition(40);
+        partitionInfo.setNumPartition(40);
         partitionInfo.setKeyColumnIds(new int[]{0});
         input.setPartitionInfo(partitionInfo);
         input.setOutput(new OutputInfo("pixels-lambda-test/orders_part_6", false,
@@ -104,7 +104,7 @@ public class TestPartitionInvoker
         tableInfo.setColumnsToRead(new String[]{"l_orderkey", "l_partkey", "l_extendedprice", "l_discount"});
         input.setTableInfo(tableInfo);
         PartitionInfo partitionInfo = new PartitionInfo();
-        partitionInfo.setNumParition(40);
+        partitionInfo.setNumPartition(40);
         partitionInfo.setKeyColumnIds(new int[]{0});
         input.setPartitionInfo(partitionInfo);
         input.setOutput(new OutputInfo("pixels-lambda-test/lineitem_part_1", false,

--- a/pixels-executor/src/test/java/io/pixelsdb/pixels/executor/join/TestPartitioner.java
+++ b/pixels-executor/src/test/java/io/pixelsdb/pixels/executor/join/TestPartitioner.java
@@ -1,0 +1,371 @@
+/*
+ * Copyright 2022 PixelsDB.
+ *
+ * This file is part of Pixels.
+ *
+ * Pixels is free software: you can redistribute it and/or modify
+ * it under the terms of the Affero GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * Pixels is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Affero GNU General Public License for more details.
+ *
+ * You should have received a copy of the Affero GNU General Public
+ * License along with Pixels.  If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package io.pixelsdb.pixels.executor.join;
+
+import io.pixelsdb.pixels.common.exception.InvalidArgumentException;
+import io.pixelsdb.pixels.common.physical.Storage;
+import io.pixelsdb.pixels.common.physical.StorageFactory;
+import io.pixelsdb.pixels.core.*;
+import io.pixelsdb.pixels.core.reader.PixelsReaderOption;
+import io.pixelsdb.pixels.core.reader.PixelsRecordReader;
+import io.pixelsdb.pixels.core.vector.BinaryColumnVector;
+import io.pixelsdb.pixels.core.vector.LongColumnVector;
+import io.pixelsdb.pixels.core.vector.VectorizedRowBatch;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+/**
+ * @author hank
+ * @date 26/06/2022
+ */
+public class TestPartitioner
+{
+    @Test
+    public void test() throws IOException
+    {
+        Storage storage = StorageFactory.Instance().getStorage(Storage.Scheme.file);
+        PixelsReader pixelsReader = PixelsReaderImpl.newBuilder()
+                .setPath("/home/hank/Desktop/20220313083127_0.compact.pxl")
+                .setStorage(storage).setPixelsFooterCache(new PixelsFooterCache()).setEnableCache(false).build();
+        PixelsReaderOption option = new PixelsReaderOption();
+        option.queryId(123456);
+        option.includeCols(new String[] {"c_custkey", "c_name", "c_address",
+                "c_nationkey", "c_phone", "c_acctbal", "c_mktsegment", "c_comment"});
+        option.rgRange(4, 4);
+        PixelsRecordReader recordReader = pixelsReader.read(option);
+
+        int rowBatchSize = 10000;
+        int numPartition = 5;
+        TypeDescription rowBatchSchema = recordReader.getResultSchema();
+        VectorizedRowBatch rowBatch;
+        List<ConcurrentLinkedQueue<VectorizedRowBatch>> partitionResult = new ArrayList<>(numPartition);
+        for (int i = 0; i < numPartition; ++i)
+        {
+            partitionResult.add(new ConcurrentLinkedQueue<>());
+        }
+        Partitioner partitioner = new Partitioner(numPartition, rowBatchSize,
+                rowBatchSchema, new int[] {0});
+
+        Map<Long, String> custKeyToAddress = new HashMap<>();
+        int num = 0, pnum = 0;
+        do
+        {
+            rowBatch = recordReader.readBatch(rowBatchSize);
+            if (rowBatch.size > 0)
+            {
+                num += rowBatch.size;
+                LongColumnVector vector0 = (LongColumnVector) rowBatch.cols[0];
+                BinaryColumnVector vector2 = (BinaryColumnVector) rowBatch.cols[2];
+                for (int i = 0; i < rowBatch.size; ++i)
+                {
+                    if (!vector2.isNull[i])
+                    {
+                        custKeyToAddress.put(vector0.vector[i],
+                                new String(vector2.vector[i], vector2.start[i], vector2.lens[i]));
+                    }
+                }
+                Map<Integer, VectorizedRowBatch> result = partitioner.partition(rowBatch);
+                if (!result.isEmpty())
+                {
+                    for (Map.Entry<Integer, VectorizedRowBatch> entry : result.entrySet())
+                    {
+                        pnum += entry.getValue().size;
+                        partitionResult.get(entry.getKey()).add(entry.getValue());
+                    }
+                }
+            }
+        } while (!rowBatch.endOfFile);
+
+        pixelsReader.close();
+
+        VectorizedRowBatch[] tailBatches = partitioner.getRowBatches();
+        for (int hash = 0; hash < tailBatches.length; ++hash)
+        {
+            if (!tailBatches[hash].isEmpty())
+            {
+                pnum += tailBatches[hash].size;
+                partitionResult.get(hash).add(tailBatches[hash]);
+            }
+        }
+
+        if (num != pnum)
+        {
+            System.out.println("error");
+            throw new InvalidArgumentException();
+        }
+
+        PixelsWriter pixelsWriter = PixelsWriterImpl.newBuilder().setStorage(storage)
+                .setPath("/home/hank/Desktop/part-0").setPartitioned(true)
+                .setEncoding(true).setPixelStride(10000).setOverwrite(true)
+                .setPartKeyColumnIds(Arrays.asList(0))
+                .setRowGroupSize(268435456).setSchema(rowBatchSchema).build();
+
+        for (int hash = 0; hash < numPartition; ++hash)
+        {
+            ConcurrentLinkedQueue<VectorizedRowBatch> batches = partitionResult.get(hash);
+            if (!batches.isEmpty())
+            {
+                for (VectorizedRowBatch batch : batches)
+                {
+                    LongColumnVector vector0 = (LongColumnVector) batch.cols[0];
+                    BinaryColumnVector vector2 = (BinaryColumnVector) batch.cols[2];
+                    for (int i = 0; i < batch.size; ++i)
+                    {
+                        String address = new String(vector2.vector[i], vector2.start[i], vector2.lens[i]);
+                        if (!custKeyToAddress.get(vector0.vector[i]).equals(address))
+                        {
+                            System.out.println("error");
+                            throw new RuntimeException("not match");
+                        }
+                    }
+                    pixelsWriter.addRowBatch(batch, hash);
+                }
+            }
+        }
+
+        pixelsWriter.close();
+
+        for (int hash = 0; hash < numPartition; ++hash)
+        {
+            ConcurrentLinkedQueue<VectorizedRowBatch> batches = partitionResult.get(hash);
+            if (!batches.isEmpty())
+            {
+                for (VectorizedRowBatch batch : batches)
+                {
+                    LongColumnVector vector0 = (LongColumnVector) batch.cols[0];
+                    BinaryColumnVector vector2 = (BinaryColumnVector) batch.cols[2];
+                    for (int i = 0; i < batch.size; ++i)
+                    {
+                        String address = new String(vector2.vector[i], vector2.start[i], vector2.lens[i]);
+                        if (!custKeyToAddress.get(vector0.vector[i]).equals(address))
+                        {
+                            System.out.println("error");
+                            throw new RuntimeException("not match");
+                        }
+                    }
+                }
+            }
+        }
+
+        PixelsReader pixelsReader1 = PixelsReaderImpl.newBuilder()
+                .setPath("/home/hank/Desktop/part-0")
+                .setStorage(storage).setPixelsFooterCache(new PixelsFooterCache()).setEnableCache(false).build();
+        PixelsReaderOption option1 = new PixelsReaderOption();
+        option1.queryId(123456);
+        option1.includeCols(new String[] {"c_custkey", "c_name", "c_address",
+                "c_nationkey", "c_phone", "c_acctbal", "c_mktsegment", "c_comment"});
+        option1.rgRange(0, -1);
+        PixelsRecordReader recordReader1 = pixelsReader1.read(option1);
+
+        pnum = 0;
+        do
+        {
+            rowBatch = recordReader1.readBatch(rowBatchSize);
+            if (rowBatch.size > 0)
+            {
+                pnum += rowBatch.size;
+                LongColumnVector vector0 = (LongColumnVector) rowBatch.cols[0];
+                BinaryColumnVector vector2 = (BinaryColumnVector) rowBatch.cols[2];
+                for (int i = 0; i < rowBatch.size; ++i)
+                {
+                    String address = new String(vector2.vector[i], vector2.start[i], vector2.lens[i]);
+                    if (!custKeyToAddress.get(vector0.vector[i]).equals(address))
+                    {
+                        System.out.println(custKeyToAddress.get(vector0.vector[i]) + " != " + address);
+                        System.out.println(pnum);
+                        throw new RuntimeException("not match");
+                    }
+                }
+            }
+        } while (!rowBatch.endOfFile);
+
+        pixelsReader1.close();
+        if (num != pnum)
+        {
+            System.out.println("error");
+            throw new RuntimeException("...");
+        }
+    }
+
+    @Test
+    public void test2() throws IOException
+    {
+        Storage storage = StorageFactory.Instance().getStorage(Storage.Scheme.file);
+        PixelsReader pixelsReader = PixelsReaderImpl.newBuilder()
+                .setPath("/home/hank/Desktop/20220313083127_0.compact.pxl")
+                .setStorage(storage).setPixelsFooterCache(new PixelsFooterCache()).setEnableCache(false).build();
+        PixelsReaderOption option = new PixelsReaderOption();
+        option.queryId(123456);
+        option.includeCols(new String[] {"c_custkey", "c_name", "c_address",
+                "c_nationkey", "c_phone", "c_acctbal", "c_mktsegment", "c_comment"});
+        option.rgRange(4, 4);
+        PixelsRecordReader recordReader = pixelsReader.read(option);
+
+        int rowBatchSize = 10000;
+        int numPartition = 5;
+        TypeDescription rowBatchSchema = recordReader.getResultSchema();
+        VectorizedRowBatch rowBatch;
+        List<ConcurrentLinkedQueue<VectorizedRowBatch>> partitionResult = new ArrayList<>(numPartition);
+        for (int i = 0; i < numPartition; ++i)
+        {
+            partitionResult.add(new ConcurrentLinkedQueue<>());
+        }
+        Partitioner partitioner = new Partitioner(numPartition, rowBatchSize,
+                rowBatchSchema, new int[] {0});
+
+        Map<Long, Long> custKeyToNationKey = new HashMap<>();
+        int num = 0, pnum = 0;
+        do
+        {
+            rowBatch = recordReader.readBatch(rowBatchSize);
+            if (rowBatch.size > 0)
+            {
+                num += rowBatch.size;
+                LongColumnVector vector0 = (LongColumnVector) rowBatch.cols[0];
+                LongColumnVector vector3 = (LongColumnVector) rowBatch.cols[3];
+                for (int i = 0; i < rowBatch.size; ++i)
+                {
+                    if (!vector3.isNull[i])
+                    {
+                        custKeyToNationKey.put(vector0.vector[i], vector3.vector[i]);
+                    }
+                }
+                Map<Integer, VectorizedRowBatch> result = partitioner.partition(rowBatch);
+                if (!result.isEmpty())
+                {
+                    for (Map.Entry<Integer, VectorizedRowBatch> entry : result.entrySet())
+                    {
+                        pnum += entry.getValue().size;
+                        partitionResult.get(entry.getKey()).add(entry.getValue());
+                    }
+                }
+            }
+        } while (!rowBatch.endOfFile);
+
+        pixelsReader.close();
+
+        VectorizedRowBatch[] tailBatches = partitioner.getRowBatches();
+        for (int hash = 0; hash < tailBatches.length; ++hash)
+        {
+            if (!tailBatches[hash].isEmpty())
+            {
+                pnum += tailBatches[hash].size;
+                partitionResult.get(hash).add(tailBatches[hash]);
+            }
+        }
+
+        if (num != pnum)
+        {
+            System.out.println("error");
+            throw new InvalidArgumentException();
+        }
+
+        PixelsWriter pixelsWriter = PixelsWriterImpl.newBuilder().setStorage(storage)
+                .setPath("/home/hank/Desktop/part-0").setPartitioned(true)
+                .setEncoding(true).setPixelStride(10000).setOverwrite(true)
+                .setPartKeyColumnIds(Arrays.asList(0))
+                .setRowGroupSize(268435456).setSchema(rowBatchSchema).build();
+
+        for (int hash = 0; hash < numPartition; ++hash)
+        {
+            ConcurrentLinkedQueue<VectorizedRowBatch> batches = partitionResult.get(hash);
+            if (!batches.isEmpty())
+            {
+                for (VectorizedRowBatch batch : batches)
+                {
+                    LongColumnVector vector0 = (LongColumnVector) batch.cols[0];
+                    LongColumnVector vector3 = (LongColumnVector) batch.cols[3];
+                    for (int i = 0; i < batch.size; ++i)
+                    {
+                        if (custKeyToNationKey.get(vector0.vector[i]) != vector3.vector[i])
+                        {
+                            System.out.println("error");
+                            throw new RuntimeException("not match");
+                        }
+                    }
+                    pixelsWriter.addRowBatch(batch, hash);
+                }
+            }
+        }
+
+        pixelsWriter.close();
+
+        for (int hash = 0; hash < numPartition; ++hash)
+        {
+            ConcurrentLinkedQueue<VectorizedRowBatch> batches = partitionResult.get(hash);
+            if (!batches.isEmpty())
+            {
+                for (VectorizedRowBatch batch : batches)
+                {
+                    LongColumnVector vector0 = (LongColumnVector) batch.cols[0];
+                    LongColumnVector vector3 = (LongColumnVector) batch.cols[3];
+                    for (int i = 0; i < batch.size; ++i)
+                    {
+                        if (custKeyToNationKey.get(vector0.vector[i]) != vector3.vector[i])
+                        {
+                            System.out.println("error");
+                            throw new RuntimeException("not match");
+                        }
+                    }
+                }
+            }
+        }
+
+        PixelsReader pixelsReader1 = PixelsReaderImpl.newBuilder()
+                .setPath("/home/hank/Desktop/part-0")
+                .setStorage(storage).setPixelsFooterCache(new PixelsFooterCache()).setEnableCache(false).build();
+        PixelsReaderOption option1 = new PixelsReaderOption();
+        option1.queryId(123456);
+        option1.includeCols(new String[] {"c_custkey", "c_name", "c_address",
+                "c_nationkey", "c_phone", "c_acctbal", "c_mktsegment", "c_comment"});
+        option1.rgRange(0, -1);
+        PixelsRecordReader recordReader1 = pixelsReader1.read(option1);
+
+        pnum = 0;
+        do
+        {
+            rowBatch = recordReader1.readBatch(rowBatchSize);
+            if (rowBatch.size > 0)
+            {
+                pnum += rowBatch.size;
+                LongColumnVector vector0 = (LongColumnVector) rowBatch.cols[0];
+                LongColumnVector vector3 = (LongColumnVector) rowBatch.cols[3];
+                for (int i = 0; i < rowBatch.size; ++i)
+                {
+                    if (custKeyToNationKey.get(vector0.vector[i]) != vector3.vector[i])
+                    {
+                        System.out.println("error");
+                        throw new RuntimeException("not match");
+                    }
+                }
+            }
+        } while (!rowBatch.endOfFile);
+
+        pixelsReader1.close();
+        if (num != pnum)
+        {
+            System.out.println("error");
+            throw new RuntimeException("...");
+        }
+    }
+}

--- a/pixels-lambda/src/main/java/io/pixelsdb/pixels/lambda/BroadcastChainJoinWorker.java
+++ b/pixels-lambda/src/main/java/io/pixelsdb/pixels/lambda/BroadcastChainJoinWorker.java
@@ -334,6 +334,7 @@ public class BroadcastChainJoinWorker implements RequestHandler<BroadcastChainJo
     private void chainJoinSplit(Joiner currJoiner, Joiner nextJoiner, List<InputInfo> rightInputs,
                                 boolean checkExistence, String[] rightCols, TableScanFilter rightFilter)
     {
+        int numInputs = 0;
         while (!rightInputs.isEmpty())
         {
             for (Iterator<InputInfo> it = rightInputs.iterator(); it.hasNext(); )
@@ -363,6 +364,7 @@ public class BroadcastChainJoinWorker implements RequestHandler<BroadcastChainJo
                 {
                     it.remove();
                 }
+                numInputs++;
                 try (PixelsReader pixelsReader = getReader(input.getPath(), s3))
                 {
                     if (input.getRgStart() >= pixelsReader.getRowGroupNum())
@@ -408,5 +410,6 @@ public class BroadcastChainJoinWorker implements RequestHandler<BroadcastChainJo
                 }
             }
         }
+        logger.info("number of inputs for chain table: " + numInputs);
     }
 }

--- a/pixels-lambda/src/main/java/io/pixelsdb/pixels/lambda/BroadcastChainJoinWorker.java
+++ b/pixels-lambda/src/main/java/io/pixelsdb/pixels/lambda/BroadcastChainJoinWorker.java
@@ -79,7 +79,7 @@ public class BroadcastChainJoinWorker implements RequestHandler<BroadcastChainJo
 
             this.queryId = event.getQueryId();
 
-            List<BroadCastJoinTableInfo> leftTables = event.getSmallTables();
+            List<BroadCastJoinTableInfo> leftTables = event.getChainTables();
             List<ChainJoinInfo> chainJoinInfos = event.getChainJoinInfos();
             requireNonNull(leftTables, "leftTables is null");
             requireNonNull(chainJoinInfos, "chainJoinInfos is null");

--- a/pixels-lambda/src/main/java/io/pixelsdb/pixels/lambda/BroadcastChainJoinWorker.java
+++ b/pixels-lambda/src/main/java/io/pixelsdb/pixels/lambda/BroadcastChainJoinWorker.java
@@ -125,7 +125,7 @@ public class BroadcastChainJoinWorker implements RequestHandler<BroadcastChainJo
 
             if (this.partitionOutput)
             {
-                logger.info("post partition num: " + this.outputPartitionInfo.getNumParition());
+                logger.info("post partition num: " + this.outputPartitionInfo.getNumPartition());
             }
 
             // build the joiner.

--- a/pixels-lambda/src/main/java/io/pixelsdb/pixels/lambda/BroadcastChainJoinWorker.java
+++ b/pixels-lambda/src/main/java/io/pixelsdb/pixels/lambda/BroadcastChainJoinWorker.java
@@ -142,10 +142,10 @@ public class BroadcastChainJoinWorker implements RequestHandler<BroadcastChainJo
                     {
                         int rowGroupNum = this.partitionOutput ?
                                 joinWithRightTableAndPartition(
-                                        queryId, joiner, inputs, false, rightCols, rightFilter,
+                                        queryId, joiner, inputs, true, rightCols, rightFilter,
                                         outputPath, encoding, outputInfo.getScheme(), this.partitionOutput,
                                         this.outputPartitionInfo) :
-                                joinWithRightTable(queryId, joiner, inputs, false, rightCols,
+                                joinWithRightTable(queryId, joiner, inputs, true, rightCols,
                                         rightFilter, outputPath, encoding, outputInfo.getScheme());
                         if (rowGroupNum > 0)
                         {
@@ -202,7 +202,7 @@ public class BroadcastChainJoinWorker implements RequestHandler<BroadcastChainJo
                 BroadCastJoinTableInfo currRightTable = leftTables.get(i);
                 BroadCastJoinTableInfo nextTable = leftTables.get(i+1);
                 TypeDescription nextTableSchema = getFileSchema(s3,
-                        nextTable.getInputSplits().get(0).getInputInfos().get(0).getPath(), false);
+                        nextTable.getInputSplits().get(0).getInputInfos().get(0).getPath(), true);
                 ChainJoinInfo currJoinInfo = chainJoinInfos.get(i-1);
                 ChainJoinInfo nextJoinInfo = chainJoinInfos.get(i);
                 TypeDescription nextResultSchema = getResultSchema(nextTableSchema, nextTable.getColumnsToRead());
@@ -217,7 +217,7 @@ public class BroadcastChainJoinWorker implements RequestHandler<BroadcastChainJo
             ChainJoinInfo lastChainJoin = chainJoinInfos.get(chainJoinInfos.size()-1);
             BroadCastJoinTableInfo lastLeftTable = leftTables.get(leftTables.size()-1);
             TypeDescription rightTableSchema = getFileSchema(s3,
-                    rightTable.getInputSplits().get(0).getInputInfos().get(0).getPath(), false);
+                    rightTable.getInputSplits().get(0).getInputInfos().get(0).getPath(), true);
             TypeDescription rightResultSchema = getResultSchema(rightTableSchema, rightTable.getColumnsToRead());
             Joiner finalJoiner = new Joiner(lastJoinInfo.getJoinType(),
                     currJoiner.getJoinedSchema(), lastJoinInfo.getSmallColumnAlias(),
@@ -252,7 +252,7 @@ public class BroadcastChainJoinWorker implements RequestHandler<BroadcastChainJo
         AtomicReference<TypeDescription> t2Schema = new AtomicReference<>();
         getFileSchema(executor, s3, t1Schema, t2Schema,
                 t1.getInputSplits().get(0).getInputInfos().get(0).getPath(),
-                t2.getInputSplits().get(0).getInputInfos().get(0).getPath(), false);
+                t2.getInputSplits().get(0).getInputInfos().get(0).getPath(), true);
         Joiner joiner = new Joiner(joinInfo.getJoinType(),
                 getResultSchema(t1Schema.get(), t1.getColumnsToRead()), joinInfo.getSmallColumnAlias(),
                 joinInfo.getSmallProjection(), t1.getKeyColumnIds(),
@@ -266,7 +266,7 @@ public class BroadcastChainJoinWorker implements RequestHandler<BroadcastChainJo
             leftFutures.add(executor.submit(() -> {
                 try
                 {
-                    buildHashTable(queryId, joiner, inputs, false, t1.getColumnsToRead(), t1Filter);
+                    buildHashTable(queryId, joiner, inputs, true, t1.getColumnsToRead(), t1Filter);
                 }
                 catch (Exception e)
                 {
@@ -304,7 +304,7 @@ public class BroadcastChainJoinWorker implements RequestHandler<BroadcastChainJo
             rightFutures.add(executor.submit(() -> {
                 try
                 {
-                    chainJoinSplit(currJoiner, nextJoiner, inputs, false,
+                    chainJoinSplit(currJoiner, nextJoiner, inputs, true,
                             currRightTable.getColumnsToRead(), currRigthFilter);
                 }
                 catch (Exception e)

--- a/pixels-lambda/src/main/java/io/pixelsdb/pixels/lambda/BroadcastChainJoinWorker.java
+++ b/pixels-lambda/src/main/java/io/pixelsdb/pixels/lambda/BroadcastChainJoinWorker.java
@@ -125,7 +125,7 @@ public class BroadcastChainJoinWorker implements RequestHandler<BroadcastChainJo
 
             if (this.partitionOutput)
             {
-                logger.info("post partitioning, number of partitions: " + this.outputPartitionInfo.getNumParition());
+                logger.info("post partition num: " + this.outputPartitionInfo.getNumParition());
             }
 
             // build the joiner.

--- a/pixels-lambda/src/main/java/io/pixelsdb/pixels/lambda/BroadcastJoinWorker.java
+++ b/pixels-lambda/src/main/java/io/pixelsdb/pixels/lambda/BroadcastJoinWorker.java
@@ -215,6 +215,7 @@ public class BroadcastJoinWorker implements RequestHandler<BroadcastJoinInput, J
     public static void buildHashTable(long queryId, Joiner joiner, List<InputInfo> leftInputs,
                                       boolean checkExistence, String[] leftCols, TableScanFilter leftFilter)
     {
+        int numInputs = 0;
         while (!leftInputs.isEmpty())
         {
             for (Iterator<InputInfo> it = leftInputs.iterator(); it.hasNext(); )
@@ -244,6 +245,7 @@ public class BroadcastJoinWorker implements RequestHandler<BroadcastJoinInput, J
                 {
                     it.remove();
                 }
+                numInputs++;
                 try (PixelsReader pixelsReader = getReader(input.getPath(), s3))
                 {
                     if (input.getRgStart() >= pixelsReader.getRowGroupNum())
@@ -278,6 +280,7 @@ public class BroadcastJoinWorker implements RequestHandler<BroadcastJoinInput, J
                 }
             }
         }
+        logger.info("number of inputs for hash table: " + numInputs);
     }
 
     /**
@@ -302,6 +305,7 @@ public class BroadcastJoinWorker implements RequestHandler<BroadcastJoinInput, J
         PixelsWriter pixelsWriter = getWriter(joiner.getJoinedSchema(),
                 outputScheme == Storage.Scheme.minio ? minio : s3, outputPath,
                 encoding, false, null);
+        int numInputs = 0;
         while (!rightInputs.isEmpty())
         {
             for (Iterator<InputInfo> it = rightInputs.iterator(); it.hasNext(); )
@@ -331,6 +335,7 @@ public class BroadcastJoinWorker implements RequestHandler<BroadcastJoinInput, J
                 {
                     it.remove();
                 }
+                numInputs++;
                 try (PixelsReader pixelsReader = getReader(input.getPath(), s3))
                 {
                     if (input.getRgStart() >= pixelsReader.getRowGroupNum())
@@ -376,6 +381,7 @@ public class BroadcastJoinWorker implements RequestHandler<BroadcastJoinInput, J
                 }
             }
         }
+        logger.info("number of inputs for large table: " + numInputs);
         try
         {
             pixelsWriter.close();
@@ -433,6 +439,7 @@ public class BroadcastJoinWorker implements RequestHandler<BroadcastJoinInput, J
             partitioned.add(new LinkedList<>());
         }
         int rowGroupNum = 0;
+        int numInputs = 0;
         while (!rightInputs.isEmpty())
         {
             for (Iterator<InputInfo> it = rightInputs.iterator(); it.hasNext(); )
@@ -462,6 +469,7 @@ public class BroadcastJoinWorker implements RequestHandler<BroadcastJoinInput, J
                 {
                     it.remove();
                 }
+                numInputs++;
                 try (PixelsReader pixelsReader = getReader(input.getPath(), s3))
                 {
                     if (input.getRgStart() >= pixelsReader.getRowGroupNum())
@@ -511,6 +519,7 @@ public class BroadcastJoinWorker implements RequestHandler<BroadcastJoinInput, J
                 }
             }
         }
+        logger.info("number of inputs for large table*: " + numInputs);
         try
         {
             VectorizedRowBatch[] tailBatches = partitioner.getRowBatches();

--- a/pixels-lambda/src/main/java/io/pixelsdb/pixels/lambda/BroadcastJoinWorker.java
+++ b/pixels-lambda/src/main/java/io/pixelsdb/pixels/lambda/BroadcastJoinWorker.java
@@ -171,7 +171,7 @@ public class BroadcastJoinWorker implements RequestHandler<BroadcastJoinInput, J
                                         queryId, joiner, inputs, true, rightCols, rightFilter,
                                         outputPath, encoding, outputInfo.getScheme(), this.partitionOutput,
                                         this.outputPartitionInfo) :
-                                joinWithRightTable(queryId, joiner, inputs, false, rightCols,
+                                joinWithRightTable(queryId, joiner, inputs, true, rightCols,
                                         rightFilter, outputPath, encoding, outputInfo.getScheme());
                         if (rowGroupNum > 0)
                         {

--- a/pixels-lambda/src/main/java/io/pixelsdb/pixels/lambda/BroadcastJoinWorker.java
+++ b/pixels-lambda/src/main/java/io/pixelsdb/pixels/lambda/BroadcastJoinWorker.java
@@ -418,10 +418,10 @@ public class BroadcastJoinWorker implements RequestHandler<BroadcastJoinInput, J
     {
         checkArgument(partitionOutput, "partitionOutput is false");
         requireNonNull(outputPartitionInfo, "outputPartitionInfo is null");
-        Partitioner partitioner = new Partitioner(outputPartitionInfo.getNumParition(),
+        Partitioner partitioner = new Partitioner(outputPartitionInfo.getNumPartition(),
                 rowBatchSize, joiner.getJoinedSchema(), outputPartitionInfo.getKeyColumnIds());
-        List<List<VectorizedRowBatch>> partitioned = new ArrayList<>(outputPartitionInfo.getNumParition());
-        for (int i = 0; i < outputPartitionInfo.getNumParition(); ++i)
+        List<List<VectorizedRowBatch>> partitioned = new ArrayList<>(outputPartitionInfo.getNumPartition());
+        for (int i = 0; i < outputPartitionInfo.getNumPartition(); ++i)
         {
             partitioned.add(new LinkedList<>());
         }
@@ -522,7 +522,7 @@ public class BroadcastJoinWorker implements RequestHandler<BroadcastJoinInput, J
                             outputPartitionInfo.getKeyColumnIds()).boxed().
                             collect(Collectors.toList()));
             int rowNum = 0;
-            for (int hash = 0; hash < outputPartitionInfo.getNumParition(); ++hash)
+            for (int hash = 0; hash < outputPartitionInfo.getNumPartition(); ++hash)
             {
                 List<VectorizedRowBatch> batches = partitioned.get(hash);
                 if (!batches.isEmpty())

--- a/pixels-lambda/src/main/java/io/pixelsdb/pixels/lambda/PartitionWorker.java
+++ b/pixels-lambda/src/main/java/io/pixelsdb/pixels/lambda/PartitionWorker.java
@@ -69,7 +69,7 @@ public class PartitionWorker implements RequestHandler<PartitionInput, Partition
 
             long queryId = event.getQueryId();
             List<InputSplit> inputSplits = event.getTableInfo().getInputSplits();
-            int numPartition = event.getPartitionInfo().getNumParition();
+            int numPartition = event.getPartitionInfo().getNumPartition();
             logger.info("table '" + event.getTableInfo().getTableName() +
                     "', number of partitions (" + numPartition + ")");
             int[] keyColumnIds = event.getPartitionInfo().getKeyColumnIds();

--- a/pixels-lambda/src/main/java/io/pixelsdb/pixels/lambda/PartitionedJoinWorker.java
+++ b/pixels-lambda/src/main/java/io/pixelsdb/pixels/lambda/PartitionedJoinWorker.java
@@ -126,7 +126,7 @@ public class PartitionedJoinWorker implements RequestHandler<PartitionedJoinInpu
 
             if (this.partitionOutput)
             {
-                logger.info("post partition num: " + this.outputPartitionInfo.getNumParition());
+                logger.info("post partition num: " + this.outputPartitionInfo.getNumPartition());
             }
 
             try
@@ -460,10 +460,10 @@ public class PartitionedJoinWorker implements RequestHandler<PartitionedJoinInpu
     {
         checkArgument(this.partitionOutput, "partitionOutput is false");
         requireNonNull(this.outputPartitionInfo, "outputPartitionInfo is null");
-        Partitioner partitioner = new Partitioner(this.outputPartitionInfo.getNumParition(),
+        Partitioner partitioner = new Partitioner(this.outputPartitionInfo.getNumPartition(),
                 rowBatchSize, joiner.getJoinedSchema(), outputPartitionInfo.getKeyColumnIds());
-        List<List<VectorizedRowBatch>> partitioned = new ArrayList<>(outputPartitionInfo.getNumParition());
-        for (int i = 0; i < outputPartitionInfo.getNumParition(); ++i)
+        List<List<VectorizedRowBatch>> partitioned = new ArrayList<>(outputPartitionInfo.getNumPartition());
+        for (int i = 0; i < outputPartitionInfo.getNumPartition(); ++i)
         {
             partitioned.add(new LinkedList<>());
         }
@@ -556,7 +556,7 @@ public class PartitionedJoinWorker implements RequestHandler<PartitionedJoinInpu
                             this.outputPartitionInfo.getKeyColumnIds()).boxed().
                             collect(Collectors.toList()));
             int rowNum = 0;
-            for (int hash = 0; hash < outputPartitionInfo.getNumParition(); ++hash)
+            for (int hash = 0; hash < outputPartitionInfo.getNumPartition(); ++hash)
             {
                 List<VectorizedRowBatch> batches = partitioned.get(hash);
                 if (!batches.isEmpty())

--- a/pixels-lambda/src/main/java/io/pixelsdb/pixels/lambda/ScanWorker.java
+++ b/pixels-lambda/src/main/java/io/pixelsdb/pixels/lambda/ScanWorker.java
@@ -194,20 +194,14 @@ public class ScanWorker implements RequestHandler<ScanInput, ScanOutput>
         // Finished scanning all the files in the split.
         try
         {
-            pixelsWriter.close();
-            while (true)
+            if (pixelsWriter != null)
             {
-                try
-                {
-                    if (minio.getStatus(outputPath) != null)
-                    {
-                        break;
-                    }
-                } catch (Exception e)
-                {
-                    // Wait for 10ms and see if the output file is visible.
-                    TimeUnit.MILLISECONDS.sleep(10);
-                }
+                pixelsWriter.close();
+            }
+            while (!minio.exists(outputPath))
+            {
+                // Wait for 10ms and see if the output file is visible.
+                TimeUnit.MILLISECONDS.sleep(10);
             }
         } catch (Exception e)
         {


### PR DESCRIPTION
1. Implement multi-pipeline joins so that we can support TPCH q5, q8, and q10.
2. Fix column filter upper bound bug.
3. Fix post-partition number and post-partition key column ids for post partitioning.
4. Fix row group range in the reader option for partitioned join.
5. Fix column writer resetting for partitioned file writing.
6. Start parsing partitioned chain joins, not finished.