### PR TITLE
[Issue #170]: improve string comparison and aggregation.

### DIFF
--- a/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/MemoryMappedFile.java
+++ b/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/MemoryMappedFile.java
@@ -31,18 +31,19 @@
  */
 package io.pixelsdb.pixels.cache;
 
-import sun.misc.Unsafe;
 import sun.nio.ch.FileChannelImpl;
 
 import java.io.FileDescriptor;
 import java.io.RandomAccessFile;
 import java.lang.reflect.Constructor;
-import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.channels.FileChannel;
+
+import static io.pixelsdb.pixels.common.utils.JvmUtils.unsafe;
+import static io.pixelsdb.pixels.common.utils.JvmUtils.nativeOrder;
 
 /**
  * This class has been tested.
@@ -56,10 +57,8 @@ import java.nio.channels.FileChannel;
 @SuppressWarnings("restriction")
 public class MemoryMappedFile
 {
-    private static final Unsafe unsafe;
     private static final Method mmap;
     private static final Method unmmap;
-    private static final ByteOrder order;
     // this is from sun.nio.ch.Util
     private static volatile Constructor<?> directByteBufferRConstructor = null;
     private static final int BYTE_ARRAY_OFFSET;
@@ -71,13 +70,9 @@ public class MemoryMappedFile
     {
         try
         {
-            Field singleOneInstanceField = Unsafe.class.getDeclaredField("theUnsafe");
-            singleOneInstanceField.setAccessible(true);
-            unsafe = (Unsafe) singleOneInstanceField.get(null);
             mmap = getMethod(FileChannelImpl.class, "map0", int.class, long.class, long.class);
             unmmap = getMethod(FileChannelImpl.class, "unmap0", long.class, long.class);
             BYTE_ARRAY_OFFSET = unsafe.arrayBaseOffset(byte[].class);
-            order = ByteOrder.nativeOrder();
         }
         catch (Exception e)
         {
@@ -171,7 +166,7 @@ public class MemoryMappedFile
 
     public static ByteOrder getOrder()
     {
-        return order;
+        return nativeOrder;
     }
 
     /**

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/utils/JvmUtils.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/utils/JvmUtils.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019-2022 PixelsDB.
+ *
+ * This file is part of Pixels.
+ *
+ * Pixels is free software: you can redistribute it and/or modify
+ * it under the terms of the Affero GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * Pixels is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Affero GNU General Public License for more details.
+ *
+ * You should have received a copy of the Affero GNU General Public
+ * License along with Pixels.  If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package io.pixelsdb.pixels.common.utils;
+
+import sun.misc.Unsafe;
+
+import java.lang.reflect.Field;
+import java.nio.ByteOrder;
+
+/**
+ * @author hank
+ * @date 8/27/22
+ */
+public final class JvmUtils
+{
+    public static final Unsafe unsafe;
+    public static final ByteOrder nativeOrder;
+
+    static
+    {
+        try
+        {
+            Field singleOneInstanceField = Unsafe.class.getDeclaredField("theUnsafe");
+            singleOneInstanceField.setAccessible(true);
+            unsafe = (Unsafe) singleOneInstanceField.get(null);
+            nativeOrder = ByteOrder.nativeOrder();
+        }
+        catch (Exception e)
+        {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/utils/BitUtils.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/utils/BitUtils.java
@@ -235,4 +235,15 @@ public class BitUtils
             bitsLeft = 8;
         }
     }
+
+    /**
+     * Copied from io.airlift.slice.
+     * Turns a long representing a sequence of 8 bytes read in little-endian order
+     * into a number that when compared produces the same effect as comparing the
+     * original sequence of bytes lexicographically
+     */
+    public static long longBytesToLong(long bytes)
+    {
+        return Long.reverseBytes(bytes) ^ Long.MIN_VALUE;
+    }
 }

--- a/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/PixelsExecutor.java
+++ b/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/PixelsExecutor.java
@@ -105,20 +105,22 @@ public class PixelsExecutor
      * @param rootTable the join plan
      * @param orderedPathEnabled whether ordered path is enabled
      * @param compactPathEnabled whether compact path is enabled
+     * @param metadataService the metadata service to access Pixels metadata
      * @throws IOException
      */
-    public PixelsExecutor(long queryId,
-                          Table rootTable,
+    public PixelsExecutor(long queryId, Table rootTable,
                           boolean orderedPathEnabled,
-                          boolean compactPathEnabled) throws IOException
+                          boolean compactPathEnabled,
+                          Optional<MetadataService> metadataService) throws IOException
     {
         this.queryId = queryId;
         this.rootTable = requireNonNull(rootTable, "rootTable is null");
         checkArgument(rootTable.getTableType() == JOINED || rootTable.getTableType() == AGGREGATED,
                 "currently, PixelsExecutor only supports join and aggregation");
         this.config = ConfigFactory.Instance();
-        this.metadataService = new MetadataService(config.getProperty("metadata.server.host"),
-                Integer.parseInt(config.getProperty("metadata.server.port")));
+        this.metadataService = metadataService.orElseGet(() ->
+                new MetadataService(config.getProperty("metadata.server.host"),
+                        Integer.parseInt(config.getProperty("metadata.server.port"))));
         this.fixedSplitSize = Integer.parseInt(config.getProperty("fixed.split.size"));
         this.projectionReadEnabled = Boolean.parseBoolean(config.getProperty("projection.read.enabled"));
         this.orderedPathEnabled = orderedPathEnabled;
@@ -264,8 +266,7 @@ public class PixelsExecutor
                 preAggrInput.setResultColumnNames(aggregation.getResultColumnAlias());
                 preAggrInput.setResultColumnTypes(aggregation.getResultColumnTypes());
                 preAggrInput.setFunctionTypes(aggregation.getFunctionTypes());
-                preAggrInput.setInputStorage(new StorageInfo(IntermediateStorage,
-                        null, null, null));
+                preAggrInput.setInputStorage(new StorageInfo(IntermediateStorage, null, null, null));
                 StorageInfo outputStorageInfo = new StorageInfo(IntermediateStorage, null, null, null);
                 preAggrInput.setParallelism(IntraWorkerParallelism);
 

--- a/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/StarlingExecutor.java
+++ b/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/StarlingExecutor.java
@@ -106,20 +106,22 @@ public class StarlingExecutor
      * @param rootTable the join plan
      * @param orderedPathEnabled whether ordered path is enabled
      * @param compactPathEnabled whether compact path is enabled
+     * @param metadataService the metadata service to access Pixels metadata
      * @throws IOException
      */
-    public StarlingExecutor(long queryId,
-                            Table rootTable,
+    public StarlingExecutor(long queryId, Table rootTable,
                             boolean orderedPathEnabled,
-                            boolean compactPathEnabled) throws IOException
+                            boolean compactPathEnabled,
+                            Optional<MetadataService> metadataService) throws IOException
     {
         this.queryId = queryId;
         this.rootTable = requireNonNull(rootTable, "rootTable is null");
         checkArgument(rootTable.getTableType() == JOINED || rootTable.getTableType() == AGGREGATED,
                 "currently, PixelsExecutor only supports join and aggregation");
         this.config = ConfigFactory.Instance();
-        this.metadataService = new MetadataService(config.getProperty("metadata.server.host"),
-                Integer.parseInt(config.getProperty("metadata.server.port")));
+        this.metadataService = metadataService.orElseGet(() ->
+                new MetadataService(config.getProperty("metadata.server.host"),
+                        Integer.parseInt(config.getProperty("metadata.server.port"))));
         this.fixedSplitSize = Integer.parseInt(config.getProperty("fixed.split.size"));
         this.projectionReadEnabled = Boolean.parseBoolean(config.getProperty("projection.read.enabled"));
         this.orderedPathEnabled = orderedPathEnabled;

--- a/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/join/Joiner.java
+++ b/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/join/Joiner.java
@@ -182,15 +182,18 @@ public class Joiner
      *
      * @param smallBatch a row batch from the left (a.k.a., small) table
      */
-    public synchronized void populateLeftTable(VectorizedRowBatch smallBatch)
+    public void populateLeftTable(VectorizedRowBatch smallBatch)
     {
         requireNonNull(smallBatch, "smallBatch is null");
         checkArgument(smallBatch.size > 0, "smallBatch is empty");
         Tuple.Builder builder = new Tuple.Builder(smallBatch, this.smallKeyColumnIds, this.smallProjection);
-        while (builder.hasNext())
+        synchronized (this.smallTable)
         {
-            Tuple tuple = builder.next();
-            this.smallTable.put(tuple);
+            while (builder.hasNext())
+            {
+                Tuple tuple = builder.next();
+                this.smallTable.put(tuple);
+            }
         }
     }
 

--- a/pixels-executor/src/test/java/io/pixelsdb/pixels/executor/TestPixelsExecutor.java
+++ b/pixels-executor/src/test/java/io/pixelsdb/pixels/executor/TestPixelsExecutor.java
@@ -93,7 +93,7 @@ public class TestPixelsExecutor
                 "region_join_nation_join_supplier_join_lineitem", join3);
 
         PixelsExecutor joinExecutor = new PixelsExecutor(
-                123456, root, false, true);
+                123456, root, false, true, Optional.empty());
 
         JoinOperator joinOperator = joinExecutor.getJoinOperator(root, Optional.empty());
     }
