### PR TITLE
[Issue #367]: fix BinaryColumnVector for dictionary encoding.

### DIFF
--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/utils/Dictionary.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/utils/Dictionary.java
@@ -29,10 +29,31 @@ import java.io.OutputStream;
  */
 public interface Dictionary
 {
+    /**
+     * Add a key (i.e., a string) into the dictionary.
+     * @param key the byte content of the key.
+     * @return the position (i.e., encoded id) of the key.
+     */
     int add(String key);
 
+    /**
+     * Add a key (i.e., a string) into the dictionary.
+     * Note that to reduce memory allocation and copying, key might be stored in the dictionary
+     * without copying, therefore the content in key should not be overwritten after being added.
+     * @param key the byte content of the key.
+     * @return the position (i.e., encoded id) of the key.
+     */
     int add(byte[] key);
 
+    /**
+     * Add a key (i.e., a string) into the dictionary.
+     * Note that to reduce memory allocation and copying, key might be stored in the dictionary
+     * without copying, therefore the content in key should not be overwritten after being added.
+     * @param key the byte content of the key.
+     * @param offset the starting offset of the key in the byte array.
+     * @param length the length in bytes of the key.
+     * @return the position (i.e., encoded id) of the key.
+     */
     int add(byte[] key, int offset, int length);
 
     /**

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/DoubleColumnVector.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/DoubleColumnVector.java
@@ -283,7 +283,8 @@ public class DoubleColumnVector extends ColumnVector
     public void reset()
     {
         super.reset();
-        Arrays.fill(vector, Double.doubleToLongBits(NULL_VALUE));
+        // Issue #367: We should not rely on the vector to distinguish null values.
+        // Arrays.fill(vector, Double.doubleToLongBits(NULL_VALUE));
     }
 
     @Override

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/LongDecimalColumnVector.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/LongDecimalColumnVector.java
@@ -414,7 +414,8 @@ public class LongDecimalColumnVector extends ColumnVector
     public void reset()
     {
         super.reset();
-        Arrays.fill(vector, DEFAULT_UNSCALED_VALUE);
+        // Issue #367: We should not rely on the vector to distinguish null values.
+        // Arrays.fill(vector, DEFAULT_UNSCALED_VALUE);
     }
 
     @Override

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/VectorizedRowBatch.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/VectorizedRowBatch.java
@@ -259,7 +259,8 @@ public class VectorizedRowBatch implements AutoCloseable
             if (vc != null)
             {
                 vc.reset();
-                vc.init();
+                // Issue #367: No need to init after reset.
+                // vc.init();
             }
         }
     }


### PR DESCRIPTION
Previously, the buffer inside BinaryColumnVector was referenced inside HashTableDictionary, but it is overwritten by the next row batch write. This is incorrect. We ensure the buffer is recreated when the row batch is reset for the next row batch write.