### PR TITLE
[Issue #170] add metadata cache and cost-based splits index.

### DIFF
--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/layout/CostBasedSplitsIndex.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/layout/CostBasedSplitsIndex.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2022 PixelsDB.
+ *
+ * This file is part of Pixels.
+ *
+ * Pixels is free software: you can redistribute it and/or modify
+ * it under the terms of the Affero GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * Pixels is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Affero GNU General Public License for more details.
+ *
+ * You should have received a copy of the Affero GNU General Public
+ * License along with Pixels.  If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package io.pixelsdb.pixels.common.layout;
+
+import io.pixelsdb.pixels.common.exception.MetadataException;
+import io.pixelsdb.pixels.common.metadata.SchemaTableName;
+import io.pixelsdb.pixels.common.metadata.MetadataCache;
+import io.pixelsdb.pixels.common.metadata.MetadataService;
+import io.pixelsdb.pixels.common.metadata.domain.Column;
+import io.pixelsdb.pixels.common.utils.ConfigFactory;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * The splits index that calculates the split size using the statistics.
+ * @author hank
+ * @date 13/07/2022
+ */
+public class CostBasedSplitsIndex implements SplitsIndex
+{
+    private static final int SPLIT_SIZE_BYTES;
+
+    static
+    {
+        String unit = ConfigFactory.Instance().getProperty("split.size.in.bytes");
+        SPLIT_SIZE_BYTES = Integer.parseInt(unit);
+    }
+
+    private int version;
+    private final int defaultSplitSize;
+    private final int maxSplitSize;
+    private final MetadataService metadataService;
+    private final Map<String, Column> columnMap;
+
+    public CostBasedSplitsIndex(MetadataService metadataService, SchemaTableName schemaTableName,
+                                int defaultSplitSize, int maxSplitSize)
+            throws MetadataException
+    {
+        checkArgument(defaultSplitSize > 0, "defaultSplitSize must be positive");
+        this.defaultSplitSize = defaultSplitSize;
+        checkArgument(maxSplitSize >= defaultSplitSize,
+                "maxSplitSize must be greater or equal to defaultSplitSize");
+        this.maxSplitSize = maxSplitSize;
+        this.metadataService = requireNonNull(metadataService, "metadataService is null");
+        requireNonNull(schemaTableName, "schemaTableName is null");
+
+        List<Column> columns = MetadataCache.Instance().getTableColumns(schemaTableName);
+        if (columns == null)
+        {
+            columns = this.metadataService.getColumns(
+                    schemaTableName.getSchemaName(), schemaTableName.getTableName(), true);
+            MetadataCache.Instance().cacheTableColumns(schemaTableName, columns);
+        }
+        this.columnMap = new HashMap<>(columns.size());
+        for (Column column : columns)
+        {
+            this.columnMap.put(column.getName(), column);
+        }
+    }
+
+    @Override
+    public SplitPattern search(ColumnSet columnSet)
+    {
+        SplitPattern bestPattern = new SplitPattern();
+
+        if (columnSet.isEmpty())
+        {
+            bestPattern.setSplitSize(this.defaultSplitSize);
+            return bestPattern;
+        }
+
+        double sumChunkSize = 0;
+        for (String column : columnSet.getColumns())
+        {
+            if (this.columnMap.containsKey(column))
+            {
+                sumChunkSize += columnMap.get(column).getChunkSize();
+            }
+        }
+
+        if (sumChunkSize >= SPLIT_SIZE_BYTES)
+        {
+            bestPattern.setSplitSize(1);
+        }
+        else
+        {
+            int splitSize = (int) Math.ceil(SPLIT_SIZE_BYTES / sumChunkSize);
+            // round the split size to be the power of 2.
+            splitSize = Integer.highestOneBit(splitSize - 1) << 1;
+            if (splitSize <= maxSplitSize)
+            {
+                bestPattern.setSplitSize(splitSize);
+            }
+            else
+            {
+                bestPattern.setSplitSize(maxSplitSize);
+            }
+        }
+
+        return bestPattern;
+    }
+
+    @Override
+    public int getVersion()
+    {
+        return version;
+    }
+
+    public void setVersion(int version)
+    {
+        this.version = version;
+    }
+}

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/layout/IndexFactory.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/layout/IndexFactory.java
@@ -19,6 +19,8 @@
  */
 package io.pixelsdb.pixels.common.layout;
 
+import io.pixelsdb.pixels.common.metadata.SchemaTableName;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -35,8 +37,8 @@ public class IndexFactory
         return instance;
     }
 
