### PR TITLE
[Issue #170]: fix column stats recorders and split size capping.

### DIFF
--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/stats/BinaryStatsRecorder.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/stats/BinaryStatsRecorder.java
@@ -31,9 +31,7 @@ public class BinaryStatsRecorder
 {
     private long sum = 0L;
 
-    BinaryStatsRecorder()
-    {
-    }
+    BinaryStatsRecorder() { }
 
     BinaryStatsRecorder(PixelsProto.ColumnStatistic statistic)
     {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/stats/BooleanStatsRecorder.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/stats/BooleanStatsRecorder.java
@@ -31,9 +31,7 @@ public class BooleanStatsRecorder
 {
     private long trueCount = 0L;
 
-    BooleanStatsRecorder()
-    {
-    }
+    BooleanStatsRecorder() { }
 
     BooleanStatsRecorder(PixelsProto.ColumnStatistic statistic)
     {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/stats/RangeStats.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/stats/RangeStats.java
@@ -22,11 +22,21 @@ package io.pixelsdb.pixels.core.stats;
 /**
  * pixels
  *
- * @author guodong
+ * @author guodong, hank
  */
 public interface RangeStats<T>
 {
     T getMinimum();
 
     T getMaximum();
+
+    /**
+     * @return true if the minimum value is present.
+     */
+    boolean hasMinimum();
+
+    /**
+     * @return true if the maximum value is present.
+     */
+    boolean hasMaximum();
 }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/stats/StatsRecorder.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/stats/StatsRecorder.java
@@ -41,9 +41,7 @@ public class StatsRecorder
     long numberOfValues = 0L;
     private boolean hasNull = false;
 
-    StatsRecorder()
-    {
-    }
+    StatsRecorder() { }
 
     StatsRecorder(PixelsProto.ColumnStatistic statistic)
     {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/TimestampColumnVector.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/TimestampColumnVector.java
@@ -58,7 +58,7 @@ public class TimestampColumnVector extends ColumnVector
         return (int) (micros % MICROS_PER_SEC * NANOS_PER_MICROS);
     }
 
-    private static long timestampToMicros(Timestamp timestamp)
+    public static long timestampToMicros(Timestamp timestamp)
     {
         return timestamp.getTime() * MICROS_PER_MILLIS +
                 timestamp.getNanos() % NANOS_PER_MILLIS / NANOS_PER_MICROS;

--- a/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/PixelsExecutor.java
+++ b/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/PixelsExecutor.java
@@ -1220,7 +1220,7 @@ public class PixelsExecutor
                 {
                     List<String> orderedPaths = storage.listPaths(layout.getOrderPath());
 
-                    if (capSplitSizeByStatistics)
+                    if (capSplitSizeByStatistics && !orderedPaths.isEmpty())
                     {
                         int splitSizeCap = JoinAdvisor.Instance().getSplitSizeCap(table, orderedPaths.size());
                         if (splitSizeCap < splitSize)
@@ -1247,7 +1247,7 @@ public class PixelsExecutor
                 {
                     List<String> compactPaths = storage.listPaths(compactPath);
 
-                    if (capSplitSizeByStatistics)
+                    if (capSplitSizeByStatistics && !compactPaths.isEmpty())
                     {
                         int splitSizeCap = JoinAdvisor.Instance().getSplitSizeCap(
                                 table, compactPaths.size() * rowGroupNum);


### PR DESCRIPTION
Fix the two bugs:
1. The column statistics were not collected into and read from the files when there are null values.
2. The split size capping is not skipped when the input path is empty.