### PR TITLE
[Issue #373]: support direct read on localFS.

### DIFF
--- a/pixels-common/pom.xml
+++ b/pixels-common/pom.xml
@@ -29,6 +29,12 @@
             <optional>true</optional>
         </dependency>
 
+        <dependency>
+            <groupId>net.java.dev.jna</groupId>
+            <artifactId>jna</artifactId>
+            <version>5.13.0</version>
+        </dependency>
+
         <!-- ozone, if it is enabled,
         make sure that it is compatible with hadoop libs. -->
         <!--<dependency>

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/PhysicalReader.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/PhysicalReader.java
@@ -42,9 +42,23 @@ public interface PhysicalReader extends Closeable
     void readFully(byte[] buffer, int offset, int length) throws IOException;
 
     /**
+     * If direct I/O is supported, {@link #readFully(int)} will directly read from the file
+     * without going through the OS cache. This is currently supported on LocalFS.
+     *
+     * @return true if direct read is supported.
+     */
+    default boolean supportsDirect()
+    {
+        return false;
+    }
+
+    /**
      * @return true if readAsync is supported.
      */
-    boolean supportsAsync();
+    default boolean supportsAsync()
+    {
+        return false;
+    }
 
     /**
      * readAsync does not affect the position of this reader, and is not affected by seek().
@@ -53,7 +67,10 @@ public interface PhysicalReader extends Closeable
      * @return
      * @throws IOException
      */
-    CompletableFuture<ByteBuffer> readAsync(long offset, int length) throws IOException;
+    default CompletableFuture<ByteBuffer> readAsync(long offset, int length) throws IOException
+    {
+        throw new UnsupportedOperationException("asynchronous read is not supported for " + getStorageScheme().name());
+    }
 
     long readLong() throws IOException;
 

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/direct/AlignedDirectBuffer.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/direct/AlignedDirectBuffer.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2023 PixelsDB.
+ *
+ * This file is part of Pixels.
+ *
+ * Pixels is free software: you can redistribute it and/or modify
+ * it under the terms of the Affero GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * Pixels is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Affero GNU General Public License for more details.
+ *
+ * You should have received a copy of the Affero GNU General Public
+ * License along with Pixels.  If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package io.pixelsdb.pixels.common.physical.direct;
+
+import com.sun.jna.Pointer;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+/**
+ * Created at: 02/02/2023
+ * Author: hank
+ */
+public class AlignedDirectBuffer implements Closeable
+{
+    private ByteBuffer buffer;
+    private Pointer pointer;
+    private final long address;
+    private final int size;
+    private final int allocatedSize;
+
+    protected AlignedDirectBuffer(Pointer alignedPointer, int size, int allocatedSize) throws IllegalAccessException
+    {
+        this.pointer = alignedPointer;
+        this.size = size;
+        this.allocatedSize = allocatedSize;
+        this.address = DirectIoLib.getAddress(alignedPointer);
+        this.buffer = DirectIoLib.newDirectByteBufferR(allocatedSize, this.address);
+    }
+
+    public void shift(int pos)
+    {
+        checkArgument(pos + this.size <= this.allocatedSize,
+                "shift leads to truncation which is not allowed");
+        this.buffer.position(pos);
+        this.buffer.limit(pos + this.size);
+    }
+
+    public void reset()
+    {
+        this.buffer.clear();
+    }
+
+    public ByteBuffer getBuffer()
+    {
+        return buffer;
+    }
+
+    public int getSize()
+    {
+        return size;
+    }
+
+    public int getAllocatedSize()
+    {
+        return allocatedSize;
+    }
+
+    public Pointer getPointer()
+    {
+        return pointer;
+    }
+
+    public long getAddress()
+    {
+        return address;
+    }
+
+    public boolean hasRemaining()
+    {
+        return this.buffer.hasRemaining();
+    }
+
+    public int remaining()
+    {
+        return this.buffer.remaining();
+    }
+
+    public byte get()
+    {
+        return this.buffer.get();
+    }
+
+    public short getShort()
+    {
+        return this.buffer.getShort();
+    }
+
+    public char getChar()
+    {
+        return this.buffer.getChar();
+    }
+
+    public int getInt()
+    {
+        return this.buffer.getInt();
+    }
+
+    public long getLong()
+    {
+        return this.buffer.getLong();
+    }
+
+    public float getFloat()
+    {
+        return this.buffer.getFloat();
+    }
+
+    public double getDouble()
+    {
+        return this.buffer.getDouble();
+    }
+
+    public int position()
+    {
+        return this.buffer.position();
+    }
+
+    @Override
+    public void close() throws IOException
+    {
+        DirectIoLib.free(this.pointer);
+        this.pointer = null;
+        this.buffer = null;
+    }
+}

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/direct/DirectIoLib.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/direct/DirectIoLib.java
@@ -1,0 +1,330 @@
+/*
+ * Copyright 2023 PixelsDB.
+ *
+ * This file is part of Pixels.
+ *
+ * Pixels is free software: you can redistribute it and/or modify
+ * it under the terms of the Affero GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * Pixels is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Affero GNU General Public License for more details.
+ *
+ * You should have received a copy of the Affero GNU General Public
+ * License along with Pixels.  If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package io.pixelsdb.pixels.common.physical.direct;
+
+import com.sun.jna.Native;
+import com.sun.jna.Platform;
+import com.sun.jna.Pointer;
+import com.sun.jna.ptr.PointerByReference;
+import io.pixelsdb.pixels.common.utils.ConfigFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.FileDescriptor;
+import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Mapping Linux I/O functions to native methods.
+ * Partially referenced the implementation of Jaydio (https://github.com/smacke/jaydio),
+ * which is implemented by Stephen Macke and licensed under Apache 2.0.
+ * We replaced the complex buffer implementation with java direct byte buffer, thus we
+ * can directly return the byte buffer to the calling problem with memory copying.
+ * <p>
+ * Created at: 02/02/2023
+ * Author: hank
+ */
+public class DirectIoLib
+{
+    private static final Logger logger = LoggerFactory.getLogger(DirectIoLib.class);
+    private static boolean compatible;
+    private static final int fsBlockSize;
+    private static final long fsBlockNotMask;
+
+    private static Field pointerPeer = null;
+    private static Constructor<?> directByteBufferRConstructor = null;
+
+    private static final int O_RDONLY = 00;
+    private static final int O_WRONLY = 01;
+    private static final int O_RDWR = 02;
+    private static final int O_CREAT = 0100;
+    private static final int O_TRUNC = 01000;
+    private static final int O_DIRECT = 040000;
+    private static final int O_SYNC = 04000000;
+
+    static
+    {
+        fsBlockSize = Integer.parseInt(ConfigFactory.Instance().getProperty("localfs.block.size"));
+        fsBlockNotMask = ~((long) fsBlockSize - 1);
+        compatible = false;
+        try
+        {
+            try
+            {
+                pointerPeer = Class.forName("com.sun.jna.Pointer").getDeclaredField("peer");
+                pointerPeer.setAccessible(true);
+                // this is from sun.nio.ch.Util.initDBBRConstructor
+                Class<?> cl = Class.forName("java.nio.DirectByteBufferR");
+                Constructor<?> ctor = cl.getDeclaredConstructor(
+                        new Class<?>[] { int.class, long.class, FileDescriptor.class, Runnable.class } );
+                ctor.setAccessible(true);
+                directByteBufferRConstructor = ctor;
+            } catch (Throwable e)
+            {
+                logger.error("failed to reflect fields and methods", e);
+                throw new InternalError(e);
+            }
+
+            if (!Platform.isLinux())
+            {
+                logger.error("direct io is not supported on OS other than Linux");
+            } else
+            { // now check to see if we have O_DIRECT...
+
+                final int linuxVersion = 0;
+                final int majorRev = 1;
+                final int minorRev = 2;
+
+                List<Integer> versionNumbers = new ArrayList<Integer>();
+                for (String v : System.getProperty("os.version").split("\\.|-"))
+                {
+                    if (v.matches("\\d"))
+                    {
+                        versionNumbers.add(Integer.parseInt(v));
+                    }
+                }
+
+                /* From "man 2 open":
+                 *
+                 * O_DIRECT  support was added under Linux in kernel version 2.4.10.
+                 * Older Linux kernels simply ignore this flag.  Some file systems may not implement
+                 * the flag and open() will fail with EINVAL if it is used.
+                 */
+
+                // test to see whether kernel version >= 2.4.10
+                if (versionNumbers.get(linuxVersion) > 2)
+                {
+                    compatible = true;
+                } else if (versionNumbers.get(linuxVersion) == 2)
+                {
+                    if (versionNumbers.get(majorRev) > 4)
+                    {
+                        compatible = true;
+                    } else if (versionNumbers.get(majorRev) == 4 && versionNumbers.get(minorRev) >= 10)
+                    {
+                        compatible = true;
+                    }
+                }
+
+                if (compatible)
+                {
+                    Native.register(Platform.C_LIBRARY_NAME); // register native methods
+                } else
+                {
+                    logger.error(String.format("O_DIRECT not supported on Linux version: %d.%d.%d", linuxVersion, majorRev, minorRev));
+                }
+            }
+        } catch (Throwable e)
+        {
+            logger.error("unable to register libc at class load time: " + e.getMessage(), e);
+        }
+    }
+
+    private DirectIoLib() { }
+
+    // -- native function hooks --
+    public static native int close(int fd);
+
+    private static native long pread(int fd, Pointer buf, long count, long offset);
+
+    private static native int open(String pathname, int flags);
+
+    /**
+     * Given a pointer-to-pointer <tt>memptr</tt>, sets the dereferenced value to point to the start
+     * of an allocated block of <tt>size</tt> bytes, where the starting address is a multiple of
+     * <tt>alignment</tt>. It is guaranteed that the block may be freed by calling @{link {@link #free(Pointer)}
+     * on the starting address. See "man 3 posix_memalign".
+     *
+     * @param memptr The pointer-to-pointer which will point to the address of the allocated aligned block
+     *
+     * @param alignment The alignment multiple of the starting address of the allocated block
+     *
+     * @param size The number of bytes to allocate
+     *
+     * @return 0 on success, one of the C error codes on failure.
+     */
+    private static native int posix_memalign(PointerByReference memptr, long alignment, long size);
+
+    /**
+     * @param ptr The pointer to the hunk of memory which needs freeing
+     */
+    public static native void free(Pointer ptr);
+
+    private static native String strerror(int errnum);
+
+    public static long getAddress(Pointer pointer) throws IllegalAccessException
+    {
+        return (Long) pointerPeer.get(pointer);
+    }
+
+    // this is derived from sun.nio.ch.Util.newMappedByteBufferR
+    // create a read only direct byte buffer without memory copy.
+    public static ByteBuffer newDirectByteBufferR(int size, long addr)
+    {
+        ByteBuffer buffer;
+        try
+        {
+            buffer = (ByteBuffer) directByteBufferRConstructor.newInstance(
+                    new Object[]{ size, addr, null, null });
+        } catch (InstantiationException |
+                IllegalAccessException |
+                InvocationTargetException e)
+        {
+            throw new InternalError(e);
+        }
+        return buffer;
+    }
+
+    /**
+     * Allocate a byte buffer aligned to a multiple of block size.
+     * @param size
+     * @return
+     */
+    public static AlignedDirectBuffer allocateAligned(int size) throws IllegalAccessException
+    {
+        PointerByReference pointerToPointer = new PointerByReference();
+        // allocate one additional block for read alignment.
+        int allocated = blockEnd(size) + fsBlockSize;
+        posix_memalign(pointerToPointer, fsBlockSize, allocated);
+        return new AlignedDirectBuffer(pointerToPointer.getValue(), size, allocated);
+    }
+
+    /**
+     *
+     * @param fd A file discriptor to pass to native pread
+     * @param fileOffset The file offset at which to read
+     * @param buffer he buffer into which to record the file read
+     * @param length the number of bytes to read from the file
+     * @return The number of bytes successfully read from the file
+     * @throws IOException
+     */
+    public static int readDirect(int fd, long fileOffset, AlignedDirectBuffer buffer, int length) throws IOException
+    {
+        // the file will be read from blockStart(fileOffset), and the first fileDelta bytes should be ignored.
+        long fileOffsetAligned = blockStart(fileOffset);
+        long toRead = blockEnd(fileOffset + length) - blockStart(fileOffset);
+        int read = (int) pread(fd, buffer.getPointer(), toRead, fileOffsetAligned);
+        buffer.reset();
+        buffer.shift(((int) (fileOffset - fileOffsetAligned)));
+        return read;
+    }
+
+    /**
+     * Use the <tt>open</tt> Linux system call and pass in the <tt>O_DIRECT</tt> flag.
+     * Currently, the only other flags passed in are <tt>O_RDONLY</tt> if <tt>readOnly</tt>
+     * is <tt>true</tt>, and (if not) <tt>O_RDWR</tt> and <tt>O_CREAT</tt>.
+     *
+     * @param path The path to the file to open. If file does not exist, and we are opening
+     *             with <tt>readOnly</tt>, this will throw an error. Otherwise, if it does
+     *             not exist, but we have <tt>readOnly</tt> set to false, create the file.
+     * @param readOnly Whether to pass in <tt>O_RDONLY</tt>
+     * @return An integer file descriptor for the opened file
+     * @throws IOException
+     */
+    public static int openDirect(String path, boolean readOnly) throws IOException
+    {
+        int flags = O_DIRECT;
+        if (readOnly)
+        {
+            flags |= O_RDONLY;
+        } else
+        {
+            flags |= O_RDWR | O_CREAT;
+        }
+        int fd = open(path, flags);
+        if (fd < 0)
+        {
+            throw new IOException("error opening " + path + ", got " + getLastError());
+        }
+        return fd;
+    }
+
+    /**
+     * Hooks into errno using Native.getLastError(), and parses it with native strerror function.
+     *
+     * @return An error message corresponding to the last <tt>errno</tt>
+     */
+    private static String getLastError()
+    {
+        return strerror(Native.getLastError());
+    }
+
+
+    // -- alignment logic utility methods
+
+    /**
+     * @return The soft block size for use with transfer multiples
+     * and memory alignment multiples
+     */
+    public static int blockSize()
+    {
+        return fsBlockSize;
+    }
+
+    /**
+     * Given <tt>value</tt>, find the largest number less than or equal
+     * to <tt>value</tt> which is a multiple of the fs block size.
+     *
+     * @param value
+     * @return The largest number less than or equal to <tt>value</tt>
+     * which is a multiple of the soft block size
+     */
+    private static long blockStart(long value)
+    {
+        return value & fsBlockNotMask;
+    }
+
+
+    /**
+     * @see #blockStart(long)
+     */
+    private static int blockStart(int value)
+    {
+        return (int) (value & fsBlockNotMask);
+    }
+
+
+    /**
+     * Given <tt>value</tt>, find the smallest number greater than or equal
+     * to <tt>value</tt> which is a multiple of the fs block size.
+     *
+     * @param value
+     * @return The smallest number greater than or equal to <tt>value</tt>
+     * which is a multiple of the soft block size
+     */
+    private static long blockEnd(long value)
+    {
+        return (value + fsBlockSize - 1) & fsBlockNotMask;
+    }
+
+
+    /**
+     * @see #blockEnd(long)
+     */
+    private static int blockEnd(int value)
+    {
+        return (int) ((value + fsBlockSize - 1) & fsBlockNotMask);
+    }
+}

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/direct/DirectRandomAccessFile.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/direct/DirectRandomAccessFile.java
@@ -1,0 +1,278 @@
+/*
+ * Copyright 2023 PixelsDB.
+ *
+ * This file is part of Pixels.
+ *
+ * Pixels is free software: you can redistribute it and/or modify
+ * it under the terms of the Affero GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * Pixels is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Affero GNU General Public License for more details.
+ *
+ * You should have received a copy of the Affero GNU General Public
+ * License along with Pixels.  If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package io.pixelsdb.pixels.common.physical.direct;
+
+import java.io.Closeable;
+import java.io.DataInput;
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.LinkedList;
+
+/**
+ * The random accessible file opened with o_direct flag.
+ * Currently, it is readonly.
+ *
+ * Created at: 02/02/2023
+ * Author: hank
+ */
+public class DirectRandomAccessFile implements DataInput, Closeable
+{
+    private File file;
+    private int fd;
+    private long offset;
+    private long length;
+    private final int blockSize;
+    private boolean bufferValid;
+    private AlignedDirectBuffer smallBuffer;
+    private LinkedList<AlignedDirectBuffer> largeBuffers = new LinkedList<>();
+
+    public DirectRandomAccessFile(File file, boolean readOnly) throws IOException
+    {
+        this.file = file;
+        this.fd = DirectIoLib.openDirect(file.getPath(), readOnly);
+        this.offset = 0;
+        this.length = this.file.length();
+        this.blockSize = DirectIoLib.blockSize();
+        this.bufferValid = false;
+        try
+        {
+            this.smallBuffer = DirectIoLib.allocateAligned(DirectIoLib.blockSize());
+        } catch (IllegalAccessException e)
+        {
+            throw new IOException("failed to allocate buffer", e);
+        }
+
+    }
+
+    @Override
+    public void close() throws IOException
+    {
+        this.smallBuffer.close();
+        this.smallBuffer = null;
+        for (AlignedDirectBuffer largeBuffer : this.largeBuffers)
+        {
+            largeBuffer.close();
+        }
+        this.largeBuffers.clear();
+        this.largeBuffers = null;
+        DirectIoLib.close(fd);
+        this.fd = -1;
+        this.offset = 0;
+        this.length = 0;
+        this.file = null;
+    }
+
+    @Override
+    public void readFully(byte[] b) throws IOException
+    {
+        ByteBuffer buffer = readDirect(b.length);
+        buffer.get(b);
+        // ((DirectBuffer) buffer).cleaner().clean();
+    }
+
+    @Override
+    public void readFully(byte[] b, int off, int len) throws IOException
+    {
+        ByteBuffer buffer = readDirect(len);
+        buffer.get(b, off, len);
+    }
+
+    public ByteBuffer readDirect(int len) throws IOException
+    {
+        try
+        {
+            AlignedDirectBuffer buffer = DirectIoLib.allocateAligned(len);
+            DirectIoLib.readDirect(this.fd, this.offset, buffer, len);
+            this.seek(this.offset + len);
+            this.largeBuffers.add(buffer);
+            return buffer.getBuffer();
+        } catch (IllegalAccessException e)
+        {
+            throw new IOException("failed to allocate buffer", e);
+        }
+    }
+
+    @Override
+    public int skipBytes(int n) throws IOException
+    {
+        if (n <= 0)
+        {
+            return 0;
+        }
+        long off = this.offset;
+        long newOff = Math.min(off + n, length);
+        seek(newOff);
+        return (int)(newOff - off);
+    }
+
+    private void populateBuffer() throws IOException
+    {
+        this.smallBuffer.reset();
+        DirectIoLib.readDirect(this.fd, this.offset, this.smallBuffer, this.blockSize);
+        this.bufferValid = true;
+    }
+
+    @Override
+    public boolean readBoolean() throws IOException
+    {
+        if (!this.bufferValid || this.smallBuffer.hasRemaining())
+        {
+            this.populateBuffer();
+        }
+        this.offset++;
+        return this.smallBuffer.get() != 0;
+    }
+
+    @Override
+    public byte readByte() throws IOException
+    {
+        if (!this.bufferValid || this.smallBuffer.hasRemaining())
+        {
+            this.populateBuffer();
+        }
+        this.offset++;
+        return this.smallBuffer.get();
+    }
+
+    @Override
+    public int readUnsignedByte() throws IOException
+    {
+        if (!this.bufferValid || this.smallBuffer.hasRemaining())
+        {
+            this.populateBuffer();
+        }
+        this.offset++;
+        return this.smallBuffer.get();
+    }
+
+    @Override
+    public short readShort() throws IOException
+    {
+        if (!this.bufferValid || this.smallBuffer.remaining() < Short.BYTES)
+        {
+            this.populateBuffer();
+        }
+        this.offset += Short.BYTES;
+        return this.smallBuffer.getShort();
+    }
+
+    @Override
+    public int readUnsignedShort() throws IOException
+    {
+        if (!this.bufferValid || this.smallBuffer.remaining() < Short.BYTES)
+        {
+            this.populateBuffer();
+        }
+        int b1 = this.smallBuffer.get();
+        int b2 = this.smallBuffer.get();
+        this.offset += 2;
+        return (b1<<8) + b2;
+    }
+
+    @Override
+    public char readChar() throws IOException
+    {
+        if (!this.bufferValid || this.smallBuffer.remaining() < Character.BYTES)
+        {
+            this.populateBuffer();
+        }
+        this.offset += Character.BYTES;
+        return this.smallBuffer.getChar();
+    }
+
+    @Override
+    public int readInt() throws IOException
+    {
+        if (!this.bufferValid || this.smallBuffer.remaining() < Integer.BYTES)
+        {
+            this.populateBuffer();
+        }
+        this.offset += Integer.BYTES;
+        return this.smallBuffer.getInt();
+    }
+
+    @Override
+    public long readLong() throws IOException
+    {
+        if (!this.bufferValid || this.smallBuffer.remaining() < Long.BYTES)
+        {
+            this.populateBuffer();
+        }
+        this.offset += Long.BYTES;
+        return this.smallBuffer.getLong();
+    }
+
+    @Override
+    public float readFloat() throws IOException
+    {
+        if (!this.bufferValid || this.smallBuffer.remaining() < Float.BYTES)
+        {
+            this.populateBuffer();
+        }
+        this.offset += Float.BYTES;
+        return this.smallBuffer.getFloat();
+    }
+
+    @Override
+    public double readDouble() throws IOException
+    {
+        if (!this.bufferValid || this.smallBuffer.remaining() < Double.BYTES)
+        {
+            this.populateBuffer();
+        }
+        this.offset += Double.BYTES;
+        return this.smallBuffer.getDouble();
+    }
+
+    @Override
+    public String readLine() throws IOException
+    {
+        throw new UnsupportedOperationException("read line is not supported");
+    }
+
+    /**
+     * This method is currently not implemented.
+     */
+    @Override
+    public String readUTF() throws IOException
+    {
+        throw new UnsupportedOperationException("read UTF is not supported");
+    }
+
+    public void seek(long offset) throws IOException
+    {
+        if (this.bufferValid && offset > this.offset - this.smallBuffer.position() &&
+                offset < this.offset + this.smallBuffer.remaining())
+        {
+            this.smallBuffer.shift(this.smallBuffer.position() + (int) (offset - this.offset));
+        }
+        else
+        {
+            this.bufferValid = false;
+        }
+        this.offset = offset;
+    }
+
+    public long length()
+    {
+        return this.length;
+    }
+}

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/direct/DirectRandomAccessFile.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/direct/DirectRandomAccessFile.java
@@ -59,7 +59,6 @@ public class DirectRandomAccessFile implements DataInput, Closeable
         {
             throw new IOException("failed to allocate buffer", e);
         }
-
     }
 
     @Override
