### PR TITLE
[Issue #386]: fix getRowNumber in PixelsRecordReaderImpl.

### DIFF
--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/PixelsRecordReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/PixelsRecordReader.java
@@ -111,13 +111,6 @@ public interface PixelsRecordReader
     boolean isEndOfFile ();
 
     /**
-     * Get current row number
-     *
-     * @return the number of the rows have been read
-     */
-    long getRowNumber();
-
-    /**
      * Seek to specified row
      *
      * @param rowIndex row index
@@ -137,6 +130,14 @@ public interface PixelsRecordReader
     boolean skip(long rowNum)
             throws IOException;
 
+    /**
+     * @return the number of the rows have been read
+     */
+    long getCompletedRows();
+
+    /**
+     * @return the number of bytes have been read
+     */
     long getCompletedBytes();
 
     /**

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/PixelsRecordReaderImpl.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/PixelsRecordReaderImpl.java
@@ -1062,17 +1062,11 @@ public class PixelsRecordReaderImpl implements PixelsRecordReader
     }
 
     /**
-     * Get current row number
-     *
      * @return number of the row currently being read
      */
     @Override
-    public long getRowNumber()
+    public long getCompletedRows()
     {
-        if (!checkValid)
-        {
-            return -1L;
-        }
         return rowIndex;
     }
 


### PR DESCRIPTION
Fix the bug and rename this method to getCompletedRows.