### PR TITLE
[Issue #170]: merge outputs in lambda worker.

### DIFF
--- a/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/lambda/input/JoinInput.java
+++ b/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/lambda/input/JoinInput.java
@@ -39,9 +39,8 @@ public class JoinInput extends Input
 
     /**
      * The information of the join output files.<br/>
-     * <b>Note: </b>for inner, right-outer, and natural joins, the number of output files
-     * should be consistent with the number of input splits in right table. For left-outer
-     * and full-outer joins, there is an additional output file for the left-outer records.
+     * <b>Note: </b>for inner, right-outer, and natural joins, there is only one output file.
+     * For left-outer and full-outer joins, there might be an additional output file for the left-outer records.
      */
     private MultiOutputInfo output;
 

--- a/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/predicate/TableScanFilter.java
+++ b/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/predicate/TableScanFilter.java
@@ -82,6 +82,11 @@ public class TableScanFilter
         return columnFilters.get(columnId);
     }
 
+    public boolean isEmpty()
+    {
+        return this.columnFilters.isEmpty();
+    }
+
     /**
      * Filter all the rows in the row batch using this table scan filter.
      * In the returned BitSet, the ith bit is set if the ith row in the row batch matches the filter.


### PR DESCRIPTION
In this way, we can reduce the number of intermediate files.
However, this sometimes leads to very large outputs and file writing overhead. We need to further optimize the write performance and the external parallelism.