@@ -85,7 +84,6 @@ public class DirectRandomAccessFile implements DataInput, Closeable
     {
         ByteBuffer buffer = readDirect(b.length);
         buffer.get(b);
-        // ((DirectBuffer) buffer).cleaner().clean();
     }
 
     @Override

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/io/MockReader.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/io/MockReader.java
@@ -1,3 +1,22 @@
+/*
+ * Copyright 2022 PixelsDB.
+ *
+ * This file is part of Pixels.
+ *
+ * Pixels is free software: you can redistribute it and/or modify
+ * it under the terms of the Affero GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * Pixels is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Affero GNU General Public License for more details.
+ *
+ * You should have received a copy of the Affero GNU General Public
+ * License along with Pixels.  If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
 package io.pixelsdb.pixels.common.physical.io;
 
 import io.pixelsdb.pixels.common.physical.PhysicalReader;

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/io/PhysicalHDFSReader.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/io/PhysicalHDFSReader.java
@@ -34,7 +34,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -200,21 +199,6 @@ public class PhysicalHDFSReader implements PhysicalReader
     {
         rawReader.readFully(buffer, offset, length);
         numRequests.incrementAndGet();
-    }
-
-    /**
-     * @return true if readAsync is supported.
-     */
-    @Override
-    public boolean supportsAsync()
-    {
-        return false;
-    }
-
-    @Override
-    public CompletableFuture<ByteBuffer> readAsync(long offset, int length) throws IOException
-    {
-        throw new IOException("Asynchronous read is not supported for HDFS.");
     }
 
     @Override

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/io/PhysicalLocalReader.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/io/PhysicalLocalReader.java
@@ -21,10 +21,10 @@ package io.pixelsdb.pixels.common.physical.io;
 
 import io.pixelsdb.pixels.common.physical.PhysicalReader;
 import io.pixelsdb.pixels.common.physical.Storage;
