### PR TITLE
[Issue #170]: optimizations for large joins.

### DIFF
--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/layout/CostBasedSplitsIndex.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/layout/CostBasedSplitsIndex.java
@@ -98,9 +98,8 @@ public class CostBasedSplitsIndex implements SplitsIndex
             double rowsPerRowGroup = table.getRowCount() / numRowGroups;
             checkArgument(rowsPerRowGroup > 0,
                     "Number of rows per row-group must > 0.");
-            int splitSizeCap = (int) Math.ceil(SPLIT_SIZE_ROWS / rowsPerRowGroup);
-            // round the split size to be the power of 2.
-            splitSizeCap = Integer.highestOneBit(splitSizeCap - 1) << 1;
+            // Round the split size cap to the nearest power of 2.
+            int splitSizeCap = round(SPLIT_SIZE_ROWS / rowsPerRowGroup);
             this.maxSplitSize = Math.min(maxSplitSize, splitSizeCap);
         }
         else
@@ -129,26 +128,38 @@ public class CostBasedSplitsIndex implements SplitsIndex
             }
         }
 
-        if (sumChunkSize >= SPLIT_SIZE_BYTES)
+        // Round the split size to the nearest power of 2.
+        int splitSize = round(SPLIT_SIZE_BYTES / sumChunkSize);
+        if (splitSize <= maxSplitSize)
         {
-            bestPattern.setSplitSize(1);
+            bestPattern.setSplitSize(splitSize);
         }
         else
         {
-            int splitSize = (int) Math.round(SPLIT_SIZE_BYTES / sumChunkSize);
-            // round the split size to be the power of 2.
-            splitSize = Integer.highestOneBit(splitSize - 1) << 1;
-            if (splitSize <= maxSplitSize)
-            {
-                bestPattern.setSplitSize(splitSize);
-            }
-            else
-            {
-                bestPattern.setSplitSize(maxSplitSize);
-            }
+            bestPattern.setSplitSize(maxSplitSize);
         }
 
         return bestPattern;
+    }
+
+    /**
+     * Round the origin number to the nearest power of two.
+     * @param origin the origin number
+     * @return the rounded integer
+     */
+    private static int round(double origin)
+    {
+        int rounded1 = (int) Math.ceil(origin);
+        if (rounded1 == 1)
+        {
+            return rounded1;
+        }
+        int rounded2 = Integer.highestOneBit(rounded1 - 1) << 1;
+        if (origin /rounded2 < 0.75)
+        {
+            return rounded2 >> 1;
+        }
+        return rounded2;
     }
 
     @Override

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/layout/CostBasedSplitsIndex.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/layout/CostBasedSplitsIndex.java
@@ -135,7 +135,7 @@ public class CostBasedSplitsIndex implements SplitsIndex
         }
         else
         {
-            int splitSize = (int) Math.ceil(SPLIT_SIZE_BYTES / sumChunkSize);
+            int splitSize = (int) Math.round(SPLIT_SIZE_BYTES / sumChunkSize);
             // round the split size to be the power of 2.
             splitSize = Integer.highestOneBit(splitSize - 1) << 1;
             if (splitSize <= maxSplitSize)
@@ -155,6 +155,12 @@ public class CostBasedSplitsIndex implements SplitsIndex
     public int getVersion()
     {
         return version;
+    }
+
+    @Override
+    public int getMaxSplitSize()
+    {
+        return maxSplitSize;
     }
 
     public void setVersion(int version)

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/layout/InvertedSplitsIndex.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/layout/InvertedSplitsIndex.java
@@ -28,7 +28,7 @@ public class InvertedSplitsIndex implements SplitsIndex
 {
     private int version;
 
-    private final int defaultSplitSize;
+    private final int maxSplitSize;
 
     /**
      * key: column name;
@@ -40,9 +40,9 @@ public class InvertedSplitsIndex implements SplitsIndex
 
     private List<String> columnOrder;
 
-    public InvertedSplitsIndex(List<String> columnOrder, List<SplitPattern> patterns, int defaultSplitSize)
+    public InvertedSplitsIndex(List<String> columnOrder, List<SplitPattern> patterns, int maxSplitSize)
     {
-        this.defaultSplitSize = defaultSplitSize;
+        this.maxSplitSize = maxSplitSize;
         this.columnOrder = new ArrayList<>(columnOrder);
         this.querySplitPatterns = new ArrayList<>(patterns);
         this.bitMapIndex = new HashMap<>(this.columnOrder.size());
@@ -69,7 +69,7 @@ public class InvertedSplitsIndex implements SplitsIndex
         if (columnSet.isEmpty())
         {
             bestPattern = new SplitPattern();
-            bestPattern.setSplitSize(this.defaultSplitSize);
+            bestPattern.setSplitSize(this.maxSplitSize);
             return bestPattern;
         }
 
@@ -117,6 +117,11 @@ public class InvertedSplitsIndex implements SplitsIndex
             }
         }
 
+        if (bestPattern.getSplitSize() > maxSplitSize)
+        {
+            bestPattern.setSplitSize(maxSplitSize);
+        }
+
         return bestPattern;
     }
 
@@ -124,6 +129,12 @@ public class InvertedSplitsIndex implements SplitsIndex
     public int getVersion()
     {
         return version;
+    }
+
+    @Override
+    public int getMaxSplitSize()
+    {
+        return maxSplitSize;
     }
 
     public void setVersion(int version)

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/layout/SplitsIndex.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/layout/SplitsIndex.java
@@ -17,4 +17,6 @@ public interface SplitsIndex
     SplitPattern search(ColumnSet columnSet);
 
     int getVersion();
+
+    int getMaxSplitSize();
 }

--- a/pixels-common/src/main/resources/pixels.properties
+++ b/pixels-common/src/main/resources/pixels.properties
@@ -95,6 +95,7 @@ executor.input.storage=s3
 executor.intermediate.storage=s3
 executor.stage.completion.ratio=0.6
 executor.intermediate.folder=/pixels-lambda-test/
+executor.selectivity.enabled=true
 # the number of threads used in each worker
 executor.intra.worker.parallelism=8
 # the maximum size in megabytes of a broadcast table.

--- a/pixels-common/src/test/java/io/pixelsdb/pixels/common/physical/TestS3.java
+++ b/pixels-common/src/test/java/io/pixelsdb/pixels/common/physical/TestS3.java
@@ -105,7 +105,7 @@ public class TestS3
     public void testGetStatus() throws IOException
     {
         Storage storage = StorageFactory.Instance().getStorage(Storage.Scheme.s3);
-        Status status = storage.getStatus("/parquet-tpch/test/123/");
+        Status status = storage.getStatus("/pixels-tpch-1t/lineitem/");
         System.out.println(status.getLength());
         System.out.println(status.getName());
         System.out.println(status.getPath());
@@ -115,7 +115,7 @@ public class TestS3
     public void testListStatus() throws IOException
     {
         Storage storage = StorageFactory.Instance().getStorage("s3://pixels-tpch/customer/");
-        List<Status> statuses = storage.listStatus("s3://pixels-tpch/nation/v-0-order");
+        List<Status> statuses = storage.listStatus("s3://pixels-tpch-1t/lineitem/v-0-order");
         System.out.println(statuses.size());
         for (Status status : statuses)
         {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/stats/DateColumnStats.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/stats/DateColumnStats.java
@@ -25,9 +25,9 @@ package io.pixelsdb.pixels.core.stats;
  * 2021-04-25
  * @author hank
  */
-public interface DateColumnStats extends RangeStats<Long>
+public interface DateColumnStats extends RangeStats<Integer>
 {
-    Long getMinimum();
+    Integer getMinimum();
 
-    Long getMaximum();
+    Integer getMaximum();
 }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/stats/DateStatsRecorder.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/stats/DateStatsRecorder.java
@@ -23,6 +23,7 @@ import io.pixelsdb.pixels.core.PixelsProto;
 
 import java.sql.Date;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static io.pixelsdb.pixels.core.utils.DatetimeUtils.millisToDay;
 
 /**
@@ -186,6 +187,35 @@ public class DateStatsRecorder
     public boolean hasMaximum()
     {
         return hasMaximum;
+    }
+
+    @Override
+    public double getSelectivity(Object lowerBound, boolean lowerInclusive, Object upperBound, boolean upperInclusive)
+    {
+        if (!this.hasMinimum || !this.hasMaximum)
+        {
+            return -1;
+        }
+        long lower = minimum;
+        long upper = maximum;
+        if (lowerBound != null)
+        {
+            lower = (long) lowerBound;
+        }
+        if (upperBound != null)
+        {
+            upper = (long) upperBound;
+        }
+        checkArgument(lower <= upper, "lower bound must be larger than the upper bound");
+        if (lower < minimum)
+        {
+            lower = minimum;
+        }
+        if (upper > maximum)
+        {
+            upper = maximum;
+        }
+        return (upper - lower) / (double) (maximum - minimum);
     }
 
     @Override

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/stats/DateStatsRecorder.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/stats/DateStatsRecorder.java
@@ -126,7 +126,7 @@ public class DateStatsRecorder
             }
             if (dateStat.hasMaximum)
             {
-                if (hasMinimum)
+                if (hasMaximum)
                 {
                     if (dateStat.getMaximum() > maximum)
                     {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/stats/DateStatsRecorder.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/stats/DateStatsRecorder.java
@@ -37,8 +37,8 @@ public class DateStatsRecorder
 {
     private boolean hasMinimum = false;
     private boolean hasMaximum = false;
-    private long minimum = Integer.MIN_VALUE;
-    private long maximum = Integer.MAX_VALUE;
+    private int minimum = Integer.MIN_VALUE;
+    private int maximum = Integer.MAX_VALUE;
 
     DateStatsRecorder() { }
 
@@ -154,11 +154,11 @@ public class DateStatsRecorder
                 PixelsProto.DateStatistic.newBuilder();
         if (hasMinimum)
         {
-            dateBuilder.setMinimum((int) minimum);
+            dateBuilder.setMinimum(minimum);
         }
         if (hasMaximum)
         {
-            dateBuilder.setMaximum((int) maximum);
+            dateBuilder.setMaximum(maximum);
         }
         builder.setDateStatistics(dateBuilder);
         builder.setNumberOfValues(numberOfValues);
@@ -166,13 +166,13 @@ public class DateStatsRecorder
     }
 
     @Override
-    public Long getMinimum()
+    public Integer getMinimum()
     {
         return minimum;
     }
 
     @Override
-    public Long getMaximum()
+    public Integer getMaximum()
     {
         return maximum;
     }
@@ -196,15 +196,15 @@ public class DateStatsRecorder
         {
             return -1;
         }
-        long lower = minimum;
-        long upper = maximum;
+        int lower = minimum;
+        int upper = maximum;
         if (lowerBound != null)
         {
-            lower = (long) lowerBound;
+            lower = (int) lowerBound;
         }
         if (upperBound != null)
         {
-            upper = (long) upperBound;
+            upper = (int) upperBound;
         }
         checkArgument(lower <= upper, "lower bound must be larger than the upper bound");
         if (lower < minimum)

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/stats/DoubleStatsRecorder.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/stats/DoubleStatsRecorder.java
@@ -21,6 +21,8 @@ package io.pixelsdb.pixels.core.stats;
 
 import io.pixelsdb.pixels.core.PixelsProto;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 /**
  * pixels
  *
@@ -180,6 +182,35 @@ public class DoubleStatsRecorder
     public boolean hasMaximum()
     {
         return hasMaximum;
+    }
+
+    @Override
+    public double getSelectivity(Object lowerBound, boolean lowerInclusive, Object upperBound, boolean upperInclusive)
+    {
+        if (!this.hasMinimum || !this.hasMaximum)
+        {
+            return -1;
+        }
+        double lower = minimum;
+        double upper = maximum;
+        if (lowerBound != null)
+        {
+            lower = (double) lowerBound;
+        }
+        if (upperBound != null)
+        {
+            upper = (double) upperBound;
+        }
+        checkArgument(lower <= upper, "lower bound must be larger than the upper bound");
+        if (lower < minimum)
+        {
+            lower = minimum;
+        }
+        if (upper > maximum)
+        {
+            upper = maximum;
+        }
+        return (upper - lower) / (maximum - minimum);
     }
 
     @Override

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/stats/GeneralRangeStats.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/stats/GeneralRangeStats.java
@@ -23,6 +23,8 @@ import io.pixelsdb.pixels.core.TypeDescription;
 
 import java.math.BigDecimal;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 /**
  * This is the general stats to be used by Trino and pixels-optimizer.
  *
@@ -66,6 +68,35 @@ public class GeneralRangeStats implements RangeStats<Double>
     public boolean hasMaximum()
     {
         return hasMaximum;
+    }
+
+    @Override
+    public double getSelectivity(Object lowerBound, boolean lowerInclusive, Object upperBound, boolean upperInclusive)
+    {
+        if (!this.hasMinimum || !this.hasMaximum)
+        {
+            return -1;
+        }
+        double lower = minimum;
+        double upper = maximum;
+        if (lowerBound != null)
+        {
+            lower = (double) lowerBound;
+        }
+        if (upperBound != null)
+        {
+            upper = (double) upperBound;
+        }
+        checkArgument(lower <= upper, "lower bound must be larger than the upper bound");
+        if (lower < minimum)
+        {
+            lower = minimum;
+        }
+        if (upper > maximum)
+        {
+            upper = maximum;
+        }
+        return (upper - lower) / (maximum - minimum);
     }
 
     public static GeneralRangeStats fromStatsRecorder(TypeDescription type, IntegerStatsRecorder statsRecorder)

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/stats/Integer128StatsRecorder.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/stats/Integer128StatsRecorder.java
@@ -199,6 +199,36 @@ public class Integer128StatsRecorder
     }
 
     @Override
+    public double getSelectivity(Object lowerBound, boolean lowerInclusive, Object upperBound, boolean upperInclusive)
+    {
+        if (!this.hasMinimum || !this.hasMaximum)
+        {
+            return -1;
+        }
+        Integer128 lower = minimum;
+        Integer128 upper = maximum;
+        if (lowerBound != null)
+        {
+            lower = (Integer128) lowerBound;
+        }
+        if (upperBound != null)
+        {
+            upper = (Integer128) upperBound;
+        }
+        checkArgument(lower.compareTo(upper) < 0, "lower bound must be larger than the upper bound");
+        if (lower.compareTo(minimum) < 0)
+        {
+            lower = minimum;
+        }
+        if (upper.compareTo(maximum) > 0)
+        {
+            upper = maximum;
+        }
+        return (upper.toBigInteger().subtract(lower.toBigInteger()))
+                .divide(maximum.toBigInteger().subtract(minimum.toBigInteger())).doubleValue();
+    }
+
+    @Override
     public boolean isSumDefined()
     {
         return false;

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/stats/IntegerStatsRecorder.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/stats/IntegerStatsRecorder.java
@@ -21,6 +21,8 @@ package io.pixelsdb.pixels.core.stats;
 
 import io.pixelsdb.pixels.core.PixelsProto;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 /**
  * pixels
  *
@@ -204,6 +206,35 @@ public class IntegerStatsRecorder
     public boolean hasMaximum()
     {
         return hasMaximum;
+    }
+
+    @Override
+    public double getSelectivity(Object lowerBound, boolean lowerInclusive, Object upperBound, boolean upperInclusive)
+    {
+        if (!this.hasMinimum || !this.hasMaximum)
+        {
+            return -1;
+        }
+        long lower = minimum;
+        long upper = maximum;
+        if (lowerBound != null)
+        {
+            lower = (long) lowerBound;
+        }
+        if (upperBound != null)
+        {
+            upper = (long) upperBound;
+        }
+        checkArgument(lower <= upper, "lower bound must be larger than the upper bound");
+        if (lower < minimum)
+        {
+            lower = minimum;
+        }
+        if (upper > maximum)
+        {
+            upper = maximum;
+        }
+        return (upper - lower) / (double) (maximum - minimum);
     }
 
     @Override

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/stats/RangeStats.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/stats/RangeStats.java
@@ -39,4 +39,14 @@ public interface RangeStats<T>
      * @return true if the maximum value is present.
      */
     boolean hasMaximum();
+
+    /**
+     * Get the estimation of selectivity given the selection range.
+     * @param lowerBound the Pixels native value for the lower bound of the range, null if not lower bounded
+     * @param lowerInclusive true if the lower bound is included
+     * @param upperBound the Pixels native value for the upper bound of the range, null if not upper bounded
+     * @param upperInclusive true if the upper bound is included
+     * @return the estimated selectivity, for example 0.05 means 5%, negative if the selectivity can not be estimated
+     */
+    double getSelectivity(Object lowerBound, boolean lowerInclusive, Object upperBound, boolean upperInclusive);
 }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/stats/StatsRecorder.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/stats/StatsRecorder.java
@@ -280,6 +280,50 @@ public class StatsRecorder
         }
     }
 
