### PR TITLE
[Issue #214]: implement multi-thread S3 output stream.

### DIFF
--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/storage/S3.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/storage/S3.java
@@ -25,6 +25,7 @@ import io.pixelsdb.pixels.common.utils.EtcdUtil;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.core.retry.RetryMode;
 import software.amazon.awssdk.http.apache.ApacheHttpClient;
 import software.amazon.awssdk.http.crt.AwsCrtAsyncHttpClient;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
@@ -123,7 +124,7 @@ public final class S3 extends AbstractS3
                 .httpClientBuilder(AwsCrtAsyncHttpClient.builder()
                         .maxConcurrency(maxConcurrency))
                 .overrideConfiguration(ClientOverrideConfiguration.builder()
-                        .apiCallTimeout(Duration.ofSeconds(ConnTimeoutSec))
+                        .apiCallTimeout(Duration.ofSeconds(ConnTimeoutSec)).retryPolicy(RetryMode.ADAPTIVE)
                         .apiCallAttemptTimeout(Duration.ofSeconds(ConnAcquisitionTimeoutSec))
                         .build()).build();
 

--- a/pixels-common/src/test/java/io/pixelsdb/pixels/common/physical/TestS3.java
+++ b/pixels-common/src/test/java/io/pixelsdb/pixels/common/physical/TestS3.java
@@ -71,7 +71,7 @@ public class TestS3
     public void testS3OutputStream() throws IOException
     {
         S3Client s3 = S3Client.builder().build();
-        InputStream input = new FileInputStream("/home/hank/Downloads/pixels/20220306043329_1.pxl");
+        InputStream input = new FileInputStream("/home/hank/pixels.zip");
         OutputStream output = new S3OutputStream(s3, "pixels-dias-empty", "object-6");
         IOUtils.copyBytes(input, output, 1024*1024, true);
     }


### PR DESCRIPTION
Asynchronous multi-part upload is not efficient. Thus we use multi-thread multi-part upload.