+import io.pixelsdb.pixels.common.physical.direct.DirectRandomAccessFile;
 import io.pixelsdb.pixels.common.physical.storage.LocalFS;
 
 import java.io.IOException;
-import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -38,7 +38,7 @@ public class PhysicalLocalReader implements PhysicalReader
     private final LocalFS local;
     private final String path;
     private final long id;
-    private final RandomAccessFile raf;
+    private final DirectRandomAccessFile raf;
     private final AtomicInteger numRequests;
 
     public PhysicalLocalReader(Storage storage, String path) throws IOException

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/io/PhysicalLocalReader.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/io/PhysicalLocalReader.java
@@ -26,7 +26,6 @@ import io.pixelsdb.pixels.common.physical.storage.LocalFS;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -79,10 +78,10 @@ public class PhysicalLocalReader implements PhysicalReader
     @Override
     public ByteBuffer readFully(int length) throws IOException
     {
-        ByteBuffer buffer = ByteBuffer.allocate(length);
-        raf.readFully(buffer.array());
+        //ByteBuffer buffer = ByteBuffer.allocate(length);
+        //raf.readFully(buffer.array());
         numRequests.incrementAndGet();
-        return buffer;
+        return raf.readDirect(length);
     }
 
     @Override
@@ -100,18 +99,12 @@ public class PhysicalLocalReader implements PhysicalReader
     }
 
     /**
-     * @return true if readAsync is supported.
+     * @return true if readDirect is supported.
      */
     @Override