+    public static StatsRecorder create(TypeDescription.Category category, PixelsProto.ColumnStatistic statistic)
+    {
+        switch (category)
+        {
+            case BOOLEAN:
+                return new BooleanStatsRecorder(statistic);
+            case BYTE:
+            case SHORT:
+            case INT:
+            case LONG:
+                return new IntegerStatsRecorder(statistic);
+            case DECIMAL:
+                /**
+                 * Issue #208:
+                 * To be compatible with Presto, use IntegerColumnStats for decimal.
+                 * Decimal and its statistics in Presto are represented as long. If
+                 * needed in other places, integer statistics can be converted to double
+                 * using the precision and scale from the type in the file footer.
+                 */
+                if (statistic.hasIntStatistics())
+                    return new IntegerStatsRecorder(statistic);
+                else
+                    return new Integer128StatsRecorder(statistic);
+            case FLOAT:
+            case DOUBLE:
+                return new DoubleStatsRecorder(statistic);
+            case STRING:
+            case CHAR:
+            case VARCHAR:
+                return new StringStatsRecorder(statistic);
+            case DATE:
+                return new DateStatsRecorder(statistic);
+            case TIME:
+                return new TimeStatsRecorder(statistic);
+            case TIMESTAMP:
+                return new TimestampStatsRecorder(statistic);
+            case BINARY:
+            case VARBINARY:
+                return new BinaryStatsRecorder(statistic);
+            default:
+                return new StatsRecorder(statistic);
+        }
+    }
+
     /**
      * Cast the range stats to general range stats according to the type of the columns.
      *

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/stats/StringStatsRecorder.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/stats/StringStatsRecorder.java
@@ -194,6 +194,12 @@ public class StringStatsRecorder
         return maximum != null;
     }
 
+    @Override
+    public double getSelectivity(Object lowerBound, boolean lowerInclusive, Object upperBound, boolean upperInclusive)
+    {
+        throw new UnsupportedOperationException("selectivity is not supported on string columns");
+    }
+
     /**
      * Get the total length of all strings
      *

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/stats/TimeStatsRecorder.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/stats/TimeStatsRecorder.java
@@ -23,6 +23,8 @@ import io.pixelsdb.pixels.core.PixelsProto;
 
 import java.sql.Time;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 /**
  * pixels
  *
@@ -188,6 +190,35 @@ public class TimeStatsRecorder
     public boolean hasMaximum()
     {
         return hasMaximum;
+    }
+
+    @Override
+    public double getSelectivity(Object lowerBound, boolean lowerInclusive, Object upperBound, boolean upperInclusive)
+    {
+        if (!this.hasMinimum || !this.hasMaximum)
+        {
+            return -1;
+        }
+        int lower = minimum;
+        int upper = maximum;
+        if (lowerBound != null)
+        {
+            lower = (int) lowerBound;
+        }
+        if (upperBound != null)
+        {
+            upper = (int) upperBound;
+        }
+        checkArgument(lower <= upper, "lower bound must be larger than the upper bound");
+        if (lower < minimum)
+        {
+            lower = minimum;
+        }
+        if (upper > maximum)
+        {
+            upper = maximum;
+        }
+        return (upper - lower) / (double) (maximum - minimum);
     }
 
     @Override

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/stats/TimestampStatsRecorder.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/stats/TimestampStatsRecorder.java
@@ -23,6 +23,7 @@ import io.pixelsdb.pixels.core.PixelsProto;
 
 import java.sql.Timestamp;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static io.pixelsdb.pixels.core.vector.TimestampColumnVector.timestampToMicros;
 
 /**
@@ -187,6 +188,35 @@ public class TimestampStatsRecorder
     public boolean hasMaximum()
     {
         return hasMaximum;
+    }
+
+    @Override
+    public double getSelectivity(Object lowerBound, boolean lowerInclusive, Object upperBound, boolean upperInclusive)
+    {
+        if (!this.hasMinimum || !this.hasMaximum)
+        {
+            return -1;
+        }
+        long lower = minimum;
+        long upper = maximum;
+        if (lowerBound != null)
+        {
+            lower = (long) lowerBound;
+        }
+        if (upperBound != null)
+        {
+            upper = (long) upperBound;
+        }
+        checkArgument(lower <= upper, "lower bound must be larger than the upper bound");
+        if (lower < minimum)
+        {
+            lower = minimum;
+        }
+        if (upper > maximum)
+        {
+            upper = maximum;
+        }
+        return (upper - lower) / (double) (maximum - minimum);
     }
 
     @Override

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/BinaryColumnVector.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/BinaryColumnVector.java
@@ -232,9 +232,9 @@ public class BinaryColumnVector extends ColumnVector
             int p = this.start[i];
             for (int j = this.start[i] + this.lens[i] - 1; j >= p; j--)
             {
-                h = 31 * h + (int)this.vector[i][j];
+                h = 524287 * h + (int)this.vector[i][j];
             }
-            hashCode[i] = 31 * hashCode[i] + h;
+            hashCode[i] = 524287 * hashCode[i] + h;
         }
         return hashCode;
     }
@@ -260,6 +260,29 @@ public class BinaryColumnVector extends ColumnVector
             return true;
         }
         return false;
+    }
+
+    @Override
+    public int compareElement(int index, int otherIndex, ColumnVector other)
+    {
+        BinaryColumnVector otherVector = (BinaryColumnVector) other;
+        if (!this.isNull[index] && !otherVector.isNull[otherIndex])
+        {
+            if (this.lens[index] != otherVector.lens[otherIndex])
+            {
+                return Integer.compare(this.lens[index], otherVector.lens[otherIndex]);
+            }
+            int start = this.start[index], otherStart = otherVector.start[otherIndex];
+            for (int i = 0; i < this.lens[index]; ++i)
+            {
+                if (this.vector[index][start+i] != otherVector.vector[otherIndex][otherStart+i])
+                {
+                    return Byte.compare(this.vector[index][start+i], otherVector.vector[otherIndex][otherStart+i]);
+                }
+            }
+            return 0;
+        }
+        return this.isNull[index] ? -1 : 1;
     }
 
     /**

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/ByteColumnVector.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/ByteColumnVector.java
@@ -96,7 +96,7 @@ public class ByteColumnVector extends ColumnVector
             {
                 continue;
             }
-            hashCode[i] = 31 * hashCode[i] + this.vector[i];
+            hashCode[i] = 524287 * hashCode[i] + this.vector[i];
         }
         return hashCode;
     }
@@ -110,6 +110,17 @@ public class ByteColumnVector extends ColumnVector
             return this.vector[index] == otherVector.vector[otherIndex];
         }
         return false;
+    }
+
+    @Override
+    public int compareElement(int index, int otherIndex, ColumnVector other)
+    {
+        ByteColumnVector otherVector = (ByteColumnVector) other;
+        if (!this.isNull[index] && !otherVector.isNull[otherIndex])
+        {
+            return Byte.compare(this.vector[index], otherVector.vector[otherIndex]);
+        }
+        return this.isNull[index] ? -1 : 1;
     }
 
     @Override

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/ColumnVector.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/ColumnVector.java
@@ -242,6 +242,18 @@ public abstract class ColumnVector implements AutoCloseable
     public abstract boolean elementEquals(int index, int otherIndex, ColumnVector other);
 
     /**
+     * Compare the elements in this and the other column vector.
+     * <b>Note</b> that null value is considered smaller than any values including null.
+     *
+     * @param index the index in this column vector
+     * @param otherIndex the index in the other column vector
+     * @param other the other column vector
+     * @return 1 if the element in this vector is larger, 0 if the two elements are equivalent, and
+     * -1 if the element in this vector is smaller.
+     */
+    public abstract int compareElement(int index, int otherIndex, ColumnVector other);
+
+    /**
      * Resets the column to default state
      * - fills the isNull array with false
      * - sets noNulls to true

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/DateColumnVector.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/DateColumnVector.java
@@ -106,7 +106,7 @@ public class DateColumnVector extends ColumnVector
             {
                 continue;
             }
-            hashCode[i] = 31 * hashCode[i] + this.dates[i];
+            hashCode[i] = 524287 * hashCode[i] + this.dates[i];
         }
         return hashCode;
     }
@@ -120,7 +120,17 @@ public class DateColumnVector extends ColumnVector
             return this.dates[index] == otherVector.dates[otherIndex];
         }
         return false;
+    }
 
+    @Override
+    public int compareElement(int index, int otherIndex, ColumnVector other)
+    {
+        DateColumnVector otherVector = (DateColumnVector) other;
+        if (!this.isNull[index] && !otherVector.isNull[otherIndex])
+        {
+            return Integer.compare(this.dates[index], otherVector.dates[otherIndex]);
+        }
+        return this.isNull[index] ? -1 : 1;
     }
 
     /**

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/DecimalColumnVector.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/DecimalColumnVector.java
@@ -252,7 +252,7 @@ public class DecimalColumnVector extends ColumnVector
             {
                 continue;
             }
-            hashCode[i] = 31 * hashCode[i] + (int)(this.vector[i] ^ (this.vector[i] >>> 32));
+            hashCode[i] = 524287 * hashCode[i] + (int)(this.vector[i] ^ (this.vector[i] >>> 32));
         }
         return hashCode;
     }
@@ -268,6 +268,22 @@ public class DecimalColumnVector extends ColumnVector
             // We assume the values never overflow and do not check the precisions.
         }
         return false;
+    }
+
+    @Override
+    public int compareElement(int index, int otherIndex, ColumnVector other)
+    {
+        DecimalColumnVector otherVector = (DecimalColumnVector) other;
+        if (!this.isNull[index] && !otherVector.isNull[otherIndex])
+        {
+            if (this.vector[index] != otherVector.vector[otherIndex])
+            {
+                return Long.compare(this.vector[index],otherVector.vector[otherIndex]);
+            }
+            return Integer.compare(this.scale, otherVector.scale);
+            // We assume the values never overflow and do not check the precisions.
+        }
+        return this.isNull[index] ? -1 : 1;
     }
 
 

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/DoubleColumnVector.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/DoubleColumnVector.java
@@ -185,7 +185,7 @@ public class DoubleColumnVector extends ColumnVector
             {
                 continue;
             }
-            hashCode[i] = 31 * hashCode[i] + (int)(this.vector[i] ^ (this.vector[i] >>> 32));
+            hashCode[i] = 524287 * hashCode[i] + (int)(this.vector[i] ^ (this.vector[i] >>> 32));
         }
         return hashCode;
     }
@@ -199,6 +199,17 @@ public class DoubleColumnVector extends ColumnVector
             return this.vector[index] == otherVector.vector[otherIndex];
         }
         return false;
+    }
+
+    @Override
+    public int compareElement(int index, int otherIndex, ColumnVector other)
+    {
+        DoubleColumnVector otherVector = (DoubleColumnVector) other;
+        if (!this.isNull[index] && !otherVector.isNull[otherIndex])
+        {
+            return Long.compare(this.vector[index], otherVector.vector[otherIndex]);
+        }
+        return this.isNull[index] ? -1 : 1;
     }
 
     @Override

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/LongColumnVector.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/LongColumnVector.java
@@ -111,7 +111,7 @@ public class LongColumnVector extends ColumnVector
             {
                 continue;
             }
-            hashCode[i] = 31 * hashCode[i] + (int)(this.vector[i] ^ (this.vector[i] >>> 32));
+            hashCode[i] = 524287 * hashCode[i] + (int)(this.vector[i] ^ (this.vector[i] >>> 32));
         }
         return hashCode;
     }
@@ -125,6 +125,18 @@ public class LongColumnVector extends ColumnVector
             return this.vector[index] == otherVector.vector[otherIndex];
         }
         return false;
+    }
+
+    @Override
+    public int compareElement(int index, int otherIndex, ColumnVector other)
+    {
+        LongColumnVector otherVector = (LongColumnVector) other;
+        if (!this.isNull[index] && !otherVector.isNull[otherIndex])
+        {
+            return this.vector[index] < otherVector.vector[otherIndex] ? -1 :
+                    (this.vector[index] == otherVector.vector[otherIndex] ? 0 : 1);
+        }
+        return this.isNull[index] ? -1 : 1;
     }
 
     // Fill the column vector with the provided value

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/LongDecimalColumnVector.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/LongDecimalColumnVector.java
@@ -289,7 +289,7 @@ public class LongDecimalColumnVector extends ColumnVector
             hash = 0x9E3779B185EBCA87L;
             hash = (hash ^ this.vector[i*2]) * 0xC2B2AE3D27D4EB4FL;
             hash = (hash ^ this.vector[i*2+1]) * 0xC2B2AE3D27D4EB4FL;
-            hashCode[i] = 31 * hashCode[i] + Long.hashCode(hash);
+            hashCode[i] = 524287 * hashCode[i] + Long.hashCode(hash);
         }
         return hashCode;
     }
@@ -306,6 +306,26 @@ public class LongDecimalColumnVector extends ColumnVector
             // We assume the values never overflow and do not check the precisions.
         }
         return false;
+    }
+
+    @Override
+    public int compareElement(int index, int otherIndex, ColumnVector other)
+    {
+        LongDecimalColumnVector otherVector = (LongDecimalColumnVector) other;
+        if (!this.isNull[index] && !otherVector.isNull[otherIndex])
+        {
+            if (this.vector[index*2] != otherVector.vector[otherIndex*2])
+            {
+                return Long.compare(this.vector[index*2], otherVector.vector[otherIndex*2]);
+            }
+            if (this.vector[index*2+1] != otherVector.vector[otherIndex*2+1])
+            {
+                return Long.compare(this.vector[index*2+1], otherVector.vector[otherIndex*2+1]);
+            }
+            return Integer.compare(this.scale, otherVector.scale);
+            // We assume the values never overflow and do not check the precisions.
+        }
+        return this.isNull[index] ? -1 : 1;
     }
 
 

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/StructColumnVector.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/StructColumnVector.java
@@ -181,6 +181,25 @@ public class StructColumnVector extends ColumnVector
     }
 
     @Override
+    public int compareElement(int index, int otherIndex, ColumnVector other)
+    {
+        StructColumnVector otherVector = (StructColumnVector) other;
+        if (!this.isNull[index] && !otherVector.isNull[otherIndex])
+        {
+            for (int i = 0; i < this.fields.length; ++i)
+            {
+                int c = this.fields[i].compareElement(index, otherIndex, otherVector.fields[i]);
+                if (c != 0)
+                {
+                    return c;
+                }
+            }
+            return 0;
+        }
+        return this.isNull[index] ? -1 : 1;
+    }
+
+    @Override
     public void reset()
     {
         super.reset();

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/TimeColumnVector.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/TimeColumnVector.java
@@ -101,7 +101,7 @@ public class TimeColumnVector extends ColumnVector
             {
                 continue;
             }
-            hashCode[i] = 31 * hashCode[i] + this.times[i];
+            hashCode[i] = 524287 * hashCode[i] + this.times[i];
         }
         return hashCode;
     }
@@ -115,6 +115,17 @@ public class TimeColumnVector extends ColumnVector
             return this.times[index] == otherVector.times[otherIndex];
         }
         return false;
+    }
+
+    @Override
+    public int compareElement(int index, int otherIndex, ColumnVector other)
+    {
+        TimeColumnVector otherVector = (TimeColumnVector) other;
+        if (!this.isNull[index] && !otherVector.isNull[otherIndex])
+        {
+            return Integer.compare(this.times[index], otherVector.times[otherIndex]);
+        }
+        return this.isNull[index] ? -1 : 1;
     }
 
     /**

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/TimestampColumnVector.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/TimestampColumnVector.java
@@ -136,7 +136,7 @@ public class TimestampColumnVector extends ColumnVector
             {
                 continue;
             }
-            hashCode[i] = 31 * hashCode[i] + (int)(this.times[i] ^ (this.times[i] >>> 32));
+            hashCode[i] = 524287 * hashCode[i] + (int)(this.times[i] ^ (this.times[i] >>> 32));
         }
         return hashCode;
     }
@@ -151,6 +151,18 @@ public class TimestampColumnVector extends ColumnVector
             return this.times[index] == otherVector.times[otherIndex];
         }
         return false;
+    }
+
+    @Override
+    public int compareElement(int index, int otherIndex, ColumnVector other)
+    {
+        TimestampColumnVector otherVector = (TimestampColumnVector) other;
+        if (!this.isNull[index] && !otherVector.isNull[otherIndex])
+        {
+            // if times are equal, precision does not matter.
+            return Long.compare(this.times[index], otherVector.times[otherIndex]);
+        }
+        return this.isNull[index] ? -1 : 1;
     }
 
     /**

--- a/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/PixelsExecutor.java
+++ b/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/PixelsExecutor.java
@@ -21,6 +21,7 @@ package io.pixelsdb.pixels.executor;
 
 import com.alibaba.fastjson.JSON;
 import com.google.common.collect.ImmutableList;
+import com.google.protobuf.InvalidProtocolBufferException;
 import io.pixelsdb.pixels.common.exception.InvalidArgumentException;
 import io.pixelsdb.pixels.common.exception.MetadataException;
 import io.pixelsdb.pixels.common.layout.*;
@@ -1084,7 +1085,8 @@ public class PixelsExecutor
      */
     private List<JoinInput> getPartitionedJoinInputs(
             JoinedTable joinedTable, Optional<JoinedTable> parent, int numPartition,
-            PartitionedTableInfo leftTableInfo, PartitionedTableInfo rightTableInfo) throws MetadataException
+            PartitionedTableInfo leftTableInfo, PartitionedTableInfo rightTableInfo)
+            throws MetadataException, InvalidProtocolBufferException
     {
         boolean postPartition = false;
         PartitionInfo postPartitionInfo = null;

--- a/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/PixelsExecutor.java
+++ b/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/PixelsExecutor.java
@@ -1194,8 +1194,23 @@ public class PixelsExecutor
                     }
                 }
                 SplitPattern bestSplitPattern = splitsIndex.search(columnSet);