-    private Map<IndexName, SplitsIndex> splitsIndexes;
-    private Map<IndexName, ProjectionsIndex> projectionsIndexes;
+    private Map<SchemaTableName, SplitsIndex> splitsIndexes;
+    private Map<SchemaTableName, ProjectionsIndex> projectionsIndexes;
 
     private IndexFactory()
     {
@@ -44,22 +46,22 @@ public class IndexFactory
         this.projectionsIndexes = new HashMap<>();
     }
 
-    public void cacheSplitsIndex(IndexName entry, SplitsIndex splitsIndex)
+    public void cacheSplitsIndex(SchemaTableName entry, SplitsIndex splitsIndex)
     {
         this.splitsIndexes.put(entry, splitsIndex);
     }
 
-    public SplitsIndex getSplitsIndex(IndexName entry)
+    public SplitsIndex getSplitsIndex(SchemaTableName entry)
     {
         return this.splitsIndexes.get(entry);
     }
 
-    public void cacheProjectionsIndex(IndexName entry, ProjectionsIndex projectionsIndex)
+    public void cacheProjectionsIndex(SchemaTableName entry, ProjectionsIndex projectionsIndex)
     {
         this.projectionsIndexes.put(entry, projectionsIndex);
     }
 
-    public ProjectionsIndex getProjectionsIndex(IndexName entry)
+    public ProjectionsIndex getProjectionsIndex(SchemaTableName entry)
     {
         return this.projectionsIndexes.get(entry);
     }

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/layout/InvertedSplitsIndex.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/layout/InvertedSplitsIndex.java
@@ -26,14 +26,14 @@ import java.util.*;
  */
 public class InvertedSplitsIndex implements SplitsIndex
 {
-    /**
-     * key: column name;
-     * value: bit map
-     */
     private int version;
 
     private final int defaultSplitSize;
 
+    /**
+     * key: column name;
+     * value: bit map
+     */
     private Map<String, BitSet> bitMapIndex;
 
     private List<SplitPattern> querySplitPatterns;
@@ -120,6 +120,7 @@ public class InvertedSplitsIndex implements SplitsIndex
         return bestPattern;
     }
 
