### PR TITLE
[Issue #170]: fix null value processing in aggregation.

### DIFF
--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/BinaryColumnVector.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/BinaryColumnVector.java
@@ -250,6 +250,10 @@ public class BinaryColumnVector extends ColumnVector
                 return false;
             }
             int start = this.start[index], otherStart = otherVector.start[otherIndex];
+            if (this.vector[index] == otherVector.vector[otherIndex] && start == otherStart)
+            {
+                return true;
+            }
             for (int i = 0; i < this.lens[index]; ++i)
             {
                 if (this.vector[index][start+i] != otherVector.vector[otherIndex][otherStart+i])
@@ -273,6 +277,10 @@ public class BinaryColumnVector extends ColumnVector
                 return Integer.compare(this.lens[index], otherVector.lens[otherIndex]);
             }
             int start = this.start[index], otherStart = otherVector.start[otherIndex];
+            if (this.vector[index] == otherVector.vector[otherIndex] && start == otherStart)
+            {
+                return 0;
+            }
             for (int i = 0; i < this.lens[index]; ++i)
             {
                 if (this.vector[index][start+i] != otherVector.vector[otherIndex][otherStart+i])

--- a/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/aggregation/Aggregator.java
+++ b/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/aggregation/Aggregator.java
@@ -28,6 +28,7 @@ import io.pixelsdb.pixels.executor.aggregation.function.FunctionFactory;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
@@ -38,7 +39,7 @@ import static java.util.Objects.requireNonNull;
  */
 public class Aggregator
 {
-    private final HashMap<AggrTuple, AggrTuple> hashTable = new HashMap<>();
+    private final Map<AggrTuple, AggrTuple> aggrTable = new HashMap<>();
     private final int batchSize;
     private final TypeDescription outputSchema;
     private final int[] groupKeyColumnIds;
@@ -117,7 +118,7 @@ public class Aggregator
         while (builder.hasNext())
         {
             AggrTuple input = builder.next();
-            AggrTuple baseTuple = this.hashTable.get(input);
+            AggrTuple baseTuple = this.aggrTable.get(input);
             if (baseTuple != null)
             {
                 baseTuple.aggregate(input);
@@ -131,7 +132,7 @@ public class Aggregator
                     functions[i] = this.aggrFunctions[i].buildCopy();
                 }
                 input.initFunctions(functions);
-                this.hashTable.put(input, input);
+                this.aggrTable.put(input, input);
             }
         }
     }
@@ -139,7 +140,7 @@ public class Aggregator
     public boolean writeAggrOutput(PixelsWriter pixelsWriter) throws IOException
     {
         VectorizedRowBatch outputRowBatch = this.outputSchema.createRowBatch(this.batchSize);
-        for (AggrTuple output : this.hashTable.values())
+        for (AggrTuple output : this.aggrTable.values())
         {
             if (outputRowBatch.isFull())
             {
@@ -162,6 +163,6 @@ public class Aggregator
 
     public void clear()
     {
-        this.hashTable.clear();
+        this.aggrTable.clear();
     }
 }

--- a/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/utils/Tuple.java
+++ b/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/utils/Tuple.java
@@ -67,11 +67,11 @@ public class Tuple implements Comparable<Tuple>
     /**
      * The index of this tuple in the corresponding row batch.
      */
-    protected final int rowId;
+    public final int rowId;
     /**
      * The common fields that are shared by all the tuples from the same row batch.
      */
-    protected final CommonFields commonFields;
+    public final CommonFields commonFields;
     /**
      * The left-table tuple that is joined with this tuple.
      * For equal join, the joined tuples should have the same join-key value.


### PR DESCRIPTION
Previously, null values are considered non-equal in aggregations. This is incorrect and may lead to very bad performance if there are many null values on the group by key columns.