### PR TITLE
[Issue #170]: add row count broadcast threshold.

### DIFF
--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/metadata/MetadataCache.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/metadata/MetadataCache.java
@@ -21,6 +21,7 @@ package io.pixelsdb.pixels.common.metadata;
 
 import com.google.common.collect.ImmutableList;
 import io.pixelsdb.pixels.common.metadata.domain.Column;
+import io.pixelsdb.pixels.common.metadata.domain.Table;
 
 import java.util.HashMap;
 import java.util.List;
@@ -43,7 +44,22 @@ public class MetadataCache
 
     private final Map<SchemaTableName, List<Column>> tableColumnsMap = new HashMap<>();
 
+    private final Map<SchemaTableName, Table> tableMap = new HashMap<>();
+
     private MetadataCache() { }
+
+    public void cacheTable(SchemaTableName schemaTableName, Table table)
+    {
+        requireNonNull(schemaTableName, "schemaTableName is null");
+        requireNonNull(table, "table is null");
+        this.tableMap.put(schemaTableName, table);
+    }
+
+    public Table getTable(SchemaTableName schemaTableName)
+    {
+        requireNonNull(schemaTableName, "schemaTableName is null");
+        return this.tableMap.get(schemaTableName);
+    }
 
     public void cacheTableColumns(SchemaTableName schemaTableName, List<Column> columns)
     {

--- a/pixels-common/src/main/resources/pixels.properties
+++ b/pixels-common/src/main/resources/pixels.properties
@@ -95,13 +95,15 @@ executor.stage.completion.ratio=0.6
 executor.intermediate.folder=/pixels-lambda-test/
 # the number of threads used in each worker
 executor.intra.worker.parallelism=6
-# the maximum size of a broadcast table, the unit can be B/KB/MB/GB, must be capitalized.
-join.broadcast.threshold=256MB
+# the maximum size in megabytes of a broadcast table.
+join.broadcast.threshold.mb=256
+# the maximum number of rows in a broadcast table.
+join.broadcast.threshold.rows=10000000
 # the maximum (average) size of a partition in partitioned join.
-join.partition.size=512MB
+join.partition.size.mb=512
 aggregation.compute.final.in.server=true
 # if the number partial aggregation files are larger than this threshold, pre-aggregation is used.
-aggregation.pre-aggr.threshold=64
+aggregation.pre-aggregate.threshold=64
 # the names of the cloud function workers
 scan.worker.name=ScanWorker
 partition.worker.name=PartitionWorker

--- a/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/PixelsExecutor.java
+++ b/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/PixelsExecutor.java
@@ -95,7 +95,7 @@ public class PixelsExecutor
         IntraWorkerParallelism = Integer.parseInt(ConfigFactory.Instance()
                 .getProperty("executor.intra.worker.parallelism"));
         PreAggrThreshold = Integer.parseInt(ConfigFactory.Instance()
-                .getProperty("aggregation.pre-aggr.threshold"));
+                .getProperty("aggregation.pre-aggregate.threshold"));
     }
 
     /**


### PR DESCRIPTION
Even though the input size of the table is small, if the table's row count is too large, it should not be broadcast.
Such a table would lead to OOM when building the hash table.