### PR TITLE
[Issue #379]: support configurable direct/non-direct I/O in LocalFS.

### DIFF
--- a/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/MemoryMappedFile.java
+++ b/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/MemoryMappedFile.java
@@ -39,7 +39,7 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.channels.FileChannel;
 
-import static io.pixelsdb.pixels.common.physical.direct.DirectIoLib.newDirectByteBufferR;
+import static io.pixelsdb.pixels.common.physical.direct.DirectIoLib.wrapReadOnlyDirectByteBuffer;
 import static io.pixelsdb.pixels.common.utils.JvmUtils.nativeOrder;
 import static io.pixelsdb.pixels.common.utils.JvmUtils.unsafe;
 
@@ -327,7 +327,7 @@ public class MemoryMappedFile
      */
     public ByteBuffer getDirectByteBuffer(long pos, int length)
     {
-        return newDirectByteBufferR(length, pos + addr);
+        return wrapReadOnlyDirectByteBuffer(length, pos + addr);
     }
 
     /**

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/direct/DirectBuffer.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/direct/DirectBuffer.java
@@ -67,11 +67,19 @@ public class DirectBuffer implements Closeable
 
     public void shift(int pos)
     {
-        checkArgument(pos + this.size <= this.allocatedSize,
+        checkArgument(pos >= 0 && pos + this.size <= this.allocatedSize,
                 "shift leads to truncation which is not allowed");
         this.buffer.clear();
         this.buffer.position(pos);
         this.buffer.limit(pos + this.size);
+    }
+
+    public void forward(int delta)
+    {
+        checkArgument(this.buffer.position() + delta >= 0 &&
+                        this.buffer.position() + delta <= this.buffer.limit(),
+                "forward out of limit is not allowed");
+        this.buffer.position(this.buffer.position() + delta);
     }
 
     public void reset()

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/direct/DirectIoLib.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/direct/DirectIoLib.java
@@ -271,10 +271,9 @@ public class DirectIoLib
      * Allocate a direct buffer. If direct I/O is enabled, the allocated buffer is block aligned.
      * <b>REMEMBER</b> to free the allocated buffer by calling {@link #free(Pointer)}.
      * <p>
-     * We find that for non-aligned buffers, allocating memory using native mappings of <tt>malloc</tt>is more
-     * efficient than allocating direct memory using {@link ByteBuffer#allocateDirect(int)}, so we always use
-     * the former way. This also allows us to manually free the allocated large buffers in time, which further
-     * improves the memory allocation performance.
+     * We find that for allocating direct memory, native mapping of <tt>malloc</tt> or <tt>posix_memalign</tt> is more
+     * efficient than {@link ByteBuffer#allocateDirect(int)}, so we always use the former way. This also allows us to
+     * manually free the allocated memory in time, which further improves the memory allocation performance.
      * </p>
      * @param size the number of byte should be allocated at least, must be positive.
      * @return
@@ -337,9 +336,9 @@ public class DirectIoLib
     }
 
     /**
-     * Use the <tt>open</tt> Linux system call and pass in the <tt>O_DIRECT</tt> flag.
-     * Currently, the only other flags passed in are <tt>O_RDONLY</tt> if <tt>readOnly</tt>
-     * is <tt>true</tt>, and (if not) <tt>O_RDWR</tt> and <tt>O_CREAT</tt>.
+     * Use the <tt>open</tt> Linux system call and pass in the <tt>O_DIRECT</tt> flag when direct I/O is enabled.
+     * Currently, the only other flags passed in are <tt>O_RDONLY</tt> if <tt>readOnly</tt> is <tt>true</tt>, and
+     * (if not) <tt>O_RDWR</tt> and <tt>O_CREAT</tt>.
      *
      * @param path The path to the file to open. If file does not exist, and we are opening
      *             with <tt>readOnly</tt>, this will throw an error. Otherwise, if it does

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/direct/DirectIoLib.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/direct/DirectIoLib.java
@@ -50,7 +50,6 @@ import java.util.List;
 public class DirectIoLib
 {
     private static final Logger logger = LoggerFactory.getLogger(DirectIoLib.class);
-    private static boolean compatible;
     /**
      * The soft block size for use with transfer multiples and memory alignment multiples
      */
@@ -79,7 +78,7 @@ public class DirectIoLib
         fsBlockSize = Integer.parseInt(ConfigFactory.Instance().getProperty("localfs.block.size"));
         fsBlockNotMask = ~((long) fsBlockSize - 1);
         directIoEnabled = Boolean.parseBoolean(ConfigFactory.Instance().getProperty("localfs.enable.direct.io"));
-        compatible = false;
+        boolean compatible = false;
         try
         {
             try

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/direct/DirectIoLib.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/direct/DirectIoLib.java
@@ -272,19 +272,19 @@ public class DirectIoLib
      */
     public static DirectBuffer allocateBuffer(int size) throws IllegalAccessException, InvocationTargetException
     {
-        if (directIoEnabled)
-        {
+        //if (directIoEnabled)
+        //{
             PointerByReference pointerToPointer = new PointerByReference();
             // allocate one additional block for read alignment.
-            int allocated = blockEnd(size) + fsBlockSize;
+            int allocated = blockEnd(size) + (directIoEnabled ? fsBlockSize : 0);
             posix_memalign(pointerToPointer, fsBlockSize, allocated);
             return new DirectBuffer(pointerToPointer.getValue(), size, allocated, true);
-        }
-        else
-        {
-            ByteBuffer buffer = ByteBuffer.allocateDirect(size);
-            return new DirectBuffer(buffer, size, false);
-        }
+        //}
+        //else
+        //{
+            //ByteBuffer buffer = ByteBuffer.allocateDirect(size);
+            //return new DirectBuffer(buffer, size, false);
+        //}
     }
 
     /**
@@ -310,7 +310,7 @@ public class DirectIoLib
         else
         {
             int read = (int) pread(fd, buffer.getPointer(), length, fileOffset);
-            buffer.reset();
+            buffer.shift(0);
             return read;
         }
     }

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/direct/DirectRandomAccessFile.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/direct/DirectRandomAccessFile.java
@@ -101,11 +101,7 @@ public class DirectRandomAccessFile implements DataInput, Closeable
             DirectBuffer buffer = DirectIoLib.allocateBuffer(len);
             DirectIoLib.read(this.fd, this.offset, buffer, len);
             this.seek(this.offset + len);
-            if (DirectIoLib.directIoEnabled)
-            {
-                // if direct io is disabled, the buffers are allocated and freed by JVM.
-                this.largeBuffers.add(buffer);
-            }
+            this.largeBuffers.add(buffer);
             return buffer.getBuffer();
         } catch (IllegalAccessException | InvocationTargetException e)
         {

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/direct/DirectRandomAccessFile.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/direct/DirectRandomAccessFile.java
@@ -264,7 +264,7 @@ public class DirectRandomAccessFile implements DataInput, Closeable
         if (this.bufferValid && offset > this.offset - this.smallBuffer.position() &&
                 offset < this.offset + this.smallBuffer.remaining())
         {
-            this.smallBuffer.shift(this.smallBuffer.position() + (int) (offset - this.offset));
+            this.smallBuffer.forward((int) (offset - this.offset));
         }
         else
         {

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/direct/DirectRandomAccessFile.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/direct/DirectRandomAccessFile.java
@@ -23,6 +23,7 @@ import java.io.Closeable;
 import java.io.DataInput;
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.nio.ByteBuffer;
 import java.util.LinkedList;
 
@@ -41,21 +42,21 @@ public class DirectRandomAccessFile implements DataInput, Closeable
     private long length;
     private final int blockSize;
     private boolean bufferValid;
-    private AlignedDirectBuffer smallBuffer;
-    private LinkedList<AlignedDirectBuffer> largeBuffers = new LinkedList<>();
+    private DirectBuffer smallBuffer;
+    private LinkedList<DirectBuffer> largeBuffers = new LinkedList<>();
 
     public DirectRandomAccessFile(File file, boolean readOnly) throws IOException
     {
         this.file = file;
-        this.fd = DirectIoLib.openDirect(file.getPath(), readOnly);
+        this.fd = DirectIoLib.open(file.getPath(), readOnly);
         this.offset = 0;
         this.length = this.file.length();
-        this.blockSize = DirectIoLib.blockSize();
+        this.blockSize = DirectIoLib.fsBlockSize;
         this.bufferValid = false;
         try
         {
-            this.smallBuffer = DirectIoLib.allocateAligned(DirectIoLib.blockSize());
-        } catch (IllegalAccessException e)
+            this.smallBuffer = DirectIoLib.allocateBuffer(DirectIoLib.fsBlockSize);
+        } catch (IllegalAccessException | InvocationTargetException e)
         {
             throw new IOException("failed to allocate buffer", e);
         }
@@ -66,7 +67,7 @@ public class DirectRandomAccessFile implements DataInput, Closeable
     {
         this.smallBuffer.close();
         this.smallBuffer = null;
-        for (AlignedDirectBuffer largeBuffer : this.largeBuffers)
+        for (DirectBuffer largeBuffer : this.largeBuffers)
         {
             largeBuffer.close();
         }
@@ -82,27 +83,31 @@ public class DirectRandomAccessFile implements DataInput, Closeable
     @Override
     public void readFully(byte[] b) throws IOException
     {
-        ByteBuffer buffer = readDirect(b.length);
+        ByteBuffer buffer = readFully(b.length);
         buffer.get(b);
     }
 
     @Override
     public void readFully(byte[] b, int off, int len) throws IOException
     {
-        ByteBuffer buffer = readDirect(len);
+        ByteBuffer buffer = readFully(len);
         buffer.get(b, off, len);
     }
 
-    public ByteBuffer readDirect(int len) throws IOException
+    public ByteBuffer readFully(int len) throws IOException
     {
         try
         {
-            AlignedDirectBuffer buffer = DirectIoLib.allocateAligned(len);
-            DirectIoLib.readDirect(this.fd, this.offset, buffer, len);
+            DirectBuffer buffer = DirectIoLib.allocateBuffer(len);
+            DirectIoLib.read(this.fd, this.offset, buffer, len);
             this.seek(this.offset + len);
-            this.largeBuffers.add(buffer);
+            if (DirectIoLib.directIoEnabled)
+            {
+                // if direct io is disabled, the buffers are allocated and freed by JVM.
+                this.largeBuffers.add(buffer);
+            }
             return buffer.getBuffer();
-        } catch (IllegalAccessException e)
+        } catch (IllegalAccessException | InvocationTargetException e)
         {
             throw new IOException("failed to allocate buffer", e);
         }
@@ -123,8 +128,7 @@ public class DirectRandomAccessFile implements DataInput, Closeable
 
     private void populateBuffer() throws IOException
     {
-        this.smallBuffer.reset();
-        DirectIoLib.readDirect(this.fd, this.offset, this.smallBuffer, this.blockSize);
+        DirectIoLib.read(this.fd, this.offset, this.smallBuffer, this.blockSize);
         this.bufferValid = true;
     }
 

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/io/PhysicalLocalReader.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/io/PhysicalLocalReader.java
@@ -79,7 +79,7 @@ public class PhysicalLocalReader implements PhysicalReader
     public ByteBuffer readFully(int length) throws IOException
     {
         numRequests.incrementAndGet();
-        return raf.readDirect(length);
+        return raf.readFully(length);
     }
 
     @Override

--- a/pixels-common/src/main/resources/pixels.properties
+++ b/pixels-common/src/main/resources/pixels.properties
@@ -88,6 +88,7 @@ s3.max.request.concurrency=1000
 s3.max.pending.requests=100000
 gcs.enable.async=true
 localfs.block.size=4096
+localfs.enable.direct.io=false
 
 # pixels executor
 executor.input.storage=s3

--- a/pixels-common/src/test/java/io/pixelsdb/pixels/common/physical/TestDirect.java
+++ b/pixels-common/src/test/java/io/pixelsdb/pixels/common/physical/TestDirect.java
@@ -19,13 +19,14 @@
  */
 package io.pixelsdb.pixels.common.physical;
 
-import io.pixelsdb.pixels.common.physical.direct.AlignedDirectBuffer;
+import io.pixelsdb.pixels.common.physical.direct.DirectBuffer;
 import io.pixelsdb.pixels.common.physical.direct.DirectIoLib;
 import io.pixelsdb.pixels.common.physical.direct.DirectRandomAccessFile;
 import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 
 /**
  * Created at: 02/02/2023
@@ -34,11 +35,11 @@ import java.io.IOException;
 public class TestDirect
 {
     @Test
-    public void testDirectIoLib() throws IOException, IllegalAccessException
+    public void testDirectIoLib() throws IOException, IllegalAccessException, InvocationTargetException
     {
-        int fd = DirectIoLib.openDirect("/home/hank/20230126155625_0.pxl", true);
-        AlignedDirectBuffer buffer = DirectIoLib.allocateAligned(8);
-        int read = DirectIoLib.readDirect(fd, 4094, buffer, 8);
+        int fd = DirectIoLib.open("/home/hank/20230126155625_0.pxl", true);
+        DirectBuffer buffer = DirectIoLib.allocateBuffer(8);
+        int read = DirectIoLib.read(fd, 4094, buffer, 8);
         System.out.println(read);
         for (int i = 0; i < 8; ++i)
         {

--- a/pixels-common/src/test/java/io/pixelsdb/pixels/common/physical/direct/TestDirect.java
+++ b/pixels-common/src/test/java/io/pixelsdb/pixels/common/physical/direct/TestDirect.java
@@ -51,14 +51,14 @@ public class TestDirect
         long start = System.currentTimeMillis();
         for (int i = 0; i < 100000; ++i)
         {
-            DirectBuffer buffer = DirectIoLib.allocateBuffer(16);
+            DirectBuffer buffer = DirectIoLib.allocateBuffer(1);
             buffer.close();
         }
         System.out.println(System.currentTimeMillis() - start);
         start = System.currentTimeMillis();
         for (int i = 0; i < 100000; ++i)
         {
-            ByteBuffer buffer = ByteBuffer.allocateDirect(16);
+            ByteBuffer buffer = ByteBuffer.allocateDirect(1);
             DirectBuffer directBuffer = new DirectBuffer(buffer, buffer.capacity(), true);
             directBuffer.close();
         }

--- a/pixels-common/src/test/java/io/pixelsdb/pixels/common/physical/direct/TestDirect.java
+++ b/pixels-common/src/test/java/io/pixelsdb/pixels/common/physical/direct/TestDirect.java
@@ -49,18 +49,26 @@ public class TestDirect
     public void testMemoryAllocation() throws InvocationTargetException, IllegalAccessException, IOException
     {
         long start = System.currentTimeMillis();
-        for (int i = 0; i < 100000; ++i)
-        {
-            DirectBuffer buffer = DirectIoLib.allocateBuffer(1);
-            buffer.close();
-        }
-        System.out.println(System.currentTimeMillis() - start);
-        start = System.currentTimeMillis();
-        for (int i = 0; i < 100000; ++i)
+        for (int i = 0; i < 10000; ++i)
         {
             ByteBuffer buffer = ByteBuffer.allocateDirect(1);
             DirectBuffer directBuffer = new DirectBuffer(buffer, buffer.capacity(), true);
             directBuffer.close();
+        }
+        System.out.println(System.currentTimeMillis() - start);
+        start = System.currentTimeMillis();
+        for (int i = 0; i < 10000; ++i)
+        {
+            ByteBuffer buffer = ByteBuffer.allocateDirect(1);
+            DirectBuffer directBuffer = new DirectBuffer(buffer, buffer.capacity(), true);
+            directBuffer.close();
+        }
+        System.out.println(System.currentTimeMillis() - start);
+        start = System.currentTimeMillis();
+        for (int i = 0; i < 10000; ++i)
+        {
+            DirectBuffer buffer = DirectIoLib.allocateBuffer(1);
+            buffer.close();
         }
         System.out.println(System.currentTimeMillis() - start);
     }

--- a/pixels-common/src/test/java/io/pixelsdb/pixels/common/physical/direct/TestDirect.java
+++ b/pixels-common/src/test/java/io/pixelsdb/pixels/common/physical/direct/TestDirect.java
@@ -17,16 +17,14 @@
  * License along with Pixels.  If not, see
  * <https://www.gnu.org/licenses/>.
  */
-package io.pixelsdb.pixels.common.physical;
+package io.pixelsdb.pixels.common.physical.direct;
 
-import io.pixelsdb.pixels.common.physical.direct.DirectBuffer;
-import io.pixelsdb.pixels.common.physical.direct.DirectIoLib;
-import io.pixelsdb.pixels.common.physical.direct.DirectRandomAccessFile;
 import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
+import java.nio.ByteBuffer;
 
 /**
  * Created at: 02/02/2023
@@ -45,6 +43,26 @@ public class TestDirect
         {
             System.out.println(buffer.get());
         }
+    }
+
+    @Test
+    public void testMemoryAllocation() throws InvocationTargetException, IllegalAccessException, IOException
+    {
+        long start = System.currentTimeMillis();
+        for (int i = 0; i < 100000; ++i)
+        {
+            DirectBuffer buffer = DirectIoLib.allocateBuffer(16);
+            buffer.close();
+        }
+        System.out.println(System.currentTimeMillis() - start);
+        start = System.currentTimeMillis();
+        for (int i = 0; i < 100000; ++i)
+        {
+            ByteBuffer buffer = ByteBuffer.allocateDirect(16);
+            DirectBuffer directBuffer = new DirectBuffer(buffer, buffer.capacity(), true);
+            directBuffer.close();
+        }
+        System.out.println(System.currentTimeMillis() - start);
     }
 
     @Test

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/TestByteBuf.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/TestByteBuf.java
@@ -26,6 +26,7 @@ import io.netty.buffer.Unpooled;
 import io.pixelsdb.pixels.common.physical.direct.DirectIoLib;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.nio.ByteBuffer;
 
@@ -37,7 +38,7 @@ import java.nio.ByteBuffer;
 public class TestByteBuf
 {
     @Test
-    public void testEndian() throws IllegalAccessException, InvocationTargetException
+    public void testEndian() throws IllegalAccessException, InvocationTargetException, IOException
     {
         ByteBuffer buffer = ByteBuffer.allocate(10);
         System.out.println(buffer.order());

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/TestByteBuf.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/TestByteBuf.java
@@ -26,6 +26,7 @@ import io.netty.buffer.Unpooled;
 import io.pixelsdb.pixels.common.physical.direct.DirectIoLib;
 import org.junit.Test;
 
+import java.lang.reflect.InvocationTargetException;
 import java.nio.ByteBuffer;
 
 /**
@@ -36,11 +37,11 @@ import java.nio.ByteBuffer;
 public class TestByteBuf
 {
     @Test
-    public void testEndian() throws IllegalAccessException
+    public void testEndian() throws IllegalAccessException, InvocationTargetException
     {
         ByteBuffer buffer = ByteBuffer.allocate(10);
         System.out.println(buffer.order());
-        ByteBuffer buffer1 = DirectIoLib.allocateAligned(10).getBuffer();
+        ByteBuffer buffer1 = DirectIoLib.allocateBuffer(10).getBuffer();
         System.out.println(buffer1.order());
         assert buffer1.order() == buffer.order();
     }


### PR DESCRIPTION
We use pread for both direct and non-direct I/O because it is more efficient than JDK's RandomAccessFile.
For non-direct I/O, we allocate the read buffer using malloc, which is more efficient than ByteBuffer.allocateDirect().