### PR TITLE
[Issue #258]: implement split size capping.

### DIFF
--- a/pixels-common/src/main/resources/pixels.properties
+++ b/pixels-common/src/main/resources/pixels.properties
@@ -91,9 +91,13 @@ join.intermediate.folder=/pixels-lambda-test/
 # the number of threads used in each partition worker
 join.intra.worker.parallelism=6
 # the maximum size of a broadcast table, the unit can be B/KB/MB/GB, must be capitalized.
-join.broadcast.threshold=1024MB
-# the maximum size of a partition in partitioned join.
-join.partition.size=1024MB
+join.broadcast.threshold=200MB
+# the maximum (average) size of a partition in partitioned join.
+join.partition.size=256MB
+# if true, the max split size is capped by the split size calculated from statistics.
+join.cap.split-size.by.statistics=true
+# the size of data to be processed by each scan task on base table.
+join.base.table.scan.unit=64MB
 
 # the rate of free memory in jvm.
 pixels.gc.threshold=0.3


### PR DESCRIPTION
Make sure the split size of the table scan in the joins is not larger than the cap calculated from the data statistics.
This is good for the joins that scan a lot of columns.