-    public boolean supportsAsync()
+    public boolean supportsDirect()
     {
-        return false;
-    }
-
-    @Override
-    public CompletableFuture<ByteBuffer> readAsync(long offset, int length) throws IOException
-    {
-        throw new IOException("Asynchronous read is not supported for local fs.");
+        return true;
     }
 
     @Override

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/io/PhysicalMinioReader.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/io/PhysicalMinioReader.java
@@ -47,7 +47,7 @@ public class PhysicalMinioReader extends AbstractS3Reader
     @Override
     public CompletableFuture<ByteBuffer> readAsync(long offset, int len) throws IOException
     {
-        throw new UnsupportedOperationException("Asynchronous read is not supported for Minio.");
+        throw new UnsupportedOperationException("asynchronous read is not supported for Minio.");
     }
 
     @Override

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/io/PhysicalRedisReader.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/io/PhysicalRedisReader.java
@@ -27,7 +27,6 @@ import redis.clients.jedis.JedisPooled;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -121,18 +120,6 @@ public class PhysicalRedisReader implements PhysicalReader
     {
         ByteBuffer byteBuffer = readFully(len);
         System.arraycopy(byteBuffer.array(), 0, buffer, off, len);
-    }
-
-    @Override
-    public boolean supportsAsync()
-    {
-        return false;
-    }
-
-    @Override
-    public CompletableFuture<ByteBuffer> readAsync(long offset, int length) throws IOException
-    {
-        throw new UnsupportedOperationException("Asynchronous read is not supported for Redis.");
     }
 
     @Override

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/storage/LocalFS.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/storage/LocalFS.java
@@ -22,6 +22,7 @@ package io.pixelsdb.pixels.common.physical.storage;
 import io.etcd.jetcd.KeyValue;
 import io.pixelsdb.pixels.common.physical.Status;
 import io.pixelsdb.pixels.common.physical.Storage;