@@ -184,7 +184,7 @@ public class TestPixelsExecutor
                 "region_join_nation_join_supplier_join_lineitem_join_orders_join_customer", join5);
 
         PixelsExecutor joinExecutor = new PixelsExecutor(
-                123456, root, false, true);
+                123456, root, false, true, Optional.empty());
 
         JoinOperator joinOperator = joinExecutor.getJoinOperator(root, Optional.empty());
     }
@@ -258,7 +258,7 @@ public class TestPixelsExecutor
                 "region_join_nation_join_supplier_join_lineitem_join_part", join4);
 
         PixelsExecutor joinExecutor = new PixelsExecutor(
-                123456, root, false, true);
+                123456, root, false, true, Optional.empty());
 
         JoinOperator joinOperator = joinExecutor.getJoinOperator(root, Optional.empty());
     }

--- a/pixels-lambda/pom.xml
+++ b/pixels-lambda/pom.xml
@@ -144,7 +144,7 @@
                 </configuration>
                 <executions>
                     <execution>
-                        <id>pixels-lambda</id>
+                        <id>pixels-lambda-workers</id>
                         <phase>package</phase>
                         <goals>
                             <goal>shade</goal>
@@ -155,7 +155,7 @@
                                     <include>io.pixelsdb:*</include>
                                 </includes>
                             </artifactSet>
-                            <finalName>pixels-lambda</finalName>
+                            <finalName>pixels-lambda-workers</finalName>
                             <outputDirectory>${project.parent.basedir}/pixels-lambda/target</outputDirectory>
                             <transformers>
                                 <transformer implementation="com.github.edwgiz.maven_shade_plugin.log4j2_cache_transformer.PluginsCacheFileTransformer">


### PR DESCRIPTION
1. improve string comparison in BinaryColumnVector and Dictionary.
2. improve concurrency of Joiner and Aggregator.
3. fix meta service error when creating Pixels/Starling executor.
4. use multiple hash maps in Aggregator to improve the scalability of the hash table.