### PR TITLE
[Issue #170]: improve execution pipeline.

### DIFF
--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/scheduler/SortMergeScheduler.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/scheduler/SortMergeScheduler.java
@@ -163,7 +163,7 @@ public class SortMergeScheduler implements Scheduler
         }
     }
 
-    protected class RequestFuture implements Comparable<RequestFuture>
+    protected static class RequestFuture implements Comparable<RequestFuture>
     {
         public Request request;
         public CompletableFuture<ByteBuffer> future;
@@ -181,7 +181,7 @@ public class SortMergeScheduler implements Scheduler
         }
     }
 
-    protected class MergedRequest
+    protected static class MergedRequest
     {
         private final long queryId;
         private final long start;
@@ -292,7 +292,7 @@ public class SortMergeScheduler implements Scheduler
      * Combination of MergedRequest and PhysicalReader,
      * it is used by the RetryPolicy.
      */
-    protected class MergedRequestReader
+    protected static class MergedRequestReader
     {
         private MergedRequest request;
         private PhysicalReader reader;
@@ -312,7 +312,7 @@ public class SortMergeScheduler implements Scheduler
      *     We future confirm that retry helps keep the large query performance stable.
      * </p>
      */
-    protected class RetryPolicy
+    protected static class RetryPolicy
     {
         private final int maxRetryNum;
         private final int intervalMs;

--- a/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/PixelsExecutor.java
+++ b/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/PixelsExecutor.java
@@ -345,7 +345,7 @@ public class PixelsExecutor
         finalAggrInput.setOutput(new OutputInfo(finalOutputBase + "final_aggr",
                 false, storageInfo, true));
 
-        AggregationOperator aggregationOperator = new AggregationOperator(
+        AggregationOperator aggregationOperator = new AggregationOperator(aggregatedTable.getTableName(),
                 finalAggrInput, preAggrInputsBuilder.build(), scanInputsBuilder.build());
         aggregationOperator.setChild(joinOperator);
 
@@ -452,7 +452,7 @@ public class PixelsExecutor
                     }
 
                     SingleStageJoinOperator joinOperator = new SingleStageJoinOperator(
-                            joinInputs.build(), JoinAlgorithm.BROADCAST_CHAIN);
+                            joinedTable.getTableName(), joinInputs.build(), JoinAlgorithm.BROADCAST_CHAIN);
                     // The right operator must be set as the large child.
                     joinOperator.setLargeChild(rightOperator);
                     return joinOperator;
@@ -491,6 +491,7 @@ public class PixelsExecutor
                     }
 
                     PartitionedJoinOperator joinOperator = new PartitionedJoinOperator(
+                            joinedTable.getTableName(),
                             rightJoinOperator.getSmallPartitionInputs(),
                             rightJoinOperator.getLargePartitionInputs(),
                             joinInputs.build(), JoinAlgorithm.PARTITIONED_CHAIN);
@@ -535,7 +536,7 @@ public class PixelsExecutor
                     joinedTable, parent, numPartition, leftTableInfo, rightTableInfo,
                     null, null);
             PartitionedJoinOperator joinOperator = new PartitionedJoinOperator(
-                    null, null, joinInputs, joinAlgo);
+                    joinedTable.getTableName(), null, null, joinInputs, joinAlgo);
 
             joinOperator.setSmallChild(leftOperator);
             joinOperator.setLargeChild(rightOperator);
@@ -633,7 +634,8 @@ public class PixelsExecutor
                 chainJoinInfos.add(chainJoinInfo);
                 broadcastChainJoinInput.setChainJoinInfos(chainJoinInfos);
 
-                return new SingleStageJoinOperator(broadcastChainJoinInput, JoinAlgorithm.BROADCAST_CHAIN);
+                return new SingleStageJoinOperator(joinedTable.getTableName(),
+                        broadcastChainJoinInput, JoinAlgorithm.BROADCAST_CHAIN);
             }
         }
         else
@@ -728,7 +730,8 @@ public class PixelsExecutor
                         joinInputs.add(complete);
                     }
 
-                    return new SingleStageJoinOperator(joinInputs.build(), JoinAlgorithm.BROADCAST_CHAIN);
+                    return new SingleStageJoinOperator(joinedTable.getTableName(),
+                            joinInputs.build(), JoinAlgorithm.BROADCAST_CHAIN);
                 }
             }
             // get the leftInputSplits or leftPartitionedFiles from childJoinInputs.
@@ -864,7 +867,7 @@ public class PixelsExecutor
                 }
             }
             SingleStageJoinOperator joinOperator =