+import io.pixelsdb.pixels.common.physical.direct.DirectRandomAccessFile;
 import io.pixelsdb.pixels.common.utils.ConfigFactory;
 import io.pixelsdb.pixels.common.utils.EtcdUtil;
 
@@ -300,7 +301,7 @@ public final class LocalFS implements Storage
         return new DataOutputStream(new BufferedOutputStream(new FileOutputStream(file), bufferSize));
     }
 
-    public RandomAccessFile openRaf(String path) throws IOException
+    public DirectRandomAccessFile openRaf(String path) throws IOException
     {
         Path p = new Path(path);
         if (!p.valid)
@@ -316,7 +317,7 @@ public final class LocalFS implements Storage
         {
             throw new IOException("File '" + p.realPath + "' doesn't exists.");
         }
-        return new RandomAccessFile(file, "r");
+        return new DirectRandomAccessFile(file, true);
     }
 
     @Override

--- a/pixels-common/src/main/resources/pixels.properties
+++ b/pixels-common/src/main/resources/pixels.properties
@@ -87,6 +87,7 @@ s3.client.service.threads=40
 s3.max.request.concurrency=1000
 s3.max.pending.requests=100000
 gcs.enable.async=true
+localfs.block.size=4096
 
 # pixels executor
 executor.input.storage=s3

