### PR TITLE
[Issue #297]: fix timestamp type, stat recorders, null value filtering, and pixels-load.

### DIFF
--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/ColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/ColumnReader.java
@@ -27,7 +27,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
-import static io.pixelsdb.pixels.core.TypeDescription.SHORT_MAX_PRECISION;
+import static io.pixelsdb.pixels.core.TypeDescription.SHORT_DECIMAL_MAX_PRECISION;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -58,7 +58,7 @@ public abstract class ColumnReader implements Closeable
             case DOUBLE:
                 return new DoubleColumnReader(type);
             case DECIMAL: // Issue #196: precision and scale are passed through type.
-                if (type.getPrecision() <= SHORT_MAX_PRECISION)
+                if (type.getPrecision() <= SHORT_DECIMAL_MAX_PRECISION)
                     return new DecimalColumnReader(type);
                 else
                     return new LongDecimalColumnReader(type);

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/DecimalColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/DecimalColumnReader.java
@@ -88,11 +88,11 @@ public class DecimalColumnReader
                      ColumnVector vector, PixelsProto.ColumnChunkIndex chunkIndex)
     {
         DecimalColumnVector columnVector = (DecimalColumnVector) vector;
-        if (type.getPrecision() != columnVector.precision || type.getScale() != columnVector.scale)
+        if (type.getPrecision() != columnVector.getPrecision() || type.getScale() != columnVector.getScale())
         {
             throw new IllegalArgumentException("reader of decimal(" + type.getPrecision() + "," + type.getScale() +
-                    ") does not match the column vector of decimal(" + columnVector.precision + "," +
-                    columnVector.scale + ")");
+                    ") does not match the column vector of decimal(" + columnVector.getPrecision() + "," +
+                    columnVector.getScale() + ")");
         }
         if (offset == 0)
         {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/LongDecimalColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/LongDecimalColumnReader.java
@@ -88,11 +88,11 @@ public class LongDecimalColumnReader
                      ColumnVector vector, PixelsProto.ColumnChunkIndex chunkIndex)
     {
         LongDecimalColumnVector columnVector = (LongDecimalColumnVector) vector;
-        if (type.getPrecision() != columnVector.precision || type.getScale() != columnVector.scale)
+        if (type.getPrecision() != columnVector.getPrecision() || type.getScale() != columnVector.getScale())
         {
             throw new IllegalArgumentException("reader of long_decimal(" + type.getPrecision() + "," + type.getScale() +
-                    ") does not match the column vector of long_decimal(" + columnVector.precision + "," +
-                    columnVector.scale + ")");
+                    ") does not match the column vector of long_decimal(" + columnVector.getPrecision() + "," +
+                    columnVector.getScale() + ")");
         }
         if (offset == 0)
         {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/TimestampColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/TimestampColumnReader.java
@@ -134,7 +134,7 @@ public class TimestampColumnReader
                 }
                 else
                 {
-                    columnVector.set(i + vectorIndex, new Timestamp(decoder.next()));
+                    columnVector.set(i + vectorIndex, decoder.next());
                 }
                 if (hasNull)
                 {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/stats/DateStatsRecorder.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/stats/DateStatsRecorder.java
@@ -151,8 +151,11 @@ public class DateStatsRecorder
         PixelsProto.ColumnStatistic.Builder builder = super.serialize();
         PixelsProto.DateStatistic.Builder dateBuilder =
                 PixelsProto.DateStatistic.newBuilder();
-        dateBuilder.setMinimum((int)minimum);
-        dateBuilder.setMaximum((int)maximum);
+        if (hasMinMax)
+        {
+            dateBuilder.setMinimum((int) minimum);
+            dateBuilder.setMaximum((int) maximum);
+        }
         builder.setDateStatistics(dateBuilder);
         builder.setNumberOfValues(numberOfValues);
         return builder;

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/stats/StatsRecorder.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/stats/StatsRecorder.java
@@ -27,7 +27,7 @@ import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
 
-import static io.pixelsdb.pixels.core.TypeDescription.SHORT_MAX_PRECISION;
+import static io.pixelsdb.pixels.core.TypeDescription.SHORT_DECIMAL_MAX_PRECISION;
 
 /**
  * This is a base class for recording (updating) all kinds of column statistics during file writing.
@@ -212,7 +212,7 @@ public class StatsRecorder
                  * using the precision and scale from the type in the file footer.
                  */
             case DECIMAL:
-                if (type.getPrecision() <= SHORT_MAX_PRECISION)
+                if (type.getPrecision() <= SHORT_DECIMAL_MAX_PRECISION)
                     return new IntegerStatsRecorder();
                 else
                     return new Integer128StatsRecorder();

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/stats/StringStatsRecorder.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/stats/StringStatsRecorder.java
@@ -27,10 +27,13 @@ import io.airlift.slice.Slices;
 import java.nio.ByteBuffer;
 import java.nio.charset.CharacterCodingException;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
 /**
  * pixels
  *
- * @author guodong
+ * @author guodong, hank
  */
 public class StringStatsRecorder
         extends StatsRecorder implements StringColumnStats
@@ -47,7 +50,7 @@ public class StringStatsRecorder
     {
         super(statistic);
         PixelsProto.StringStatistic strStat = statistic.getStringStatistics();
-        if (strStat.hasMaximum())
+        if (strStat.hasMinimum())
         {
             minimum = strStat.getMinimum();
         }
@@ -73,6 +76,8 @@ public class StringStatsRecorder
     @Override
     public void updateString(String value, int repetitions)
     {
+        requireNonNull(value, "value is null");
+        checkArgument(repetitions > 0, "repetitions is non-positive");
         if (minimum == null)
         {
             minimum = maximum = value;
@@ -88,7 +93,7 @@ public class StringStatsRecorder
                 maximum = value;
             }
         }
-        sum += value.length() * repetitions;
+        sum += (long) value.length() * repetitions;
         numberOfValues += repetitions;
     }
 
@@ -153,7 +158,7 @@ public class StringStatsRecorder
         PixelsProto.ColumnStatistic.Builder builder = super.serialize();
         PixelsProto.StringStatistic.Builder strBuilder =
                 PixelsProto.StringStatistic.newBuilder();
-        if (getNumberOfValues() != 0)
+        if (minimum != null)
         {
             strBuilder.setMinimum(minimum);
             strBuilder.setMaximum(maximum);

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/stats/TimeStatsRecorder.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/stats/TimeStatsRecorder.java
@@ -94,16 +94,16 @@ public class TimeStatsRecorder
         {
             if (value.getTime() < minimum)
             {
-                minimum = (int)value.getTime();
+                minimum = (int) value.getTime();
             }
             if (value.getTime() > maximum)
             {
-                maximum = (int)value.getTime();
+                maximum = (int) value.getTime();
             }
         }
         else
         {
-            minimum = maximum = (int)value.getTime();
+            minimum = maximum = (int) value.getTime();
             hasMinMax = true;
         }
         numberOfValues++;
@@ -148,8 +148,11 @@ public class TimeStatsRecorder
         PixelsProto.ColumnStatistic.Builder builder = super.serialize();
         PixelsProto.TimeStatistic.Builder tBuilder =
                 PixelsProto.TimeStatistic.newBuilder();
-        tBuilder.setMinimum(minimum);
-        tBuilder.setMaximum(maximum);
+        if (hasMinMax)
+        {
+            tBuilder.setMinimum(minimum);
+            tBuilder.setMaximum(maximum);
+        }
         builder.setTimeStatistics(tBuilder);
         builder.setNumberOfValues(numberOfValues);
         return builder;

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/stats/TimestampStatsRecorder.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/stats/TimestampStatsRecorder.java
@@ -148,8 +148,11 @@ public class TimestampStatsRecorder
         PixelsProto.ColumnStatistic.Builder builder = super.serialize();
         PixelsProto.TimestampStatistic.Builder tsBuilder =
                 PixelsProto.TimestampStatistic.newBuilder();
-        tsBuilder.setMinimum(minimum);
-        tsBuilder.setMaximum(maximum);
+        if (hasMinMax)
+        {
+            tsBuilder.setMinimum(minimum);
+            tsBuilder.setMaximum(maximum);
+        }
         builder.setTimestampStatistics(tsBuilder);
         builder.setNumberOfValues(numberOfValues);
         return builder;

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/utils/Decimal.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/utils/Decimal.java
@@ -20,7 +20,7 @@
 package io.pixelsdb.pixels.core.utils;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static io.pixelsdb.pixels.core.TypeDescription.SHORT_MAX_PRECISION;
+import static io.pixelsdb.pixels.core.TypeDescription.SHORT_DECIMAL_MAX_PRECISION;
 
 /**
  * Created at: 08/04/2022
@@ -59,7 +59,7 @@ public class Decimal implements Comparable<Decimal>
 
     public Decimal(long value, int precision, int scale)
     {
-        checkArgument(precision > 0 && scale >= 0 && precision >= scale && precision <= SHORT_MAX_PRECISION,
+        checkArgument(precision > 0 && scale >= 0 && precision >= scale && precision <= SHORT_DECIMAL_MAX_PRECISION,
                 "invalid precision and scale (" + precision + "," + scale + ")");
         checkArgument(value < SCALE_FACTOR[precision], "overflow");
         this.value = value;

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/utils/LongDecimal.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/utils/LongDecimal.java
@@ -22,7 +22,7 @@ package io.pixelsdb.pixels.core.utils;
 import java.math.BigInteger;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static io.pixelsdb.pixels.core.TypeDescription.LONG_MAX_PRECISION;
+import static io.pixelsdb.pixels.core.TypeDescription.LONG_DECIMAL_MAX_PRECISION;
 
 /**
  * @date 03/07/2022
@@ -78,7 +78,7 @@ public class LongDecimal implements Comparable<LongDecimal>
 
     public LongDecimal(Integer128 value, int precision, int scale)
     {
-        checkArgument(precision > 0 && scale >= 0 && precision >= scale && precision <= LONG_MAX_PRECISION,
+        checkArgument(precision > 0 && scale >= 0 && precision >= scale && precision <= LONG_DECIMAL_MAX_PRECISION,
                 "invalid precision and scale (" + precision + "," + scale + ")");
         this.value = value;
         this.precision = precision;

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/DateColumnVector.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/DateColumnVector.java
@@ -38,7 +38,7 @@ import static java.util.Objects.requireNonNull;
  * We store the value field of a Date class in primitive arrays.
  * <p>
  * We do this to avoid an array of Java Date objects which would have poor storage
- * and memory access characteristics.
+ * and memory access performance.
  * <p>
  * Generally, the caller will fill in a scratch date object with values from a row, work
  * using the scratch date, and then perhaps update the column vector row with a result.

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/DateColumnVector.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/DateColumnVector.java
@@ -162,16 +162,6 @@ public class DateColumnVector extends ColumnVector
     }
 
     /**
-     * Return the scratch date (contents undefined).
-     *
-     * @return
-     */
-    public Date getScratchDate()
-    {
-        return scratchDate;
-    }
-
-    /**
      * Return a long representation of a date.
      *
      * @param elementNum
@@ -249,8 +239,7 @@ public class DateColumnVector extends ColumnVector
     public int compareTo(int elementNum1, DateColumnVector dateColVector2,
                          int elementNum2)
     {
-        return asScratchDate(elementNum1).compareTo(
-                dateColVector2.asScratchDate(elementNum2));
+        return Integer.compare(this.dates[elementNum1], dateColVector2.dates[elementNum2]);
     }
 
     /**
@@ -264,8 +253,7 @@ public class DateColumnVector extends ColumnVector
     public int compareTo(DateColumnVector dateColVector1, int elementNum1,
                          int elementNum2)
     {
-        return dateColVector1.asScratchDate(elementNum1).compareTo(
-                asScratchDate(elementNum2));
+        return Integer.compare(dateColVector1.dates[elementNum1], this.dates[elementNum2]);
     }
 
     @Override

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/DecimalColumnVector.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/DecimalColumnVector.java
@@ -26,8 +26,8 @@ import java.math.MathContext;
 import java.util.Arrays;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static io.pixelsdb.pixels.core.TypeDescription.SHORT_MAX_PRECISION;
-import static io.pixelsdb.pixels.core.TypeDescription.SHORT_MAX_SCALE;
+import static io.pixelsdb.pixels.core.TypeDescription.SHORT_DECIMAL_MAX_PRECISION;
+import static io.pixelsdb.pixels.core.TypeDescription.SHORT_DECIMAL_MAX_SCALE;
 import static java.math.BigDecimal.ROUND_HALF_UP;
 import static java.util.Objects.requireNonNull;
 
@@ -48,8 +48,8 @@ public class DecimalColumnVector extends ColumnVector
 {
     public static final long DEFAULT_UNSCALED_VALUE = 0;
     public long[] vector;
-    public int precision;
-    public int scale;
+    private int precision;
+    private int scale;
 
     public DecimalColumnVector(int precision, int scale)
     {
@@ -67,10 +67,10 @@ public class DecimalColumnVector extends ColumnVector
         {
             throw new IllegalArgumentException("precision " + precision + " is negative");
         }
-        else if (precision > SHORT_MAX_PRECISION)
+        else if (precision > SHORT_DECIMAL_MAX_PRECISION)
         {
             throw new IllegalArgumentException("precision " + precision +
-                    " is out of the max precision " + SHORT_MAX_PRECISION);
+                    " is out of the max precision " + SHORT_DECIMAL_MAX_PRECISION);
         }
         this.precision = precision;
 
@@ -78,10 +78,10 @@ public class DecimalColumnVector extends ColumnVector
         {
             throw new IllegalArgumentException("scale " + scale + " is negative");
         }
-        else if (scale > SHORT_MAX_SCALE)
+        else if (scale > SHORT_DECIMAL_MAX_SCALE)
         {
             throw new IllegalArgumentException("scale " + scale +
-                    " is out of the max scale " + SHORT_MAX_SCALE);
+                    " is out of the max scale " + SHORT_DECIMAL_MAX_SCALE);
         }
         else if (scale > precision)
         {
@@ -89,6 +89,16 @@ public class DecimalColumnVector extends ColumnVector
                     " is smaller that scale " + scale);
         }
         this.scale = scale;
+    }
+
+    public int getPrecision()
+    {
+        return precision;
+    }
+
+    public int getScale()
+    {
+        return scale;
     }
 
     /**

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/LongDecimalColumnVector.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/LongDecimalColumnVector.java
@@ -29,8 +29,8 @@ import java.nio.ByteOrder;
 import java.util.Arrays;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static io.pixelsdb.pixels.core.TypeDescription.LONG_MAX_PRECISION;
-import static io.pixelsdb.pixels.core.TypeDescription.LONG_MAX_SCALE;
+import static io.pixelsdb.pixels.core.TypeDescription.LONG_DECIMAL_MAX_PRECISION;
+import static io.pixelsdb.pixels.core.TypeDescription.LONG_DECIMAL_MAX_SCALE;
 import static java.math.BigDecimal.ROUND_HALF_UP;
 import static java.util.Objects.requireNonNull;
 
@@ -46,8 +46,8 @@ public class LongDecimalColumnVector extends ColumnVector
     public static final ByteOrder ENDIAN = ByteOrder.BIG_ENDIAN;
     public static final long DEFAULT_UNSCALED_VALUE = 0;
     public long[] vector;
-    public int precision;
-    public int scale;
+    private int precision;
+    private int scale;
 
     public LongDecimalColumnVector(int precision, int scale)
     {
@@ -65,10 +65,10 @@ public class LongDecimalColumnVector extends ColumnVector
         {
             throw new IllegalArgumentException("precision " + precision + " is negative");
         }
-        else if (precision > LONG_MAX_PRECISION)
+        else if (precision > LONG_DECIMAL_MAX_PRECISION)
         {
             throw new IllegalArgumentException("precision " + precision +
-                    " is out of the max precision " + LONG_MAX_PRECISION);
+                    " is out of the max precision " + LONG_DECIMAL_MAX_PRECISION);
         }
         this.precision = precision;
 
@@ -76,10 +76,10 @@ public class LongDecimalColumnVector extends ColumnVector
         {
             throw new IllegalArgumentException("scale " + scale + " is negative");
         }
-        else if (scale > LONG_MAX_SCALE)
+        else if (scale > LONG_DECIMAL_MAX_SCALE)
         {
             throw new IllegalArgumentException("scale " + scale +
-                    " is out of the max scale " + LONG_MAX_SCALE);
+                    " is out of the max scale " + LONG_DECIMAL_MAX_SCALE);
         }
         else if (scale > precision)
         {
@@ -87,6 +87,16 @@ public class LongDecimalColumnVector extends ColumnVector
                     " is smaller that scale " + scale);
         }
         this.scale = scale;
+    }
+
+    public int getPrecision()
+    {
+        return precision;
+    }
+
+    public int getScale()
+    {
+        return scale;
     }
 
     /**

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/TimeColumnVector.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/TimeColumnVector.java
@@ -155,16 +155,6 @@ public class TimeColumnVector extends ColumnVector
     }
 
     /**
-     * Return the scratch time (contents undefined).
-     *
-     * @return
-     */
-    public Time getScratchTime()
-    {
-        return scratchTime;
-    }
-
-    /**
      * Return a long representation of a time.
      *
      * @param elementNum
@@ -242,8 +232,7 @@ public class TimeColumnVector extends ColumnVector
     public int compareTo(int elementNum1, TimeColumnVector timeColVector2,
                          int elementNum2)
     {
-        return asScratchTime(elementNum1).compareTo(
-                timeColVector2.asScratchTime(elementNum2));
+        return Integer.compare(this.times[elementNum1], timeColVector2.times[elementNum2]);
     }
 
     /**
@@ -257,8 +246,7 @@ public class TimeColumnVector extends ColumnVector
     public int compareTo(TimeColumnVector timeColVector1, int elementNum1,
                          int elementNum2)
     {
-        return timeColVector1.asScratchTime(elementNum1).compareTo(
-                asScratchTime(elementNum2));
+        return Integer.compare(timeColVector1.times[elementNum1], this.times[elementNum2]);
     }
 
     @Override

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/TimeColumnVector.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/TimeColumnVector.java
@@ -37,7 +37,7 @@ import static java.util.Objects.requireNonNull;
  * We store the value field of a Time class in primitive arrays.
  * <p>
  * We do this to avoid an array of Java Time objects which would have poor storage
- * and memory access characteristics.
+ * and memory access performance.
  * <p>
  * Generally, the caller will fill in a scratch time object with values from a row, work
  * using the scratch time, and then perhaps update the column vector row with a result.

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/ColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/ColumnWriter.java
@@ -26,7 +26,7 @@ import io.pixelsdb.pixels.core.vector.ColumnVector;
 
 import java.io.IOException;
 
-import static io.pixelsdb.pixels.core.TypeDescription.SHORT_MAX_PRECISION;
+import static io.pixelsdb.pixels.core.TypeDescription.SHORT_DECIMAL_MAX_PRECISION;
 
 /**
  * pixels
@@ -59,7 +59,7 @@ public interface ColumnWriter
             case DOUBLE:
                 return new DoubleColumnWriter(type, pixelStride, isEncoding);
             case DECIMAL: // Issue #196: precision and scale are passed through type.
-                if (type.getPrecision() <= SHORT_MAX_PRECISION)
+                if (type.getPrecision() <= SHORT_DECIMAL_MAX_PRECISION)
                     return new DecimalColumnWriter(type, pixelStride, isEncoding);
                 else
                     return new LongDecimalColumnWriter(type, pixelStride, isEncoding);

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/StringColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/StringColumnWriter.java
@@ -113,7 +113,8 @@ public class StringColumnWriter extends BaseColumnWriter
         return outputStream.size();
     }
 
-    private void writeCurPartWithoutDict(BinaryColumnVector columnVector, byte[][] values, int[] vLens, int[] vOffsets, int curPartLength, int curPartOffset)
+    private void writeCurPartWithoutDict(BinaryColumnVector columnVector, byte[][] values,
+                                         int[] vLens, int[] vOffsets, int curPartLength, int curPartOffset)
     {
         for (int i = 0; i < curPartLength; i++)
         {
@@ -127,16 +128,16 @@ public class StringColumnWriter extends BaseColumnWriter
             {
                 outputStream.write(values[curPartOffset + i], vOffsets[curPartOffset + i], vLens[curPartOffset + i]);
                 lensArray.add(vLens[curPartOffset + i]);
-                pixelStatRecorder
-                        .updateString(values[curPartOffset + i], vOffsets[curPartOffset + i], vLens[curPartOffset + i],
-                                1);
+                pixelStatRecorder.updateString(values[curPartOffset + i], vOffsets[curPartOffset + i],
+                        vLens[curPartOffset + i], 1);
             }
         }
         System.arraycopy(columnVector.isNull, curPartOffset, isNull, curPixelIsNullIndex, curPartLength);
         curPixelIsNullIndex += curPartLength;
     }
 
-    private void writeCurPartWithDict(BinaryColumnVector columnVector, byte[][] values, int[] vLens, int[] vOffsets, int curPartLength, int curPartOffset)
+    private void writeCurPartWithDict(BinaryColumnVector columnVector, byte[][] values, int[] vLens, int[] vOffsets,
+                                      int curPartLength, int curPartOffset)
     {
         for (int i = 0; i < curPartLength; i++)
         {
@@ -150,9 +151,8 @@ public class StringColumnWriter extends BaseColumnWriter
             {
                 curPixelVector[curPixelVectorIndex++] = dictionary
                         .add(values[curPartOffset + i], vOffsets[curPartOffset + i], vLens[curPartOffset + i]);
-                pixelStatRecorder
-                        .updateString(values[curPartOffset + i], vOffsets[curPartOffset + i], vLens[curPartOffset + i],
-                                1);
+                pixelStatRecorder.updateString(values[curPartOffset + i], vOffsets[curPartOffset + i],
+                        vLens[curPartOffset + i], 1);
             }
         }
         System.arraycopy(columnVector.isNull, curPartOffset, isNull, curPixelIsNullIndex, curPartLength);

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/TimestampColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/TimestampColumnWriter.java
@@ -31,9 +31,8 @@ import java.nio.ByteBuffer;
 /**
  * Timestamp column writer.
  * All timestamp values are converted to standard UTC time before they are stored as long values.
- * TODO: Currently not support nanos
  *
- * @author guodong
+ * @author hank
  */
 public class TimestampColumnWriter extends BaseColumnWriter
 {

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/writer/TestPixelsWriter.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/writer/TestPixelsWriter.java
@@ -74,10 +74,10 @@ public class TestPixelsWriter
             DecimalColumnVector vi = (DecimalColumnVector) rowBatch.cols[8];        // decimal
             LongDecimalColumnVector vj = (LongDecimalColumnVector) rowBatch.cols[9];// long decimal
 
-            System.out.println(vi.precision);
-            System.out.println(vi.scale);
-            System.out.println(vj.precision);
-            System.out.println(vj.scale);
+            System.out.println(vi.getPrecision());
+            System.out.println(vi.getScale());
+            System.out.println(vj.getPrecision());
+            System.out.println(vj.getScale());
 
             PixelsWriter pixelsWriter =
                     PixelsWriterImpl.newBuilder()

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/writer/TestPixelsWriter.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/writer/TestPixelsWriter.java
@@ -108,7 +108,6 @@ public class TestPixelsWriter
                     vc.vector[row] = 0;
                     vd.isNull[row] = true;
                     vd.times[row] = 0;
-                    vd.nanos[row] = 0;
                     ve.isNull[row] = true;
                     ve.vector[row] = 0;
                     vf.isNull[row] = true;
@@ -271,16 +270,15 @@ public class TestPixelsWriter
             BinaryColumnVector hcv = (BinaryColumnVector) rowBatch.cols[7];
             DecimalColumnVector icv = (DecimalColumnVector) rowBatch.cols[8];
             LongDecimalColumnVector jcv = (LongDecimalColumnVector) rowBatch.cols[9];
-            for (int i = 0, j = 0; i < rowBatch.size; ++i)
+            for (int i = 0; i < rowBatch.size; ++i)
             {
-                if (jcv.isNull[i])
+                if (dcv.isNull[i])
                 {
                     System.out.println("null");
                 }
                 else
                 {
-                    System.out.println(jcv.vector[j*2] + ", " + jcv.vector[j*2+1]);
-                    System.out.println(jcv.getScratchDecimal(j++).toString());
+                    System.out.println(dcv.asScratchTimestamp(i));
 
                 }
             }

--- a/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/predicate/ColumnFilter.java
+++ b/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/predicate/ColumnFilter.java
@@ -300,13 +300,12 @@ public class ColumnFilter<T extends Comparable<T>>
                 {
                     for (int i = start; i < start + length; ++i)
                     {
-                        if (vector[i] >= lowerBound && vector[i] <= upperBound)
+                        if ((noNulls || !isNull[i]) && vector[i] >= lowerBound && vector[i] <= upperBound)
                         {
                             result.set(i);
                         }
                     }
                 }
-
             }
         }
         else
@@ -327,7 +326,7 @@ public class ColumnFilter<T extends Comparable<T>>
                 {
                     for (int i = start; i < start + length; ++i)
                     {
-                        if (includes.contains(vector[i]))
+                        if ((noNulls || !isNull[i]) && includes.contains(vector[i]))
                         {
                             result.set(i);
                         }
@@ -350,7 +349,7 @@ public class ColumnFilter<T extends Comparable<T>>
                 {
                     for (int i = start; i < start + length; ++i)
                     {
-                        if (!excludes.contains(vector[i]))
+                        if ((noNulls || !isNull[i]) && !excludes.contains(vector[i]))
                         {
                             result.set(i);
                         }
@@ -393,13 +392,12 @@ public class ColumnFilter<T extends Comparable<T>>
                 {
                     for (int i = start; i < start + length; ++i)
                     {
-                        if (vector[i] >= lowerBound && vector[i] <= upperBound)
+                        if ((noNulls || !isNull[i]) && vector[i] >= lowerBound && vector[i] <= upperBound)
                         {
                             result.set(i);
                         }
                     }
                 }
-
             }
         }
         else
@@ -420,7 +418,7 @@ public class ColumnFilter<T extends Comparable<T>>
                 {
                     for (int i = start; i < start + length; ++i)
                     {
-                        if (includes.contains(vector[i]))
+                        if ((noNulls || !isNull[i]) && includes.contains(vector[i]))
                         {
                             result.set(i);
                         }
@@ -443,7 +441,7 @@ public class ColumnFilter<T extends Comparable<T>>
                 {
                     for (int i = start; i < start + length; ++i)
                     {
-                        if (!excludes.contains(vector[i]))
+                        if ((noNulls || !isNull[i]) && !excludes.contains(vector[i]))
                         {
                             result.set(i);
                         }
@@ -504,7 +502,8 @@ public class ColumnFilter<T extends Comparable<T>>
                 {
                     for (int i = start; i < start + length; ++i)
                     {
-                        if (lowerBound.compareTo(vector[i], precision, scale)<= 0 ||
+                        if ((noNulls || !isNull[i]) &&
+                                lowerBound.compareTo(vector[i], precision, scale) <= 0 &&
                                 upperBound.compareTo(vector[i], precision, scale) >= 0)
                         {
                             result.set(i);
@@ -531,7 +530,7 @@ public class ColumnFilter<T extends Comparable<T>>
                 {
                     for (int i = start; i < start + length; ++i)
                     {
-                        if (includes.contains(vector[i]))
+                        if ((noNulls || !isNull[i]) && includes.contains(vector[i]))
                         {
                             result.set(i);
                         }
@@ -554,7 +553,7 @@ public class ColumnFilter<T extends Comparable<T>>
                 {
                     for (int i = start; i < start + length; ++i)
                     {
-                        if (!excludes.contains(vector[i]))
+                        if ((noNulls || !isNull[i]) && !excludes.contains(vector[i]))
                         {
                             result.set(i);
                         }
@@ -639,6 +638,10 @@ public class ColumnFilter<T extends Comparable<T>>
                 {
                     for (int i = start; i < start + length; ++i)
                     {
+                        if (!noNulls && isNull[i])
+                        {
+                            continue;
+                        }
                         int cmp1 = lowerBounded ?
                                 byteArrayCmp(vector[i], starts[i], lens[i], lowerBound, 0, lowerBound.length) : 1;
                         int cmp2 = upperBounded ?
@@ -649,7 +652,6 @@ public class ColumnFilter<T extends Comparable<T>>
                         }
                     }
                 }
-
             }
         }
         else
@@ -660,12 +662,8 @@ public class ColumnFilter<T extends Comparable<T>>
                 {
                     for (int i = start; i < start + length; ++i)
                     {
-                        if (isNull[i])
-                        {
-                            continue;
-                        }
-                        if (includes.contains(new String(vector[i],
-                                starts[i], lens[i], StandardCharsets.UTF_8)))
+                        if (isNull[i] || includes.contains(
+                                new String(vector[i], starts[i], lens[i], StandardCharsets.UTF_8)))
                         {
                             result.set(i);
                         }
@@ -675,8 +673,8 @@ public class ColumnFilter<T extends Comparable<T>>
                 {
                     for (int i = start; i < start + length; ++i)
                     {
-                        if (includes.contains(new String(vector[i],
-                                starts[i], lens[i], StandardCharsets.UTF_8)))
+                        if ((noNulls || !isNull[i]) && includes.contains(
+                                new String(vector[i], starts[i], lens[i], StandardCharsets.UTF_8)))
                         {
                             result.set(i);
                         }
@@ -689,8 +687,8 @@ public class ColumnFilter<T extends Comparable<T>>
                 {
                     for (int i = start; i < start + length; ++i)
                     {
-                        if (isNull[i] || !excludes.contains(new String(vector[i],
-                                starts[i], lens[i], StandardCharsets.UTF_8)))
+                        if (isNull[i] || !excludes.contains(
+                                new String(vector[i], starts[i], lens[i], StandardCharsets.UTF_8)))
                         {
                             result.set(i);
                         }
@@ -700,8 +698,8 @@ public class ColumnFilter<T extends Comparable<T>>
                 {
                     for (int i = start; i < start + length; ++i)
                     {
-                        if (!excludes.contains(new String(vector[i],
-                                starts[i], lens[i], StandardCharsets.UTF_8)))
+                        if ((noNulls || !isNull[i]) && !excludes.contains(
+                                new String(vector[i], starts[i], lens[i], StandardCharsets.UTF_8)))
                         {
                             result.set(i);
                         }
@@ -744,13 +742,12 @@ public class ColumnFilter<T extends Comparable<T>>
                 {
                     for (int i = start; i < start + length; ++i)
                     {
-                        if (vector[i] >= lowerBound && vector[i] <= upperBound)
+                        if ((noNulls || !isNull[i]) && vector[i] >= lowerBound && vector[i] <= upperBound)
                         {
                             result.set(i);
                         }
                     }
                 }
-
             }
         }
         else
@@ -771,7 +768,7 @@ public class ColumnFilter<T extends Comparable<T>>
                 {
                     for (int i = start; i < start + length; ++i)
                     {
-                        if (includes.contains(vector[i]))
+                        if ((noNulls || !isNull[i]) && includes.contains(vector[i]))
                         {
                             result.set(i);
                         }
@@ -794,7 +791,7 @@ public class ColumnFilter<T extends Comparable<T>>
                 {
                     for (int i = start; i < start + length; ++i)
                     {
-                        if (!excludes.contains(vector[i]))
+                        if ((noNulls || !isNull[i]) && !excludes.contains(vector[i]))
                         {
                             result.set(i);
                         }

--- a/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/predicate/ColumnFilter.java
+++ b/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/predicate/ColumnFilter.java
@@ -240,7 +240,6 @@ public class ColumnFilter<T extends Comparable<T>>
                 DoubleColumnVector dcv = (DoubleColumnVector) columnVector;
                 doFilter(dcv.vector, dcv.noNulls ? null : dcv.isNull, start, length, result);
                 return;
-
             case STRING:
             case VARCHAR:
             case CHAR:

--- a/pixels-load/src/main/java/io/pixelsdb/pixels/load/Main.java
+++ b/pixels-load/src/main/java/io/pixelsdb/pixels/load/Main.java
@@ -58,7 +58,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 /**
  * pixels loader command line tool
  * <p>
- * LOAD -f pixels -o hdfs://dbiir27:9000/pixels/pixels/test_105/source -d pixels -t test_105 -n 220000 -r \t -c 16
+ * LOAD -f pixels -o s3://text-105/source -d pixels -t test_105 -n 220000 -r \t -c 16 -l s3://pixels-105/v-0-order
  * -p false [optional, default false]
  * </p>
  * <p>
@@ -75,7 +75,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * QUERY -t pixels -w /home/tao/software/station/bitbucket/105_dedup_query.txt -l /home/tao/software/station/bitbucket/pixels_duration_local.csv
  * </p>
  * <p>
- * COPY -p .pxl -s hdfs://dbiir27:9000/pixels/pixels/test_105/v_1_order -d hdfs://dbiir27:9000/pixels/pixels/test_105/v_1_order -n 3
+ * COPY -p .pxl -s hdfs://dbiir27:9000/pixels/pixels/test_105/v_1_order -d hdfs://dbiir27:9000/pixels/pixels/test_105/v_1_order -n 3 -c 3
  * </p>
  * <p>
  * COMPACT -s pixels -t test_105 -l 3 -n yes -c 8
@@ -376,7 +376,7 @@ public class Main
                     Storage destStorage = StorageFactory.Instance().getStorage(destination);
 
                     List<Status> files =  sourceStorage.listStatus(source);
-                    long blockSize = Long.parseLong(configFactory.getProperty("block.size")) * 1024l * 1024l;
+                    long blockSize = Long.parseLong(configFactory.getProperty("block.size"));
                     short replication = Short.parseShort(configFactory.getProperty("block.replication"));
 
                     // copy
@@ -507,7 +507,7 @@ public class Main
                     ConfigFactory configFactory = ConfigFactory.Instance();
                     Storage orderStorage = StorageFactory.Instance().getStorage(layout.getOrderPath());
                     Storage compactStorage = StorageFactory.Instance().getStorage(layout.getCompactPath());
-                    long blockSize = Long.parseLong(configFactory.getProperty("block.size")) * 1024l * 1024l;
+                    long blockSize = Long.parseLong(configFactory.getProperty("block.size"));
                     short replication = Short.parseShort(configFactory.getProperty("block.replication"));
                     List<Status> statuses = orderStorage.listStatus(layout.getOrderPath());
 

--- a/pixels-load/src/main/java/io/pixelsdb/pixels/load/ORCConsumer.java
+++ b/pixels-load/src/main/java/io/pixelsdb/pixels/load/ORCConsumer.java
@@ -77,8 +77,8 @@ public class ORCConsumer
 
             Properties prop = getProp();
             int pixelStride = Integer.parseInt(prop.getProperty("pixel.stride"));
-            int rowGroupSize = Integer.parseInt(prop.getProperty("row.group.size")) * 1024 * 1024;
-            long blockSize = Long.parseLong(prop.getProperty("block.size")) * 1024l * 1024l;
+            int rowGroupSize = Integer.parseInt(prop.getProperty("row.group.size"));
+            long blockSize = Long.parseLong(prop.getProperty("block.size"));
             short replication = Short.parseShort(prop.getProperty("block.replication"));
 
             Configuration conf = new Configuration();


### PR DESCRIPTION
Fix these bugs for the 105-column workload evaluation.
Timestamp now supports 0-6 precisions.