-                    new SingleStageJoinOperator(joinInputs.build(), joinAlgo);
+                    new SingleStageJoinOperator(joinedTable.getTableName(), joinInputs.build(), joinAlgo);
             if (join.getJoinEndian() == JoinEndian.SMALL_LEFT)
             {
                 joinOperator.setSmallChild(childOperator);
@@ -904,13 +907,13 @@ public class PixelsExecutor
 
                 if (join.getJoinEndian() == JoinEndian.SMALL_LEFT)
                 {
-                    joinOperator = new PartitionedJoinOperator(
+                    joinOperator = new PartitionedJoinOperator(joinedTable.getTableName(),
                             null, rightPartitionInputs, joinInputs, joinAlgo);
                     joinOperator.setSmallChild(childOperator);
                 }
                 else
                 {
-                    joinOperator = new PartitionedJoinOperator(
+                    joinOperator = new PartitionedJoinOperator(joinedTable.getTableName(),
                             rightPartitionInputs, null, joinInputs, joinAlgo);
                     joinOperator.setLargeChild(childOperator);
                 }
@@ -940,12 +943,12 @@ public class PixelsExecutor
 
                 if (join.getJoinEndian() == JoinEndian.SMALL_LEFT)
                 {
-                    joinOperator = new PartitionedJoinOperator(
+                    joinOperator = new PartitionedJoinOperator(joinedTable.getTableName(),
                             leftPartitionInputs, rightPartitionInputs, joinInputs, joinAlgo);
                 }
                 else
                 {
-                    joinOperator = new PartitionedJoinOperator(
+                    joinOperator = new PartitionedJoinOperator(joinedTable.getTableName(),
                             rightPartitionInputs, leftPartitionInputs, joinInputs, joinAlgo);
                 }
             }

--- a/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/lambda/AggregationOperator.java
+++ b/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/lambda/AggregationOperator.java
@@ -72,10 +72,11 @@ public class AggregationOperator extends Operator
      */
     private CompletableFuture<?>[] finalAggrOutput = null;
 
-    public AggregationOperator(AggregationInput finalAggrInput,
+    public AggregationOperator(String name, AggregationInput finalAggrInput,
                                List<AggregationInput> preAggrInputs,
                                List<ScanInput> scanInputs)
     {
+        super(name);
         this.finalAggrInput = requireNonNull(finalAggrInput, "aggregateInput is null");
         if (preAggrInputs == null || preAggrInputs.isEmpty())
         {

--- a/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/lambda/JoinOperator.java
+++ b/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/lambda/JoinOperator.java
@@ -40,6 +40,11 @@ public abstract class JoinOperator extends Operator
         LargeSideCompletionRatio = Double.parseDouble(ratio);
     }
 
+    public JoinOperator(String name)
+    {
+        super(name);
+    }
+
     public abstract List<JoinInput> getJoinInputs();
 
     public abstract JoinAlgorithm getJoinAlgo();

--- a/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/lambda/Operator.java
+++ b/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/lambda/Operator.java
@@ -43,6 +43,21 @@ public abstract class Operator
         Runtime.getRuntime().addShutdownHook(new Thread(operatorService::shutdownNow));
     }
 
+    private final String name;
+
+    public Operator(String name)
+    {
+        this.name = name;
+    }
+
+    /**
+     * @return the name of the operator
+     */
+    public String getName()
+    {
+        return name;
+    }
+
     /**
      * Execute this operator recursively.
      *

--- a/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/lambda/SingleStageJoinOperator.java
+++ b/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/lambda/SingleStageJoinOperator.java
@@ -23,6 +23,8 @@ import com.google.common.collect.ImmutableList;
 import io.pixelsdb.pixels.executor.join.JoinAlgorithm;
 import io.pixelsdb.pixels.executor.lambda.input.JoinInput;
 import io.pixelsdb.pixels.executor.lambda.output.Output;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -37,20 +39,23 @@ import java.util.concurrent.ExecutionException;
  */
 public class SingleStageJoinOperator extends JoinOperator
 {
+    private static final Logger logger = LogManager.getLogger(SingleStageJoinOperator.class);
     protected final List<JoinInput> joinInputs;
     protected final JoinAlgorithm joinAlgo;
     protected JoinOperator smallChild = null;
     protected JoinOperator largeChild = null;
     protected CompletableFuture<?>[] joinOutputs = null;
 
-    public SingleStageJoinOperator(JoinInput joinInput, JoinAlgorithm joinAlgo)
+    public SingleStageJoinOperator(String name, JoinInput joinInput, JoinAlgorithm joinAlgo)
     {
+        super(name);
         this.joinInputs = ImmutableList.of(joinInput);
         this.joinAlgo = joinAlgo;
     }
 
-    public SingleStageJoinOperator(List<JoinInput> joinInputs, JoinAlgorithm joinAlgo)
+    public SingleStageJoinOperator(String name, List<JoinInput> joinInputs, JoinAlgorithm joinAlgo)
     {
+        super(name);
         this.joinInputs = ImmutableList.copyOf(joinInputs);
         this.joinAlgo = joinAlgo;
     }
@@ -123,6 +128,8 @@ public class SingleStageJoinOperator extends JoinOperator
                     throw new UnsupportedOperationException("join algorithm '" + joinAlgo + "' is unsupported");
                 }
             }
+
+            logger.info("invoke " + this.getName());
             return joinOutputs;
         });
     }


### PR DESCRIPTION
Make the execution pipeline of the query operators fully parallelized. Previously, each operator blocks and waits for the completion of its previous stages.