-                // log.info("bestPattern: " + bestPattern.toString());
                 splitSize = bestSplitPattern.getSplitSize();
+                double selectivity = JoinAdvisor.Instance().getTableSelectivity(table);
+                if (selectivity >= 0)
+                {
+                    // Increasing split size according to the selectivity.
+                    if (selectivity < 0.25)
+                    {
+                        splitSize *= 4;
+                    } else if (selectivity < 0.5)
+                    {
+                        splitSize *= 2;
+                    }
+                    if (splitSize > splitsIndex.getMaxSplitSize())
+                    {
+                        splitSize = splitsIndex.getMaxSplitSize();
+                    }
+                }
             }
             logger.debug("using split size: " + splitSize);
             int rowGroupNum = splits.getNumRowGroupInBlock();

--- a/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/PixelsExecutor.java
+++ b/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/PixelsExecutor.java
@@ -775,8 +775,8 @@ public class PixelsExecutor
             }
 
             int internalParallelism = IntraWorkerParallelism;
-            if (leftTable.getTableType() == BASE && ((BaseTable) leftTable).getFilter().isEmpty())// &&
-                    //rightTable.getFilter().isEmpty() && (leftInputSplits.size() <= 128 && rightInputSplits.size() <= 128))
+            if (leftTable.getTableType() == BASE && ((BaseTable) leftTable).getFilter().isEmpty() &&
+                    rightTable.getFilter().isEmpty())// && (leftInputSplits.size() <= 128 && rightInputSplits.size() <= 128))
             {
                 /*
                  * This is used to reduce the latency of join result writing, by increasing the

--- a/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/PixelsExecutor.java
+++ b/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/PixelsExecutor.java
@@ -214,7 +214,7 @@ public class PixelsExecutor
                 scanInput.setPartialAggregationPresent(true);
                 scanInput.setPartialAggregationInfo(partialAggregationInfo);
                 String fileName = computeFinalAggrInServer && !preAggregate ? finalOutputBase : intermediateBase;
-                fileName += "partial_aggr_" + outputId++;
+                fileName += (outputId++) + "/partial_aggr";
                 StorageInfo storageInfo;
                 if (computeFinalAggrInServer && !preAggregate)
                 {
@@ -312,7 +312,7 @@ public class PixelsExecutor
                 preAggrInput.setParallelism(IntraWorkerParallelism);
 
                 String fileName = computeFinalAggrInServer ? finalOutputBase : intermediateBase;
-                fileName += "pre_aggr_" + outputId++;
+                fileName += (outputId++) + "/pre_aggr";
                 preAggrInput.setOutput(new OutputInfo(fileName, false,
                         outputStorageInfo, true));
                 finalAggrInputFilesBuilder.add(fileName);
@@ -431,7 +431,7 @@ public class PixelsExecutor
                     {
                         ImmutableList.Builder<InputSplit> inputsBuilder = ImmutableList
                                 .builderWithExpectedSize(IntraWorkerParallelism);
-                        ImmutableList<String> outputs = ImmutableList.of("join_" + outputId++);
+                        ImmutableList<String> outputs = ImmutableList.of((outputId++) + "/join");
                         for (int j = 0; j < IntraWorkerParallelism && i < rightInputSplits.size(); ++j, ++i)
                         {
                             inputsBuilder.add(rightInputSplits.get(i));
@@ -703,7 +703,7 @@ public class PixelsExecutor
                     {
                         ImmutableList.Builder<InputSplit> inputsBuilder = ImmutableList
                                 .builderWithExpectedSize(IntraWorkerParallelism);
-                        ImmutableList<String> outputs = ImmutableList.of("join_" + outputId++);
+                        ImmutableList<String> outputs = ImmutableList.of((outputId++) + "/join");
                         for (int j = 0; j < IntraWorkerParallelism && i < rightInputSplits.size(); ++j, ++i)
                         {
                             inputsBuilder.add(rightInputSplits.get(i));
@@ -800,7 +800,7 @@ public class PixelsExecutor
                 {
                     ImmutableList.Builder<InputSplit> inputsBuilder = ImmutableList
                             .builderWithExpectedSize(internalParallelism);
-                    ImmutableList<String> outputs = ImmutableList.of("join_" + outputId++);
+                    ImmutableList<String> outputs = ImmutableList.of((outputId++) + "/join");
                     for (int j = 0; j < internalParallelism && i < rightInputSplits.size(); ++j, ++i)
                     {
                         inputsBuilder.add(rightInputSplits.get(i));
@@ -835,7 +835,7 @@ public class PixelsExecutor
                 {
                     ImmutableList.Builder<InputSplit> inputsBuilder = ImmutableList
                             .builderWithExpectedSize(internalParallelism);
-                    ImmutableList<String> outputs = ImmutableList.of("join_" + outputId++);
+                    ImmutableList<String> outputs = ImmutableList.of((outputId++) + "/join");
                     for (int j = 0; j < internalParallelism && i < leftInputSplits.size(); ++j, ++i)
                     {
                         inputsBuilder.add(leftInputSplits.get(i));
@@ -884,7 +884,7 @@ public class PixelsExecutor
                 List<PartitionInput> rightPartitionInputs = getPartitionInputs(
                         rightTable, rightInputSplits, rightKeyColumnIds, numPartition,
                         IntermediateFolder + queryId + "/" + joinedTable.getSchemaName() + "/" +
-                                joinedTable.getTableName() + "/" + rightTable.getTableName() + "/part-");
+                                joinedTable.getTableName() + "/" + rightTable.getTableName() + "/");
 
                 PartitionedTableInfo rightTableInfo = getPartitionedTableInfo(
                         rightTable, rightKeyColumnIds, rightPartitionInputs);
@@ -911,14 +911,14 @@ public class PixelsExecutor
                 List<PartitionInput> leftPartitionInputs = getPartitionInputs(
                         leftTable, leftInputSplits, leftKeyColumnIds, numPartition,
                         IntermediateFolder + queryId + "/" + joinedTable.getSchemaName() + "/" +
-                                joinedTable.getTableName() + "/" + leftTable.getTableName() + "/part-");
+                                joinedTable.getTableName() + "/" + leftTable.getTableName() + "/");
                 PartitionedTableInfo leftTableInfo = getPartitionedTableInfo(
                         leftTable, leftKeyColumnIds, leftPartitionInputs);
 
                 List<PartitionInput> rightPartitionInputs = getPartitionInputs(
                         rightTable, rightInputSplits, rightKeyColumnIds, numPartition,
                         IntermediateFolder + queryId + "/" + joinedTable.getSchemaName() + "/" +
-                                joinedTable.getTableName() + "/" + rightTable.getTableName() + "/part-");
+                                joinedTable.getTableName() + "/" + rightTable.getTableName() + "/");
                 PartitionedTableInfo rightTableInfo = getPartitionedTableInfo(
                         rightTable, rightKeyColumnIds, rightPartitionInputs);
 
@@ -1063,7 +1063,7 @@ public class PixelsExecutor
                         TableScanFilter.empty(inputTable.getSchemaName(), inputTable.getTableName())));
             }
             partitionInput.setTableInfo(tableInfo);
-            partitionInput.setOutput(new OutputInfo(outputBase + outputId++, false,
+            partitionInput.setOutput(new OutputInfo(outputBase + (outputId++) + "/part", false,
                     new StorageInfo(InputStorage, null, null, null), true));
             partitionInput.setPartitionInfo(new PartitionInfo(keyColumnIds, numPartition));
             partitionInputsBuilder.add(partitionInput);
@@ -1113,11 +1113,11 @@ public class PixelsExecutor
         {
             ImmutableList.Builder<String> outputFileNames = ImmutableList
                     .builderWithExpectedSize(IntraWorkerParallelism);
-            outputFileNames.add("join_" + i);
+            outputFileNames.add(i + "/join");
             if (joinedTable.getJoin().getJoinType() == JoinType.EQUI_LEFT ||
                     joinedTable.getJoin().getJoinType() == JoinType.EQUI_FULL)
             {
-                outputFileNames.add("join_" + i + "_left");
+                outputFileNames.add(i + "/join_left");
             }
 
             String path = IntermediateFolder + queryId + "/" + joinedTable.getSchemaName() + "/" +

--- a/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/join/JoinAdvisor.java
+++ b/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/join/JoinAdvisor.java
@@ -19,6 +19,7 @@
  */
 package io.pixelsdb.pixels.executor.join;
 
+import com.alibaba.fastjson.JSON;
 import com.google.protobuf.InvalidProtocolBufferException;
 import io.pixelsdb.pixels.common.exception.MetadataException;
 import io.pixelsdb.pixels.common.metadata.MetadataCache;
@@ -232,6 +233,12 @@ public class JoinAdvisor
                     ByteBuffer buffer = column.getRecordStats();
                     PixelsProto.ColumnStatistic columnStats = PixelsProto.ColumnStatistic.parseFrom(buffer);
                     double s = columnFilter.getSelectivity(column.getNullFraction(), column.getCardinality(), columnStats);
+                    if (columnStats.hasDateStatistics())
+                    {
+                        PixelsProto.DateStatistic dateStatistic = columnStats.getDateStatistics();
+                        logger.info("column " + column.getName() + " min: " + dateStatistic.getMinimum() + ", max: " + dateStatistic.getMaximum()
+                        + ", selectivity: " + s + ", columnFilter: " + JSON.toJSONString(columnFilter));
+                    }
                     if (s >= 0 && s < selectivity)
                     {
                         // Use the minimum selectivity of the columns as the selectivity on this table.

--- a/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/join/JoinAdvisor.java
+++ b/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/join/JoinAdvisor.java
@@ -19,16 +19,24 @@
  */
 package io.pixelsdb.pixels.executor.join;
 
+import com.google.protobuf.InvalidProtocolBufferException;
 import io.pixelsdb.pixels.common.exception.MetadataException;
 import io.pixelsdb.pixels.common.metadata.MetadataCache;
 import io.pixelsdb.pixels.common.metadata.MetadataService;
 import io.pixelsdb.pixels.common.metadata.SchemaTableName;
 import io.pixelsdb.pixels.common.metadata.domain.Column;
 import io.pixelsdb.pixels.common.utils.ConfigFactory;
+import io.pixelsdb.pixels.core.PixelsProto;
+import io.pixelsdb.pixels.executor.plan.BaseTable;
 import io.pixelsdb.pixels.executor.plan.JoinEndian;
 import io.pixelsdb.pixels.executor.plan.JoinedTable;
 import io.pixelsdb.pixels.executor.plan.Table;
+import io.pixelsdb.pixels.executor.predicate.ColumnFilter;
+import io.pixelsdb.pixels.executor.predicate.TableScanFilter;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
+import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -45,6 +53,7 @@ import static io.pixelsdb.pixels.executor.plan.Table.TableType.JOINED;
  */
 public class JoinAdvisor
 {
+    private static final Logger logger = LogManager.getLogger(JoinAdvisor.class);
     private static final JoinAdvisor instance = new JoinAdvisor();
 
     public static JoinAdvisor Instance()
@@ -79,19 +88,23 @@ public class JoinAdvisor
     }
 
     public JoinAlgorithm getJoinAlgorithm(Table leftTable, Table rightTable, JoinEndian joinEndian)
-            throws MetadataException
+            throws MetadataException, InvalidProtocolBufferException
     {
         double smallTableSize;
         long smallTableRows;
         if (joinEndian == JoinEndian.SMALL_LEFT)
         {
-            smallTableSize = getTableInputSize(leftTable);
-            smallTableRows = getTableRowCount(leftTable);
+            double selectivity = getTableSelectivity(leftTable);
+            logger.info("selectivity on table '" + leftTable.getTableName() + "': " + selectivity);
+            smallTableSize = getTableInputSize(leftTable) * selectivity;
+            smallTableRows = (long) (getTableRowCount(leftTable) * selectivity);
         }
         else
         {
-            smallTableSize = getTableInputSize(rightTable);
-            smallTableRows = getTableRowCount(rightTable);
+            double selectivity = getTableSelectivity(rightTable);
+            logger.info("selectivity on table '" + rightTable.getTableName() + "': " + selectivity);
+            smallTableSize = getTableInputSize(rightTable) * selectivity;
+            smallTableRows = (long) (getTableRowCount(rightTable) * selectivity);
         }
         if (smallTableSize >= broadcastThresholdBytes || smallTableRows > broadcastThresholdRows)
         {
@@ -104,11 +117,15 @@ public class JoinAdvisor
         // Chain joins are only generated during execution.
     }
 
-    public JoinEndian getJoinEndian(Table leftTable, Table rightTable) throws MetadataException
+    public JoinEndian getJoinEndian(Table leftTable, Table rightTable) throws MetadataException, InvalidProtocolBufferException
     {
         // Use row count instead of input size, because building hash table is the main cost.
-        long leftTableRowCount = getTableRowCount(leftTable);
-        long rightTableRowCount = getTableRowCount(rightTable);
+        double leftSelectivity = getTableSelectivity(leftTable);
+        double rightSelectivity = getTableSelectivity(rightTable);
+        logger.info("selectivity on table '" + leftTable.getTableName() + "': " + leftSelectivity);
+        logger.info("selectivity on table '" + rightTable.getTableName() + "': " + rightSelectivity);
+        long leftTableRowCount = (long) (getTableRowCount(leftTable) * leftSelectivity);
+        long rightTableRowCount = (long) (getTableRowCount(rightTable) * rightSelectivity);
         if (leftTableRowCount < rightTableRowCount)
         {
             return JoinEndian.SMALL_LEFT;
@@ -120,7 +137,7 @@ public class JoinAdvisor
     }
 
     public int getNumPartition(Table leftTable, Table rightTable, JoinEndian joinEndian)
-            throws MetadataException
+            throws MetadataException, InvalidProtocolBufferException
     {
         double largeTableSize;
         double largeTableRowCount;
@@ -134,8 +151,13 @@ public class JoinAdvisor
             largeTableSize = getTableInputSize(rightTable);
             largeTableRowCount = getTableRowCount(rightTable);
         }
-        int numFromSize = (int) Math.ceil(largeTableSize / partitionSizeBytes);
-        int numFromRows = (int) Math.ceil(largeTableRowCount / partitionSizeRows);
+        double leftSelectivity = getTableSelectivity(leftTable);
+        double rightSelectivity = getTableSelectivity(rightTable);
+        logger.info("selectivity on table '" + leftTable.getTableName() + "': " + leftSelectivity);
+        logger.info("selectivity on table '" + rightTable.getTableName() + "': " + rightSelectivity);
+        double selectivity = Math.min(leftSelectivity, rightSelectivity);
+        int numFromSize = (int) Math.ceil(selectivity * largeTableSize / partitionSizeBytes);
+        int numFromRows = (int) Math.ceil(selectivity * largeTableRowCount / partitionSizeRows);
         // Limit the partition size by choosing the maximum number of partitions.
         return Math.max(numFromSize, numFromRows);
     }
@@ -144,28 +166,7 @@ public class JoinAdvisor
     {
         if (table.getTableType() == BASE)
         {
-            SchemaTableName schemaTableName = new SchemaTableName(table.getSchemaName(), table.getTableName());
-            Map<String, Column> columnMap;
-            if (columnStatisticCache.containsKey(schemaTableName))
-            {
-                columnMap = columnStatisticCache.get(schemaTableName);
-            }
-            else
-            {
-                List<Column> columns = MetadataCache.Instance().getTableColumns(schemaTableName);
-                if (columns == null)
-                {
-                    columns = metadataService.getColumns(
-                            table.getSchemaName(), table.getTableName(), true);
-                    MetadataCache.Instance().cacheTableColumns(schemaTableName, columns);
-                }
-                columnMap = new HashMap<>(columns.size());
-                for (Column column : columns)
-                {
-                    columnMap.put(column.getName(), column);
-                }
-                columnStatisticCache.put(schemaTableName, columnMap);
-            }
+            Map<String, Column> columnMap = getColumnMap((BaseTable) table);
             double size = 0;
             for (String columnName : table.getColumnNames())
             {
@@ -202,5 +203,66 @@ public class JoinAdvisor
         Table rightTable = joinedTable.getJoin().getRightTable();
         // We estimate the number of rows in the joined table by the max of the two tables' row count.
         return Math.max(getTableRowCount(leftTable), getTableRowCount(rightTable));
+    }
+
+    protected double getTableSelectivity(Table table) throws MetadataException, InvalidProtocolBufferException
+    {
+        if (table.getTableType() == BASE)
+        {
+            Map<String, Column> columnMap = getColumnMap((BaseTable) table);
+            double selectivity = 1;
+            TableScanFilter tableScanFilter = ((BaseTable) table).getFilter();
+            String[] columnsToRead = table.getColumnNames();
+            for (int i = 0; i < columnsToRead.length; ++i)
+            {
+                ColumnFilter<?> columnFilter = tableScanFilter.getColumnFilter(i);
+                if (columnFilter != null)
+                {
+                    Column column = columnMap.get(columnsToRead[i]);
+                    ByteBuffer buffer = column.getRecordStats();
+                    PixelsProto.ColumnStatistic columnStats = PixelsProto.ColumnStatistic.parseFrom(buffer);
+                    double s = columnFilter.getSelectivity(column.getNullFraction(), column.getCardinality(), columnStats);
+                    if (s >= 0 && s < selectivity)
+                    {
+                        // Use the minimum selectivity of the columns as the selectivity on this table.
+                        selectivity = s;
+                    }
+                }
+            }
+            return selectivity;
+        }
+        checkArgument(table.getTableType() == JOINED, "the table is not a base or joined table");
+        JoinedTable joinedTable = (JoinedTable) table;
+        Table leftTable = joinedTable.getJoin().getLeftTable();
+        Table rightTable = joinedTable.getJoin().getRightTable();
+        // We estimate the selectivity the joined table by the minimum of the two tables' selectivity.
+        return Math.min(getTableSelectivity(leftTable), getTableSelectivity(rightTable));
+    }
+
+    private Map<String, Column> getColumnMap(BaseTable table) throws MetadataException
+    {
+        SchemaTableName schemaTableName = new SchemaTableName(table.getSchemaName(), table.getTableName());
+        Map<String, Column> columnMap;
+        if (columnStatisticCache.containsKey(schemaTableName))
+        {
+            columnMap = columnStatisticCache.get(schemaTableName);
+        }
+        else
+        {
+            List<Column> columns = MetadataCache.Instance().getTableColumns(schemaTableName);
+            if (columns == null)
+            {
+                columns = metadataService.getColumns(
+                        table.getSchemaName(), table.getTableName(), true);
+                MetadataCache.Instance().cacheTableColumns(schemaTableName, columns);
+            }
+            columnMap = new HashMap<>(columns.size());
+            for (Column column : columns)
+            {
+                columnMap.put(column.getName(), column);
+            }
+            columnStatisticCache.put(schemaTableName, columnMap);
+        }
+        return columnMap;
     }
 }

--- a/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/lambda/AggregationOperator.java
+++ b/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/lambda/AggregationOperator.java
@@ -250,5 +250,30 @@ public class AggregationOperator extends Operator
         {
             this.finalAggrOutput = finalAggrOutput;
         }
+
+        @Override
+        public long getCumulativeDurationMs()
+        {
+            long duration = 0;
+            if (this.scanOutputs != null)
+            {
+                for (Output output : scanOutputs)
+                {
+                    duration += output.getDurationMs();
+                }
+            }
+            if (this.preAggrOutputs != null)
+            {
+                for (Output output : preAggrOutputs)
+                {
+                    duration += output.getDurationMs();
+                }
+            }
+            if (this.finalAggrOutput != null)
+            {
+                duration += finalAggrOutput.getDurationMs();
+            }
+            return duration;
+        }
     }
 }

--- a/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/lambda/AggregationOperator.java
+++ b/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/lambda/AggregationOperator.java
@@ -29,14 +29,13 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static io.pixelsdb.pixels.executor.lambda.SingleStageJoinOperator.waitForCompletion;
 import static java.util.Objects.requireNonNull;
 
 /**
  * @author hank
  * @date 05/07/2022
  */
-public class AggregationOperator implements Operator
+public class AggregationOperator extends Operator
 {
     /**
      * The input of the final aggregation worker that produce the

--- a/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/lambda/JoinOperator.java
+++ b/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/lambda/JoinOperator.java
@@ -102,5 +102,20 @@ public abstract class JoinOperator extends Operator
         {
             this.largeChild = largeChild;
         }
+
+        @Override
+        public long getCumulativeDurationMs()
+        {
+            long duration = 0;
+            if (this.smallChild != null)
+            {
+                duration += smallChild.getCumulativeDurationMs();
+            }
+            if (this.largeChild != null)
+            {
+                duration += largeChild.getCumulativeDurationMs();
+            }
+            return duration;
+        }
     }
 }

--- a/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/lambda/JoinOperator.java
+++ b/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/lambda/JoinOperator.java
@@ -29,19 +29,19 @@ import java.util.concurrent.ExecutionException;
  * @author hank
  * @date 05/06/2022
  */
-public interface JoinOperator extends Operator
+public abstract class JoinOperator extends Operator
 {
-    List<JoinInput> getJoinInputs();
+    public abstract List<JoinInput> getJoinInputs();
 
-    JoinAlgorithm getJoinAlgo();
+    public abstract JoinAlgorithm getJoinAlgo();
 
-    void setSmallChild(JoinOperator child);
+    public abstract void setSmallChild(JoinOperator child);
 
-    void setLargeChild(JoinOperator child);
+    public abstract void setLargeChild(JoinOperator child);
 
-    JoinOperator getSmallChild();
+    public abstract JoinOperator getSmallChild();
 
-    JoinOperator getLargeChild();
+    public abstract JoinOperator getLargeChild();
 
     /**
      * This method collects the outputs of the join operator. It may block until the join
@@ -49,14 +49,14 @@ public interface JoinOperator extends Operator
      * it will block the query execution.
      * @return the out
      */
-    JoinOutputCollection collectOutputs() throws ExecutionException, InterruptedException;
+    public abstract JoinOutputCollection collectOutputs() throws ExecutionException, InterruptedException;
 
     /**
      * This class is used to collect the outputs of a join operator.
      * It can be serialized to a json string or deserialized to an object from json string
      * by fastjson or other feasible json libraries.
      */
-    class JoinOutputCollection implements OutputCollection
+    public static class JoinOutputCollection implements OutputCollection
     {
         protected JoinAlgorithm joinAlgo;
         protected OutputCollection smallChild;

--- a/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/lambda/Operator.java
+++ b/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/lambda/Operator.java
@@ -64,7 +64,10 @@ public abstract class Operator
      */
     public abstract OutputCollection collectOutputs() throws ExecutionException, InterruptedException;
 
-    public interface OutputCollection { }
+    public interface OutputCollection
+    {
+        long getCumulativeDurationMs();
+    }
 
     public static void waitForCompletion(CompletableFuture<?>[] stageOutputs)
     {

--- a/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/lambda/PartitionedJoinOperator.java
+++ b/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/lambda/PartitionedJoinOperator.java
@@ -271,6 +271,27 @@ public class PartitionedJoinOperator extends SingleStageJoinOperator
             this.largePartitionOutputs = largePartitionOutputs;
         }
 
+        @Override
+        public long getCumulativeDurationMs()
+        {
+            long duration = super.getCumulativeDurationMs();
+            if (this.smallPartitionOutputs != null)
+            {
+                for (Output output : smallPartitionOutputs)
+                {
+                    duration += output.getDurationMs();
+                }
+            }
+            if (this.largePartitionOutputs != null)
+            {
+                for (Output output : largePartitionOutputs)
+                {
+                    duration += output.getDurationMs();
+                }
+            }
+            return duration;
+        }
+
         public Output[] getSmallPartitionOutputs()
         {
             return smallPartitionOutputs;

--- a/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/lambda/SingleStageJoinOperator.java
+++ b/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/lambda/SingleStageJoinOperator.java
@@ -179,6 +179,20 @@ public class SingleStageJoinOperator extends JoinOperator
             this.joinOutputs = joinOutputs;
         }
 
+        @Override
+        public long getCumulativeDurationMs()
+        {
+            long duration = super.getCumulativeDurationMs();
+            if (this.joinOutputs != null)
+            {
+                for (Output output : joinOutputs)
+                {
+                    duration += output.getDurationMs();
+                }
+            }
+            return duration;
+        }
+
         public Output[] getJoinOutputs()
         {
             return joinOutputs;

--- a/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/predicate/ColumnFilter.java
+++ b/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/predicate/ColumnFilter.java
@@ -175,8 +175,8 @@ public class ColumnFilter<T extends Comparable<T>>
                 case BYTE:
                     for (Range<T> range : this.filter.ranges)
                     {
-                        T lower = range.lowerBound.type != Bound.Type.UNBOUNDED ? null : range.lowerBound.value;
-                        T upper = range.upperBound.type != Bound.Type.UNBOUNDED ? null : range.upperBound.value;
+                        T lower = range.lowerBound.type != Bound.Type.UNBOUNDED ? range.lowerBound.value : null;
+                        T upper = range.upperBound.type != Bound.Type.UNBOUNDED ? range.upperBound.value : null;
                         double s = rangeStats.getSelectivity(
                                 lower, range.lowerBound.type == Bound.Type.INCLUDED,
                                 upper, range.upperBound.type == Bound.Type.INCLUDED);
@@ -190,10 +190,10 @@ public class ColumnFilter<T extends Comparable<T>>
                 case FLOAT:
                     for (Range<T> range : this.filter.ranges)
                     {
-                        Double lower = range.lowerBound.type != Bound.Type.UNBOUNDED ? null :
-                                Double.longBitsToDouble((Long) range.lowerBound.value);
-                        Double upper = range.upperBound.type != Bound.Type.UNBOUNDED ? null :
-                                Double.longBitsToDouble((Long) range.upperBound.value);
+                        Double lower = range.lowerBound.type != Bound.Type.UNBOUNDED ?
+                                Double.longBitsToDouble((Long) range.lowerBound.value) : null;
+                        Double upper = range.upperBound.type != Bound.Type.UNBOUNDED ?
+                                Double.longBitsToDouble((Long) range.upperBound.value) : null;
                         double s = rangeStats.getSelectivity(
                                 lower, range.lowerBound.type == Bound.Type.INCLUDED,
                                 upper, range.upperBound.type == Bound.Type.INCLUDED);

--- a/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/predicate/ColumnFilter.java
+++ b/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/predicate/ColumnFilter.java
@@ -24,7 +24,10 @@ import com.alibaba.fastjson.annotation.JSONCreator;
 import com.alibaba.fastjson.annotation.JSONField;
 import com.alibaba.fastjson.annotation.JSONType;
 import com.google.common.reflect.TypeToken;
+import io.pixelsdb.pixels.core.PixelsProto;
 import io.pixelsdb.pixels.core.TypeDescription;
+import io.pixelsdb.pixels.core.stats.RangeStats;
+import io.pixelsdb.pixels.core.stats.StatsRecorder;
 import io.pixelsdb.pixels.core.utils.Bitmap;
 import io.pixelsdb.pixels.core.utils.Decimal;
 import io.pixelsdb.pixels.core.vector.*;
@@ -33,6 +36,9 @@ import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
 import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
 
 /**
  * Created at: 07/04/2022
@@ -126,6 +132,101 @@ public class ColumnFilter<T extends Comparable<T>>
                 excludes.add(discrete.value);
             }
         }
+    }
+
+    /**
+     * Get the estimation of the selectivity of this column filter.
+     * @param nullFraction the fraction of the null values in this column
+     * @param cardinality the cardinality of this column
+     * @param columnStats the statistics of this column, mainly the min/max values
+     * @return the estimated selectivity, for example 0.05 means 5%, negative if the selectivity can not be estimated
+     */
+    public double getSelectivity(double nullFraction, long cardinality, PixelsProto.ColumnStatistic columnStats)
+    {
+        checkArgument(nullFraction >= 0 && nullFraction <= 1, "nullFraction is not in the range [0, 1]");
+        checkArgument(cardinality >= 0, "cardinality is negative");
+        requireNonNull(columnStats, "stats is null");
+        if (this.filter.isAll)
+        {
+            return 1.0;
+        }
+        if (this.filter.isNone)
+        {
+            return 0.0;
+        }
+        double selectivity = 0.0;
+        if (this.filter.allowNull)
+        {
+            selectivity += nullFraction;
+        }
+        StatsRecorder stats = StatsRecorder.create(columnType, columnStats);
+        if (this.filter.getRangeCount() > 0 && stats instanceof RangeStats<?>)
+        {
+            RangeStats<?> rangeStats = (RangeStats<?>) stats;
+            switch (columnType)
+            {
+                case DATE:
+                case TIME:
+                case TIMESTAMP:
+                case LONG:
+                case DECIMAL:
+                case INT:
+                case SHORT:
+                case BYTE:
+                    for (Range<T> range : this.filter.ranges)
+                    {
+                        T lower = range.lowerBound.type != Bound.Type.UNBOUNDED ? null : range.lowerBound.value;
+                        T upper = range.upperBound.type != Bound.Type.UNBOUNDED ? null : range.upperBound.value;
+                        double s = rangeStats.getSelectivity(
+                                lower, range.lowerBound.type == Bound.Type.INCLUDED,
+                                upper, range.upperBound.type == Bound.Type.INCLUDED);
+                        if (s >= 0)
+                        {
+                            selectivity += s;
+                        }
+                    }
+                    break;
+                case DOUBLE:
+                case FLOAT:
+                    for (Range<T> range : this.filter.ranges)
+                    {
+                        Double lower = range.lowerBound.type != Bound.Type.UNBOUNDED ? null :
+                                Double.longBitsToDouble((Long) range.lowerBound.value);
+                        Double upper = range.upperBound.type != Bound.Type.UNBOUNDED ? null :
+                                Double.longBitsToDouble((Long) range.upperBound.value);
+                        double s = rangeStats.getSelectivity(
+                                lower, range.lowerBound.type == Bound.Type.INCLUDED,
+                                upper, range.upperBound.type == Bound.Type.INCLUDED);
+                        if (s >= 0)
+                        {
+                            selectivity += s;
+                        }
+                    }
+                    break;
+                default:
+                    selectivity = -1;
+                    break;
+            }
+        }
+
+        if (selectivity < 0)
+        {
+            return selectivity;
+        }
+
+        if (this.filter.getDiscreteValueCount() > 0)
+        {
+            checkArgument(this.filter.getDiscreteValueCount() <= cardinality,
+                    "the discrete value count is larger than the cardinality of this column");
+            selectivity += (this.filter.getDiscreteValueCount() / (double) cardinality);
+        }
+
+        if (selectivity > 1)
+        {
+            selectivity = 1;
+        }
+
+        return selectivity;
     }
 
     public String getColumnName()

--- a/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/predicate/ColumnFilter.java
+++ b/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/predicate/ColumnFilter.java
@@ -180,7 +180,7 @@ public class ColumnFilter<T extends Comparable<T>>
                         double s = rangeStats.getSelectivity(
                                 lower, range.lowerBound.type == Bound.Type.INCLUDED,
                                 upper, range.upperBound.type == Bound.Type.INCLUDED);
-                        if (s >= 0)
+                        if (s > 0)
                         {
                             selectivity += s;
                         }

--- a/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/predicate/TableScanFilter.java
+++ b/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/predicate/TableScanFilter.java
@@ -77,6 +77,11 @@ public class TableScanFilter
         return columnFilters;
     }
 
+    /**
+     * Get the column filter on the column.
+     * @param columnId the index of the column in the scan result
+     * @return null if there is no filter on this column
+     */
     public ColumnFilter getColumnFilter(int columnId)
     {
         return columnFilters.get(columnId);

--- a/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/utils/Tuple.java
+++ b/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/utils/Tuple.java
@@ -33,7 +33,7 @@ import static java.util.Objects.requireNonNull;
  * @author hank
  * @date 09/05/2022
  */
-public class Tuple
+public class Tuple implements Comparable<Tuple>
 {
     protected static class CommonFields
     {
@@ -103,19 +103,19 @@ public class Tuple
     @Override
     public boolean equals(Object obj)
     {
-//        if (this == obj)
-//        {
-//            return true;
-//        }
-//        if (obj == null || getClass() != obj.getClass())
-//        {
-//            return false;
-//        }
+        if (this == obj)
+        {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass())
+        {
+            return false;
+        }
         Tuple other = (Tuple) obj;
-//        if (this.commonFields.keyColumnIds.length != other.commonFields.keyColumnIds.length)
-//        {
-//            return false;
-//        }
+        if (this.commonFields.keyColumnIds.length != other.commonFields.keyColumnIds.length)
+        {
+            return false;
+        }
         for (int i = 0; i < this.commonFields.keyColumnIds.length; ++i)
         {
             // We only support equi-joins, thus null value is considered not equal to anything.
@@ -126,6 +126,29 @@ public class Tuple
             }
         }
         return true;
+    }
+
+    @Override
+    public int compareTo(Tuple other)
+    {
+        if (this == other)
+        {
+            return 0;
+        }
+        if (this.commonFields.keyColumnIds.length != other.commonFields.keyColumnIds.length)
+        {
+            return Integer.compare(this.commonFields.keyColumnIds.length, other.commonFields.keyColumnIds.length);
+        }
+        for (int i = 0; i < this.commonFields.keyColumnIds.length; ++i)
+        {
+            int c = this.commonFields.columns[this.commonFields.keyColumnIds[i]].compareElement(
+                    this.rowId, other.rowId, other.commonFields.columns[other.commonFields.keyColumnIds[i]]);
+            if (c != 0)
+            {
+                return c;
+            }
+        }
+        return 0;
     }
 
     /**

--- a/pixels-lambda/src/main/java/io/pixelsdb/pixels/lambda/AggregationWorker.java
+++ b/pixels-lambda/src/main/java/io/pixelsdb/pixels/lambda/AggregationWorker.java
@@ -39,7 +39,6 @@ import io.pixelsdb.pixels.executor.lambda.output.AggregationOutput;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -220,9 +219,10 @@ public class AggregationWorker implements RequestHandler<AggregationInput, Aggre
                         it.remove();
                     } else
                     {
+                        TimeUnit.MILLISECONDS.sleep(10);
                         continue;
                     }
-                } catch (IOException e)
+                } catch (Exception e)
                 {
                     throw new PixelsWorkerException(
                             "failed to check the existence of the input partial aggregation file '" +

--- a/pixels-lambda/src/main/java/io/pixelsdb/pixels/lambda/BroadcastChainJoinWorker.java
+++ b/pixels-lambda/src/main/java/io/pixelsdb/pixels/lambda/BroadcastChainJoinWorker.java
@@ -423,9 +423,10 @@ public class BroadcastChainJoinWorker implements RequestHandler<BroadcastChainJo
                             it.remove();
                         } else
                         {
+                            TimeUnit.MILLISECONDS.sleep(10);
                             continue;
                         }
-                    } catch (IOException e)
+                    } catch (Exception e)
                     {
                         throw new PixelsWorkerException(
                                 "failed to check the existence of the right table input file '" +

--- a/pixels-lambda/src/main/java/io/pixelsdb/pixels/lambda/BroadcastJoinWorker.java
+++ b/pixels-lambda/src/main/java/io/pixelsdb/pixels/lambda/BroadcastJoinWorker.java
@@ -41,7 +41,6 @@ import io.pixelsdb.pixels.executor.predicate.TableScanFilter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicReference;
@@ -294,9 +293,10 @@ public class BroadcastJoinWorker implements RequestHandler<BroadcastJoinInput, J
                             it.remove();
                         } else
                         {
+                            TimeUnit.MILLISECONDS.sleep(10);
                             continue;
                         }
-                    } catch (IOException e)
+                    } catch (Exception e)
                     {
                         throw new PixelsWorkerException(
                                 "failed to check the existence of the left table input file '" +
@@ -378,9 +378,10 @@ public class BroadcastJoinWorker implements RequestHandler<BroadcastJoinInput, J
                             it.remove();
                         } else
                         {
+                            TimeUnit.MILLISECONDS.sleep(10);
                             continue;
                         }
-                    } catch (IOException e)
+                    } catch (Exception e)
                     {
                         throw new PixelsWorkerException(
                                 "failed to check the existence of the right table input file '" +
@@ -477,9 +478,10 @@ public class BroadcastJoinWorker implements RequestHandler<BroadcastJoinInput, J
                             it.remove();
                         } else
                         {
+                            TimeUnit.MILLISECONDS.sleep(10);
                             continue;
                         }
-                    } catch (IOException e)
+                    } catch (Exception e)
                     {
                         throw new PixelsWorkerException(
                                 "failed to check the existence of the right table input file '" +

--- a/pixels-lambda/src/main/java/io/pixelsdb/pixels/lambda/PartitionedChainJoinWorker.java
+++ b/pixels-lambda/src/main/java/io/pixelsdb/pixels/lambda/PartitionedChainJoinWorker.java
@@ -39,7 +39,6 @@ import io.pixelsdb.pixels.executor.lambda.output.JoinOutput;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicReference;
@@ -409,9 +408,10 @@ public class PartitionedChainJoinWorker implements RequestHandler<PartitionedCha
                         it.remove();
                     } else
                     {
+                        TimeUnit.MILLISECONDS.sleep(10);
                         continue;
                     }
-                } catch (IOException e)
+                } catch (Exception e)
                 {
                     throw new PixelsWorkerException("failed to check the existence of the partitioned file '" +
                             rightPartitioned + "' of the right table", e);
@@ -511,9 +511,10 @@ public class PartitionedChainJoinWorker implements RequestHandler<PartitionedCha
                         it.remove();
                     } else
                     {
+                        TimeUnit.MILLISECONDS.sleep(10);
                         continue;
                     }
-                } catch (IOException e)
+                } catch (Exception e)
                 {
                     throw new PixelsWorkerException("failed to check the existence of the partitioned file '" +
                             rightPartitioned + "' of the right table", e);

--- a/pixels-lambda/src/main/java/io/pixelsdb/pixels/lambda/PartitionedJoinWorker.java
+++ b/pixels-lambda/src/main/java/io/pixelsdb/pixels/lambda/PartitionedJoinWorker.java
@@ -41,7 +41,6 @@ import io.pixelsdb.pixels.executor.lambda.output.JoinOutput;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicReference;
@@ -362,9 +361,10 @@ public class PartitionedJoinWorker implements RequestHandler<PartitionedJoinInpu
                         it.remove();
                     } else
                     {
+                        TimeUnit.MILLISECONDS.sleep(10);
                         continue;
                     }
-                } catch (IOException e)
+                } catch (Exception e)
                 {
                     throw new PixelsWorkerException("failed to check the existence of the partitioned file '" +
                             leftPartitioned + "' of the left table", e);
@@ -436,9 +436,10 @@ public class PartitionedJoinWorker implements RequestHandler<PartitionedJoinInpu
                         it.remove();
                     } else
                     {
+                        TimeUnit.MILLISECONDS.sleep(10);
                         continue;
                     }
-                } catch (IOException e)
+                } catch (Exception e)
                 {
                     throw new PixelsWorkerException("failed to check the existence of the partitioned file '" +
                             rightPartitioned + "' of the right table", e);
@@ -527,9 +528,10 @@ public class PartitionedJoinWorker implements RequestHandler<PartitionedJoinInpu
                         it.remove();
                     } else
                     {
+                        TimeUnit.MILLISECONDS.sleep(10);
                         continue;
                     }
-                } catch (IOException e)
+                } catch (Exception e)
                 {
                     throw new PixelsWorkerException("failed to check the existence of the partitioned file '" +
                             rightPartitioned + "' of the right table", e);

--- a/pixels-lambda/src/main/java/io/pixelsdb/pixels/lambda/WorkerCommon.java
+++ b/pixels-lambda/src/main/java/io/pixelsdb/pixels/lambda/WorkerCommon.java
@@ -102,7 +102,7 @@ public class WorkerCommon
                 {
                     while (!exists(s3, leftPath))
                     {
-                        TimeUnit.MILLISECONDS.sleep(100);
+                        TimeUnit.MILLISECONDS.sleep(50);
                     }
                 }
                 PixelsReader reader = getReader(leftPath, storage);
@@ -120,7 +120,7 @@ public class WorkerCommon
                 {
                     while (!exists(s3, rightPath))
                     {
-                        TimeUnit.MILLISECONDS.sleep(100);
+                        TimeUnit.MILLISECONDS.sleep(50);
                     }
                 }
                 PixelsReader reader = getReader(rightPath, storage);
@@ -179,7 +179,7 @@ public class WorkerCommon
         {
             while (!exists(storage, path))
             {
-                TimeUnit.MILLISECONDS.sleep(100);
+                TimeUnit.MILLISECONDS.sleep(50);
             }
         }
         PixelsReader reader = getReader(path, storage);

--- a/pixels-load/src/main/java/io/pixelsdb/pixels/load/ConsumerGenerator.java
+++ b/pixels-load/src/main/java/io/pixelsdb/pixels/load/ConsumerGenerator.java
@@ -81,7 +81,7 @@ public class ConsumerGenerator
                 {
                     if (config.getFormat().equalsIgnoreCase("pixels"))
                     {
-                        PixelsConsumer pixelsConsumer = new PixelsConsumer(queue, prop, config);
+                        PixelsConsumer pixelsConsumer = new PixelsConsumer(queue, prop, config, i);
                         consumers[i] = pixelsConsumer;
                         pixelsConsumer.start();
                     } else if (config.getFormat().equalsIgnoreCase("orc"))


### PR DESCRIPTION
1. implement the comparable interface in Tuple. Thus hash table can transform into a tree-based structure when there are too many collisions.
2. reduce memory usage in the partitioner.
3. add prefix into the intermediate files to prevent throttling.
4. divide the hash table into segments to support a larger capacity.
5. use selectivity estimation in join optimization.
6. fix a bug in the date stats recorder.