+    @Override
     public int getVersion()
     {
         return version;

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/layout/SplitsIndex.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/layout/SplitsIndex.java
@@ -3,6 +3,11 @@ package io.pixelsdb.pixels.common.layout;
 
 public interface SplitsIndex
 {
+    enum IndexType
+    {
+        INVERTED, COST_BASED
+    }
+
     /**
      * search viable split pattern for a column set
      *

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/metadata/MetadataCache.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/metadata/MetadataCache.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2022 PixelsDB.
+ *
+ * This file is part of Pixels.
+ *
+ * Pixels is free software: you can redistribute it and/or modify
+ * it under the terms of the Affero GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * Pixels is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Affero GNU General Public License for more details.
+ *
+ * You should have received a copy of the Affero GNU General Public
+ * License along with Pixels.  If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package io.pixelsdb.pixels.common.metadata;
+
+import com.google.common.collect.ImmutableList;
+import io.pixelsdb.pixels.common.metadata.domain.Column;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * @author hank
+ * @date 13/07/2022
+ */
+public class MetadataCache
+{
+    private static final MetadataCache instance = new MetadataCache();
+
+    public static MetadataCache Instance()
+    {
+        return instance;
+    }
+
+    private final Map<SchemaTableName, List<Column>> tableColumnsMap = new HashMap<>();
+
+    private MetadataCache() { }
+
+    public void cacheTableColumns(SchemaTableName schemaTableName, List<Column> columns)
+    {
+        requireNonNull(schemaTableName, "schemaTableName is null");
+        requireNonNull(columns, "columns is null");
+        this.tableColumnsMap.put(schemaTableName, ImmutableList.copyOf(columns));
+    }
+
+    /**
+     * Get the cached column metadata for the table.
+     * @param schemaTableName the schema and table name of the table
+     * @return null for cache miss
+     */
+    public List<Column> getTableColumns(SchemaTableName schemaTableName)
+    {
+        requireNonNull(schemaTableName, "schemaTableName is null");
+        return this.tableColumnsMap.get(schemaTableName);
+    }
+}

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/metadata/SchemaTableName.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/metadata/SchemaTableName.java
@@ -17,18 +17,20 @@
  * License along with Pixels.  If not, see
  * <https://www.gnu.org/licenses/>.
  */
-package io.pixelsdb.pixels.common.layout;
+package io.pixelsdb.pixels.common.metadata;
+
+import com.google.common.base.Objects;
 
 /**
- * @author: tao
+ * @author: tao, hank
  * @date: Create in 2018-06-19 14:46
  **/
-public class IndexName
+public class SchemaTableName
 {
-    private String schemaName;
-    private String tableName;
+    private final String schemaName;
+    private final String tableName;
 
-    public IndexName(String schemaName, String tableName)
+    public SchemaTableName(String schemaName, String tableName)
     {
         this.schemaName = schemaName;
         this.tableName = tableName;
@@ -39,19 +41,9 @@ public class IndexName
         return schemaName;
     }
 
-    public void setSchemaName(String schemaName)
-    {
-        this.schemaName = schemaName;
-    }
-
     public String getTableName()
     {
         return tableName;
-    }
-
-    public void setTableName(String tableName)
-    {
-        this.tableName = tableName;
     }
 
     @Override
@@ -59,18 +51,23 @@ public class IndexName
     {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-
-        IndexName that = (IndexName) o;
-
-        if (schemaName != null ? !schemaName.equals(that.schemaName) : that.schemaName != null) return false;
-        return tableName != null ? tableName.equals(that.tableName) : that.tableName == null;
+        SchemaTableName that = (SchemaTableName) o;
+        return Objects.equal(schemaName, that.schemaName) &&
+                Objects.equal(tableName, that.tableName);
     }
 
     @Override
     public int hashCode()
     {
-        int result = schemaName != null ? schemaName.hashCode() : 0;
-        result = 31 * result + (tableName != null ? tableName.hashCode() : 0);
-        return result;
+        return Objects.hashCode(schemaName, tableName);
+    }
+
+    @Override
+    public String toString()
+    {
+        return "SchemaTableName{" +
+                "schemaName='" + schemaName + '\'' +
+                ", tableName='" + tableName + '\'' +
+                '}';
     }
 }

--- a/pixels-common/src/main/resources/pixels.properties
+++ b/pixels-common/src/main/resources/pixels.properties
@@ -61,6 +61,10 @@ etcd.port=2379
 fixed.split.size=-1
 # true to enable just-in-time splitting in ordered path.
 multi.split.for.ordered=true
+# the size in bytes of the table scan split, 64MB by default
+split.size.in.bytes=67108864
+# the type of split size index to be used, can be cost_based or inverted
+splits.index.type=cost_based
 # which scheduler to use for read requests.
 # valid values: noop, sortmerge, ratelimited
 read.request.scheduler=sortmerge
@@ -92,13 +96,9 @@ executor.intermediate.folder=/pixels-lambda-test/
 # the number of threads used in each worker
 executor.intra.worker.parallelism=6
 # the maximum size of a broadcast table, the unit can be B/KB/MB/GB, must be capitalized.
-join.broadcast.threshold=200MB
+join.broadcast.threshold=256MB
 # the maximum (average) size of a partition in partitioned join.
-join.partition.size=256MB
-# if true, the max split size is capped by the split size calculated from statistics.
-join.cap.split-size.by.statistics=true
-# the size of data to be processed by each scan task on base table.
-join.base.table.scan.unit=64MB
+join.partition.size=512MB
 aggregation.compute.final.in.server=true
 # if the number partial aggregation files are larger than this threshold, pre-aggregation is used.
 aggregation.pre-aggr.threshold=64

--- a/pixels-common/src/test/java/io/pixelsdb/pixels/common/layout/TestCostBasedSplitsIndex.java
+++ b/pixels-common/src/test/java/io/pixelsdb/pixels/common/layout/TestCostBasedSplitsIndex.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 PixelsDB.
+ *
+ * This file is part of Pixels.
+ *
+ * Pixels is free software: you can redistribute it and/or modify
+ * it under the terms of the Affero GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * Pixels is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Affero GNU General Public License for more details.
+ *
+ * You should have received a copy of the Affero GNU General Public
+ * License along with Pixels.  If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package io.pixelsdb.pixels.common.layout;
+
+import io.pixelsdb.pixels.common.exception.MetadataException;
+import io.pixelsdb.pixels.common.metadata.MetadataService;
+import io.pixelsdb.pixels.common.metadata.SchemaTableName;
+import io.pixelsdb.pixels.common.utils.ConfigFactory;
+import org.junit.Test;
+
+/**
+ * @author hank
+ * @date 14/07/2022
+ */
+public class TestCostBasedSplitsIndex
+{
+    @Test
+    public void test() throws MetadataException
+    {
+        MetadataService metadataService = new MetadataService(
+                ConfigFactory.Instance().getProperty("metadata.server.host"),
+                Integer.parseInt(ConfigFactory.Instance().getProperty("metadata.server.port")));
+
+        CostBasedSplitsIndex index = new CostBasedSplitsIndex(metadataService,
+                new SchemaTableName("tpch", "orders"),4, 8);
+
+        ColumnSet columnSet = new ColumnSet();
+        columnSet.addColumn("o_orderkey");
+        columnSet.addColumn("o_custkey");
+        columnSet.addColumn("o_orderdate");
+        columnSet.addColumn("o_shippriority");
+
+        SplitPattern splitPattern = index.search(columnSet);
+        System.out.println(splitPattern.getSplitSize());
+    }
+}

--- a/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/PixelsExecutor.java
+++ b/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/PixelsExecutor.java
@@ -1268,7 +1268,7 @@ public class PixelsExecutor
         List<String> columnOrder = order.getColumnOrder();
         SplitsIndex index;
         String indexTypeName = ConfigFactory.Instance().getProperty("splits.index.type");
-        SplitsIndex.IndexType indexType = SplitsIndex.IndexType.valueOf(indexTypeName);
+        SplitsIndex.IndexType indexType = SplitsIndex.IndexType.valueOf(indexTypeName.toUpperCase());
         switch (indexType)
         {
             case INVERTED:

--- a/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/utils/Tuple.java
+++ b/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/utils/Tuple.java
@@ -103,19 +103,19 @@ public class Tuple
     @Override
     public boolean equals(Object obj)
     {
-        if (this == obj)
-        {
-            return true;
-        }
-        if (obj == null || getClass() != obj.getClass())
-        {
-            return false;
-        }
+//        if (this == obj)
+//        {
+//            return true;
+//        }
+//        if (obj == null || getClass() != obj.getClass())
+//        {
+//            return false;
+//        }
         Tuple other = (Tuple) obj;
-        if (this.commonFields.keyColumnIds.length != other.commonFields.keyColumnIds.length)
-        {
-            return false;
-        }
+//        if (this.commonFields.keyColumnIds.length != other.commonFields.keyColumnIds.length)
+//        {
+//            return false;
+//        }
         for (int i = 0; i < this.commonFields.keyColumnIds.length; ++i)
         {
             // We only support equi-joins, thus null value is considered not equal to anything.

--- a/pom.xml
+++ b/pom.xml
@@ -57,8 +57,8 @@
         <!-- storage systems -->
         <dep.hadoop.version>3.3.1</dep.hadoop.version>
         <dep.ozone.version>0.5.0-beta</dep.ozone.version>
-        <dep.awssdk.version>2.17.61</dep.awssdk.version>
-        <dep.awssdk.preview.version>2.17.61-PREVIEW</dep.awssdk.preview.version>
+        <dep.awssdk.version>2.17.231</dep.awssdk.version>
+        <dep.awssdk.preview.version>2.17.231-PREVIEW</dep.awssdk.preview.version>
 
         <!-- common libraries -->
         <dep.airlift.slice.version>0.34</dep.airlift.slice.version>


### PR DESCRIPTION
The split size capping is removed as it is not needed.