--- a/pixels-common/src/test/java/io/pixelsdb/pixels/common/physical/TestDirect.java
+++ b/pixels-common/src/test/java/io/pixelsdb/pixels/common/physical/TestDirect.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2023 PixelsDB.
+ *
+ * This file is part of Pixels.
+ *
+ * Pixels is free software: you can redistribute it and/or modify
+ * it under the terms of the Affero GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * Pixels is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Affero GNU General Public License for more details.
+ *
+ * You should have received a copy of the Affero GNU General Public
+ * License along with Pixels.  If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package io.pixelsdb.pixels.common.physical;
+
+import io.pixelsdb.pixels.common.physical.direct.AlignedDirectBuffer;
+import io.pixelsdb.pixels.common.physical.direct.DirectIoLib;
+import io.pixelsdb.pixels.common.physical.direct.DirectRandomAccessFile;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Created at: 02/02/2023
+ * Author: hank
+ */
+public class TestDirect
+{
+    @Test
+    public void testDirectIoLib() throws IOException, IllegalAccessException
+    {
+        int fd = DirectIoLib.openDirect("/home/hank/20230126155625_0.pxl", true);
+        AlignedDirectBuffer buffer = DirectIoLib.allocateAligned(8);
+        int read = DirectIoLib.readDirect(fd, 4094, buffer, 8);
+        System.out.println(read);
+        for (int i = 0; i < 8; ++i)
+        {
+            System.out.println(buffer.get());
+        }
+    }
+
+    @Test
+    public void testDirectRaf() throws IOException
+    {
+        DirectRandomAccessFile raf = new DirectRandomAccessFile(new File("/home/hank/20230126155625_0.pxl"), true);
+        raf.seek(raf.length()-8);
+        int a = raf.readInt();
+        System.out.println(a);
+        raf.seek(raf.length()-4);
+        int b = raf.readInt();
+        System.out.println(b);
+        System.out.println(raf.length());
+    }
+}

