### PR TITLE
[Issue #258]: upgrade Prometheus dependencies.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <dep.protobuf.version>3.6.1</dep.protobuf.version>
         <dep.grpc.version>1.27.1</dep.grpc.version>
         <dep.jetcd.version>0.5.0</dep.jetcd.version>
-        <dep.prometheus.client.version>0.2.0</dep.prometheus.client.version>
+        <dep.prometheus.client.version>0.16.0</dep.prometheus.client.version>
         <dep.apache-httpclient.version>4.5.13</dep.apache-httpclient.version>
 
         <!-- logging -->
@@ -146,6 +146,16 @@
             <dependency>
                 <groupId>io.prometheus</groupId>
                 <artifactId>simpleclient_pushgateway</artifactId>
+                <version>${dep.prometheus.client.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.prometheus</groupId>
+                <artifactId>simpleclient_servlet</artifactId>
+                <version>${dep.prometheus.client.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.prometheus</groupId>
+                <artifactId>simpleclient_hotspot</artifactId>
                 <version>${dep.prometheus.client.version}</version>
             </dependency>
 


### PR DESCRIPTION
Added dependencies for simpleclient_servlet and simpleclient_hotspot.
Upgraded Prometheus version from 0.2.0 to 0.16.0