--- a/pixels-common/src/test/java/io/pixelsdb/pixels/common/physical/TestGCS.java
+++ b/pixels-common/src/test/java/io/pixelsdb/pixels/common/physical/TestGCS.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 PixelsDB.
+ * Copyright 2022 PixelsDB.
  *
  * This file is part of Pixels.
  *

--- a/pixels-common/src/test/java/io/pixelsdb/pixels/common/physical/TestJNA.java
+++ b/pixels-common/src/test/java/io/pixelsdb/pixels/common/physical/TestJNA.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2023 PixelsDB.
+ *
+ * This file is part of Pixels.
+ *
+ * Pixels is free software: you can redistribute it and/or modify
+ * it under the terms of the Affero GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * Pixels is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Affero GNU General Public License for more details.
+ *
+ * You should have received a copy of the Affero GNU General Public
+ * License along with Pixels.  If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package io.pixelsdb.pixels.common.physical;
+
+import com.sun.jna.Native;
+import com.sun.jna.Platform;
+import com.sun.jna.Pointer;
+import com.sun.jna.ptr.PointerByReference;
+import org.junit.Test;
+import sun.nio.ch.DirectBuffer;
+
+import java.lang.reflect.Field;
+import java.nio.ByteBuffer;
+
+/**
+ * Created at: 02/02/2023
+ * Author: hank
+ */
+public class TestJNA
+{
+    private static native long pread(int fd, Pointer buf, long count, long offset);
+    private static native int open(String pathname, int flags);
+    public native int close(int fd); // musn't forget to do this
+    private static native String strerror(int errnum);
+    private static native int posix_memalign(PointerByReference memptr, long alignment, long size);
+    private static native void free(long ptr);
+
+    public static final int O_RDONLY = 00;
+    public static final int O_WRONLY = 01;
+    public static final int O_RDWR = 02;
+    public static final int O_CREAT = 0100;
+    public static final int O_TRUNC = 01000;
+    public static final int O_DIRECT = 040000;
+    public static final int O_SYNC = 04000000;
+
+    private static final int BLOCK_SIZE = 4096;
+
+    static
+    {
+        Native.register(Platform.C_LIBRARY_NAME);
+    }
+
+    private ByteBuffer readDirect(int fd, long fileOffset, int length)
+    {
+        int toAllocate = (length/BLOCK_SIZE*BLOCK_SIZE) + (BLOCK_SIZE*3);
+        long startOffset = fileOffset / BLOCK_SIZE * BLOCK_SIZE;
+        long endOffset = (fileOffset+length) / BLOCK_SIZE * BLOCK_SIZE + BLOCK_SIZE;
+        int fileAlign = (int) (fileOffset % BLOCK_SIZE);
+        int toRead = (int) (endOffset - startOffset);
+        ByteBuffer buffer = ByteBuffer.allocateDirect(toAllocate);
+        long addr = ((DirectBuffer) buffer).address();
+        int bufferAlign = BLOCK_SIZE - (int) (addr % BLOCK_SIZE);
+        buffer.position(fileAlign + bufferAlign);
+        buffer.limit(buffer.position()+length);
+        long read = pread(fd, Pointer.createConstant(addr + bufferAlign), toRead, fileOffset-fileAlign);
+        System.out.println(read);
+        return buffer;
+    }
+
+    @Test
+    public void testDirect()
+    {
+        int fd = open("/home/hank/20230126155625_0.pxl", O_DIRECT | O_RDONLY);
+        ByteBuffer buffer = readDirect(fd, 4094, 8);
+        for (int i = 0; i < 8; ++i)
+        {
+            System.out.println(buffer.get());
+        }
+        close(fd);
+        System.out.println(strerror(Native.getLastError()));
+    }
+
+    @Test
+    public void testNonDirect()
+    {
+        int fd = open("/home/hank/20230126155625_0.pxl", O_RDONLY);
+        ByteBuffer buffer = ByteBuffer.allocateDirect(4096);
+        long addr = ((DirectBuffer) buffer).address();
+        long read = pread(fd, Pointer.createConstant(addr), 4096, 4094);
+        System.out.println(read);
+        for (int i = 0; i < 8; ++i)
+        {
+            System.out.println(buffer.get());
+        }
+        close(fd);
+        System.out.println(strerror(Native.getLastError()));
+    }
+
+    @Test
+    public void testAllocate() throws ClassNotFoundException, NoSuchFieldException, IllegalAccessException
+    {
+        Field peer = Class.forName("com.sun.jna.Pointer").getDeclaredField("peer");
+        peer.setAccessible(true);
+        PointerByReference pointerToPointer = new PointerByReference();
+        posix_memalign(pointerToPointer, 4096, 8192);
+        free((Long) peer.get(pointerToPointer.getValue()));
+    }
+}

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/PixelsReaderImpl.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/PixelsReaderImpl.java
@@ -37,6 +37,7 @@ import org.apache.logging.log4j.Logger;
 
 import javax.annotation.concurrent.NotThreadSafe;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Random;
@@ -174,8 +175,7 @@ public class PixelsReaderImpl
                 long fileTailOffset = fsReader.readLong();
                 int fileTailLength = (int) (fileLen - fileTailOffset - Long.BYTES);
                 fsReader.seek(fileTailOffset);
-                byte[] fileTailBuffer = new byte[fileTailLength];
-                fsReader.readFully(fileTailBuffer);
+                ByteBuffer fileTailBuffer = fsReader.readFully(fileTailLength);
                 fileTail = PixelsProto.FileTail.parseFrom(fileTailBuffer);
                 builderPixelsFooterCache.putFileTail(fileName, fileTail);
             }
@@ -227,9 +227,8 @@ public class PixelsReaderImpl
     {
         long footerOffset = footer.getRowGroupInfos(rowGroupId).getFooterOffset();
         int footerLength = footer.getRowGroupInfos(rowGroupId).getFooterLength();
-        byte[] footer = new byte[footerLength];
         physicalReader.seek(footerOffset);
-        physicalReader.readFully(footer);
+        ByteBuffer footer = physicalReader.readFully(footerLength);
         return PixelsProto.RowGroupFooter.parseFrom(footer);
     }
 

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/DictionaryColumnVector.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/DictionaryColumnVector.java
@@ -38,12 +38,12 @@ import static sun.misc.Unsafe.ARRAY_BYTE_BASE_OFFSET;
 public class DictionaryColumnVector extends ColumnVector
 {
     // The backing array of the dictionary. If dictArray is null, it means dictionary is not set (initialized).
-    public byte[] dictArray;
+    public byte[] dictArray = null;
 
     /* The start offset of each value in the dictionary. The last element is the length of the dictionary.
      * We currently do not support dictionary larger than 2GB, thus using int (not long) array for start.
      */
-    public int[] dictOffsets;
+    public int[] dictOffsets = null;
 
     /* The index of each data element in the dictionary.
      * E.g., there are 1000 data items in this column vector and 10 values in the dictionary, then ids has


### PR DESCRIPTION
If local fs is used for table storage, we use Linux system calls to open the files with the o_direct flag and read the files using spread.
Thus, we can by pass the OS page cache.