### PR TITLE
[Issue #393] support mmap in local file systems.

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -7,7 +7,7 @@ We also include a copy of Apache License Version 2.0 at the end of this NOTICE f
 1. MappedBus
 Copyright 2015 Caplogic AB.
 Licensed under the Apache License, Version 2.0.
-* MemoryMappedFile in pixels-cache is derived from MappedBus.
+* MemoryMappedFile in pixels-common is derived from MappedBus.
 
 
 2. Apache ORC

--- a/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/HashIndexReader.java
+++ b/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/HashIndexReader.java
@@ -19,6 +19,7 @@
  */
 package io.pixelsdb.pixels.cache;
 
+import io.pixelsdb.pixels.common.physical.natives.MemoryMappedFile;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import sun.nio.ch.DirectBuffer;

--- a/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/HashIndexWriter.java
+++ b/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/HashIndexWriter.java
@@ -19,6 +19,7 @@
  */
 package io.pixelsdb.pixels.cache;
 
+import io.pixelsdb.pixels.common.physical.natives.MemoryMappedFile;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 

--- a/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/MmapFileCacheContentReader.java
+++ b/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/MmapFileCacheContentReader.java
@@ -19,6 +19,8 @@
  */
 package io.pixelsdb.pixels.cache;
 
+import io.pixelsdb.pixels.common.physical.natives.MemoryMappedFile;
+
 import java.io.IOException;
 import java.nio.ByteBuffer;
 

--- a/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/NativeHashIndexReader.java
+++ b/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/NativeHashIndexReader.java
@@ -19,6 +19,7 @@
  */
 package io.pixelsdb.pixels.cache;
 
+import io.pixelsdb.pixels.common.physical.natives.MemoryMappedFile;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import sun.nio.ch.DirectBuffer;

--- a/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/NativeRadixIndexReader.java
+++ b/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/NativeRadixIndexReader.java
@@ -19,6 +19,7 @@
  */
 package io.pixelsdb.pixels.cache;
 
+import io.pixelsdb.pixels.common.physical.natives.MemoryMappedFile;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 

--- a/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PartitionCacheReader.java
+++ b/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PartitionCacheReader.java
@@ -19,6 +19,7 @@
  */
 package io.pixelsdb.pixels.cache;
 
+import io.pixelsdb.pixels.common.physical.natives.MemoryMappedFile;
 import io.pixelsdb.pixels.common.utils.ConfigFactory;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PartitionRadixIndexReader.java
+++ b/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PartitionRadixIndexReader.java
@@ -19,6 +19,7 @@
  */
 package io.pixelsdb.pixels.cache;
 
+import io.pixelsdb.pixels.common.physical.natives.MemoryMappedFile;
 import io.pixelsdb.pixels.common.utils.ConfigFactory;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsCacheKey.java
+++ b/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsCacheKey.java
@@ -20,6 +20,7 @@
 package io.pixelsdb.pixels.cache;
 
 import io.pixelsdb.pixels.cache.mq.Message;
+import io.pixelsdb.pixels.common.physical.natives.MemoryMappedFile;
 
 import java.nio.ByteBuffer;
 import java.util.Objects;

--- a/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsCacheReader.java
+++ b/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsCacheReader.java
@@ -19,6 +19,7 @@
  */
 package io.pixelsdb.pixels.cache;
 
+import io.pixelsdb.pixels.common.physical.natives.MemoryMappedFile;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 

--- a/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsCacheUtil.java
+++ b/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsCacheUtil.java
@@ -20,6 +20,7 @@
 package io.pixelsdb.pixels.cache;
 
 import io.pixelsdb.pixels.common.exception.CacheException;
+import io.pixelsdb.pixels.common.physical.natives.MemoryMappedFile;
 import io.pixelsdb.pixels.common.utils.Constants;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsCacheWriter.java
+++ b/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsCacheWriter.java
@@ -24,6 +24,7 @@ import io.pixelsdb.pixels.common.metadata.MetadataService;
 import io.pixelsdb.pixels.common.metadata.domain.Compact;
 import io.pixelsdb.pixels.common.metadata.domain.Layout;
 import io.pixelsdb.pixels.common.physical.*;
+import io.pixelsdb.pixels.common.physical.natives.MemoryMappedFile;
 import io.pixelsdb.pixels.common.utils.ConfigFactory;
 import io.pixelsdb.pixels.common.utils.Constants;
 import io.pixelsdb.pixels.common.utils.EtcdUtil;

--- a/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsPartitionCacheWriter.java
+++ b/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsPartitionCacheWriter.java
@@ -25,6 +25,7 @@ import io.pixelsdb.pixels.common.metadata.domain.Compact;
 import io.pixelsdb.pixels.common.metadata.domain.Layout;
 import io.pixelsdb.pixels.common.physical.Storage;
 import io.pixelsdb.pixels.common.physical.StorageFactory;
+import io.pixelsdb.pixels.common.physical.natives.MemoryMappedFile;
 import io.pixelsdb.pixels.common.utils.Constants;
 import io.pixelsdb.pixels.common.utils.EtcdUtil;
 import org.apache.logging.log4j.LogManager;
@@ -39,7 +40,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
-import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import static com.google.common.base.Preconditions.checkArgument;

--- a/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/RadixIndexReader.java
+++ b/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/RadixIndexReader.java
@@ -19,6 +19,7 @@
  */
 package io.pixelsdb.pixels.cache;
 
+import io.pixelsdb.pixels.common.physical.natives.MemoryMappedFile;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 

--- a/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/RadixIndexWriter.java
+++ b/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/RadixIndexWriter.java
@@ -19,6 +19,7 @@
  */
 package io.pixelsdb.pixels.cache;
 
+import io.pixelsdb.pixels.common.physical.natives.MemoryMappedFile;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 

--- a/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/mq/Message.java
+++ b/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/mq/Message.java
@@ -19,7 +19,7 @@
  */
 package io.pixelsdb.pixels.cache.mq;
 
-import io.pixelsdb.pixels.cache.MemoryMappedFile;
+import io.pixelsdb.pixels.common.physical.natives.MemoryMappedFile;
 
 /**
  * The interface of messages that can be write/read into/from

--- a/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/mq/SharedMQ.java
+++ b/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/mq/SharedMQ.java
@@ -19,7 +19,7 @@
  */
 package io.pixelsdb.pixels.cache.mq;
 
-import io.pixelsdb.pixels.cache.MemoryMappedFile;
+import io.pixelsdb.pixels.common.physical.natives.MemoryMappedFile;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.pixelsdb.pixels.common.error.ErrorCode.*;

--- a/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/utils/RadixIndexEndianRewriter.java
+++ b/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/utils/RadixIndexEndianRewriter.java
@@ -1,6 +1,6 @@
 package io.pixelsdb.pixels.cache.utils;
 
-import io.pixelsdb.pixels.cache.MemoryMappedFile;
+import io.pixelsdb.pixels.common.physical.natives.MemoryMappedFile;
 
 // convert all big-endian to little-endian
 // inplace rewrite!!!

--- a/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/utils/RadixTreeDumper.java
+++ b/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/utils/RadixTreeDumper.java
@@ -1,9 +1,6 @@
 package io.pixelsdb.pixels.cache.utils;
 
-import io.pixelsdb.pixels.cache.MemoryMappedFile;
-import io.pixelsdb.pixels.cache.PixelsCacheUtil;
-
-import java.nio.ByteBuffer;
+import io.pixelsdb.pixels.common.physical.natives.MemoryMappedFile;
 
 // dump the little-endian radix tree to a txt file
 // note that in current cache(including partitioned radix), we use big-endian radix tree more

--- a/pixels-cache/src/test/java/io/pixelsdb/pixels/cache/BenchmarkCacheContentReader.java
+++ b/pixels-cache/src/test/java/io/pixelsdb/pixels/cache/BenchmarkCacheContentReader.java
@@ -19,6 +19,7 @@
  */
 package io.pixelsdb.pixels.cache;
 
+import io.pixelsdb.pixels.common.physical.natives.MemoryMappedFile;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/pixels-cache/src/test/java/io/pixelsdb/pixels/cache/BenchmarkCacheIndexReader.java
+++ b/pixels-cache/src/test/java/io/pixelsdb/pixels/cache/BenchmarkCacheIndexReader.java
@@ -19,6 +19,7 @@
  */
 package io.pixelsdb.pixels.cache;
 
+import io.pixelsdb.pixels.common.physical.natives.MemoryMappedFile;
 import io.pixelsdb.pixels.common.utils.ConfigFactory;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.config.Configurator;

--- a/pixels-cache/src/test/java/io/pixelsdb/pixels/cache/BenchmarkCacheReader.java
+++ b/pixels-cache/src/test/java/io/pixelsdb/pixels/cache/BenchmarkCacheReader.java
@@ -20,9 +20,9 @@
 package io.pixelsdb.pixels.cache;
 
 import com.google.common.util.concurrent.SettableFuture;
+import io.pixelsdb.pixels.common.physical.natives.MemoryMappedFile;
 import io.pixelsdb.pixels.common.utils.ConfigFactory;
 import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.core.config.Configurator;
 import org.junit.Before;
 import org.junit.Test;

--- a/pixels-cache/src/test/java/io/pixelsdb/pixels/cache/TestHashIndexReader.java
+++ b/pixels-cache/src/test/java/io/pixelsdb/pixels/cache/TestHashIndexReader.java
@@ -19,6 +19,7 @@
  */
 package io.pixelsdb.pixels.cache;
 
+import io.pixelsdb.pixels.common.physical.natives.MemoryMappedFile;
 import org.junit.Test;
 
 import java.io.RandomAccessFile;

--- a/pixels-cache/src/test/java/io/pixelsdb/pixels/cache/TestIndexWriter.java
+++ b/pixels-cache/src/test/java/io/pixelsdb/pixels/cache/TestIndexWriter.java
@@ -19,6 +19,7 @@
  */
 package io.pixelsdb.pixels.cache;
 
+import io.pixelsdb.pixels.common.physical.natives.MemoryMappedFile;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.config.Configurator;
 import org.junit.Before;

--- a/pixels-cache/src/test/java/io/pixelsdb/pixels/cache/TestMemFile.java
+++ b/pixels-cache/src/test/java/io/pixelsdb/pixels/cache/TestMemFile.java
@@ -19,6 +19,7 @@
  */
 package io.pixelsdb.pixels.cache;
 
+import io.pixelsdb.pixels.common.physical.natives.MemoryMappedFile;
 import org.junit.Test;
 
 import java.io.File;

--- a/pixels-cache/src/test/java/io/pixelsdb/pixels/cache/TestMemFileConcurrentRW.java
+++ b/pixels-cache/src/test/java/io/pixelsdb/pixels/cache/TestMemFileConcurrentRW.java
@@ -19,6 +19,7 @@
  */
 package io.pixelsdb.pixels.cache;
 
+import io.pixelsdb.pixels.common.physical.natives.MemoryMappedFile;
 import org.junit.Test;
 
 /**

--- a/pixels-cache/src/test/java/io/pixelsdb/pixels/cache/TestMemFileWrite.java
+++ b/pixels-cache/src/test/java/io/pixelsdb/pixels/cache/TestMemFileWrite.java
@@ -19,6 +19,7 @@
  */
 package io.pixelsdb.pixels.cache;
 
+import io.pixelsdb.pixels.common.physical.natives.MemoryMappedFile;
 import org.junit.Test;
 
 import java.io.File;

--- a/pixels-cache/src/test/java/io/pixelsdb/pixels/cache/TestPartitionCacheReader.java
+++ b/pixels-cache/src/test/java/io/pixelsdb/pixels/cache/TestPartitionCacheReader.java
@@ -20,6 +20,7 @@
 package io.pixelsdb.pixels.cache;
 
 import com.google.common.util.concurrent.SettableFuture;
+import io.pixelsdb.pixels.common.physical.natives.MemoryMappedFile;
 import io.pixelsdb.pixels.common.utils.ConfigFactory;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.config.Configurator;

--- a/pixels-cache/src/test/java/io/pixelsdb/pixels/cache/TestPartitionCacheWriter.java
+++ b/pixels-cache/src/test/java/io/pixelsdb/pixels/cache/TestPartitionCacheWriter.java
@@ -20,6 +20,7 @@
 package io.pixelsdb.pixels.cache;
 
 import com.google.common.util.concurrent.SettableFuture;
+import io.pixelsdb.pixels.common.physical.natives.MemoryMappedFile;
 import io.pixelsdb.pixels.common.utils.ConfigFactory;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.config.Configurator;

--- a/pixels-cache/src/test/java/io/pixelsdb/pixels/cache/TestPixelsCacheReader.java
+++ b/pixels-cache/src/test/java/io/pixelsdb/pixels/cache/TestPixelsCacheReader.java
@@ -19,6 +19,7 @@
  */
 package io.pixelsdb.pixels.cache;
 
+import io.pixelsdb.pixels.common.physical.natives.MemoryMappedFile;
 import org.junit.Test;
 
 import java.nio.ByteBuffer;

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/io/PhysicalLocalReader.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/io/PhysicalLocalReader.java
@@ -21,7 +21,7 @@ package io.pixelsdb.pixels.common.physical.io;
 
 import io.pixelsdb.pixels.common.physical.PhysicalReader;
 import io.pixelsdb.pixels.common.physical.Storage;
-import io.pixelsdb.pixels.common.physical.natives.DirectRandomAccessFile;
+import io.pixelsdb.pixels.common.physical.natives.PixelsRandomAccessFile;
 import io.pixelsdb.pixels.common.physical.storage.LocalFS;
 
 import java.io.IOException;
@@ -37,7 +37,7 @@ public class PhysicalLocalReader implements PhysicalReader
     private final LocalFS local;
     private final String path;
     private final long id;
-    private final DirectRandomAccessFile raf;
+    private final PixelsRandomAccessFile raf;
     private final AtomicInteger numRequests;
 
     public PhysicalLocalReader(Storage storage, String path) throws IOException

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/io/PhysicalLocalReader.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/io/PhysicalLocalReader.java
@@ -21,7 +21,7 @@ package io.pixelsdb.pixels.common.physical.io;
 
 import io.pixelsdb.pixels.common.physical.PhysicalReader;
 import io.pixelsdb.pixels.common.physical.Storage;
-import io.pixelsdb.pixels.common.physical.direct.DirectRandomAccessFile;
+import io.pixelsdb.pixels.common.physical.natives.DirectRandomAccessFile;
 import io.pixelsdb.pixels.common.physical.storage.LocalFS;
 
 import java.io.IOException;

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/natives/DirectBuffer.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/natives/DirectBuffer.java
@@ -17,7 +17,7 @@
  * License along with Pixels.  If not, see
  * <https://www.gnu.org/licenses/>.
  */
-package io.pixelsdb.pixels.common.physical.direct;
+package io.pixelsdb.pixels.common.physical.natives;
 
 import com.sun.jna.Pointer;
 

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/natives/DirectIoLib.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/natives/DirectIoLib.java
@@ -17,7 +17,7 @@
  * License along with Pixels.  If not, see
  * <https://www.gnu.org/licenses/>.
  */
-package io.pixelsdb.pixels.common.physical.direct;
+package io.pixelsdb.pixels.common.physical.natives;
 
 import com.sun.jna.Native;
 import com.sun.jna.Platform;

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/natives/DirectIoLib.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/natives/DirectIoLib.java
@@ -37,6 +37,8 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 
+import static io.pixelsdb.pixels.common.utils.JvmUtils.JavaVersion;
+
 /**
  * Mapping Linux I/O functions to native methods.
  * Partially referenced the implementation of Jaydio (https://github.com/smacke/jaydio),
@@ -59,7 +61,6 @@ public class DirectIoLib
      * Whether direct io (i.e., o_direct) is enabled.
      */
     public static final boolean DirectIoEnabled;
-    private static int javaVersion = -1;
 
     private static Field jnaPointerPeer = null;
     private static Method directByteBufferAddress = null;
@@ -83,30 +84,7 @@ public class DirectIoLib
         {
             try
             {
-                List<Integer> versionNumbers = new ArrayList<Integer>();
-                for (String v : System.getProperty("java.version").split("\\.|-"))
-                {
-                    if (v.matches("\\d+"))
-                    {
-                        versionNumbers.add(Integer.parseInt(v));
-                    }
-                }
-                if (versionNumbers.get(0) == 1)
-                {
-                    if (versionNumbers.get(1) >= 8)
-                    {
-                        javaVersion = versionNumbers.get(1);
-                    }
-                } else if (versionNumbers.get(0) > 8)
-                {
-                    javaVersion = versionNumbers.get(0);
-                }
-                if (javaVersion < 0)
-                {
-                    throw new Exception(String.format("Java version: %s is not supported", System.getProperty("java.version")));
-                }
-
-                if (javaVersion <= 11)
+                if (JavaVersion <= 11)
                 {
                     // this is from sun.nio.ch.Util.initDBBRConstructor
                     Class<?> cl = Class.forName("java.nio.DirectByteBufferR");
@@ -246,7 +224,7 @@ public class DirectIoLib
         ByteBuffer buffer;
         try
         {
-            if (javaVersion <= 11)
+            if (JavaVersion <= 11)
             {
                 buffer = (ByteBuffer) directByteBufferRConstructor.newInstance(
                         new Object[]{size, address, null, null});

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/natives/DirectRandomAccessFile.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/natives/DirectRandomAccessFile.java
@@ -17,7 +17,7 @@
  * License along with Pixels.  If not, see
  * <https://www.gnu.org/licenses/>.
  */
-package io.pixelsdb.pixels.common.physical.direct;
+package io.pixelsdb.pixels.common.physical.natives;
 
 import java.io.Closeable;
 import java.io.DataInput;

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/natives/DirectRandomAccessFile.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/natives/DirectRandomAccessFile.java
@@ -31,7 +31,7 @@ import java.util.LinkedList;
  * Created at: 02/02/2023
  * Author: hank
  */
-public class DirectPixelsRandomAccessFile implements PixelsRandomAccessFile
+public class DirectRandomAccessFile implements PixelsRandomAccessFile
 {
     private File file;
     private int fd;
@@ -42,7 +42,7 @@ public class DirectPixelsRandomAccessFile implements PixelsRandomAccessFile
     private DirectBuffer smallBuffer;
     private LinkedList<DirectBuffer> largeBuffers = new LinkedList<>();
 
-    public DirectPixelsRandomAccessFile(File file) throws IOException
+    public DirectRandomAccessFile(File file) throws IOException
     {
         this.file = file;
         this.fd = DirectIoLib.open(file.getPath(), true);

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/natives/MappedPixelsRandomAccessFile.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/natives/MappedPixelsRandomAccessFile.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2023 PixelsDB.
+ *
+ * This file is part of Pixels.
+ *
+ * Pixels is free software: you can redistribute it and/or modify
+ * it under the terms of the Affero GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * Pixels is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Affero GNU General Public License for more details.
+ *
+ * You should have received a copy of the Affero GNU General Public
+ * License along with Pixels.  If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package io.pixelsdb.pixels.common.physical.natives;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.pixelsdb.pixels.common.utils.JvmUtils.nativeIsLittleEndian;
+import static io.pixelsdb.pixels.common.utils.JvmUtils.nativeOrder;
+
+/**
+ * Created at: 2/21/23
+ * Author: hank
+ */
+public class MappedPixelsRandomAccessFile implements PixelsRandomAccessFile
+{
+    private File file;
+    private long offset;
+    private long length;
+    private MemoryMappedFile mmf;
+
+    public MappedPixelsRandomAccessFile(File file) throws IOException
+    {
+        this.file = file;
+        this.offset = 0;
+        this.length = this.file.length();
+        this.mmf = new MemoryMappedFile(file.getPath(), this.length, false);
+    }
+
+    @Override
+    public void readFully(byte[] b) throws IOException
+    {
+        this.mmf.getBytes(this.offset, b);
+    }
+
+    @Override
+    public void readFully(byte[] b, int off, int len) throws IOException
+    {
+        this.mmf.getBytes(this.offset, b, off, len);
+    }
+
+    @Override
+    public int skipBytes(int n) throws IOException
+    {
+        if (n <= 0)
+        {
+            return 0;
+        }
+        long off = this.offset;
+        long newOff = Math.min(off + n, length);
+        seek(newOff);
+        return (int) (newOff - off);
+    }
+
+    @Override
+    public boolean readBoolean() throws IOException
+    {
+        return this.mmf.getByte(this.offset) != 0;
+    }
+
+    @Override
+    public byte readByte() throws IOException
+    {
+        return this.mmf.getByte(this.offset);
+    }
+
+    @Override
+    public int readUnsignedByte() throws IOException
+    {
+        return this.mmf.getByte(this.offset) & 0xff;
+    }
+
+    @Override
+    public short readShort() throws IOException
+    {
+        if (nativeIsLittleEndian)
+        {
+            return Short.reverseBytes(this.mmf.getShort(this.offset));
+        }
+        return this.mmf.getShort(this.offset);
+    }
+
+    @Override
+    public int readUnsignedShort() throws IOException
+    {
+        if (nativeIsLittleEndian)
+        {
+            return Short.reverseBytes(this.mmf.getShort(this.offset)) & 0xffff;
+        }
+        return this.mmf.getShort(this.offset) & 0xffff;
+    }
+
+    @Override
+    public char readChar() throws IOException
+    {
+        return this.mmf.getChar(this.offset);
+    }
+
+    @Override
+    public int readInt() throws IOException
+    {
+        if (nativeIsLittleEndian)
+        {
+            return Integer.reverseBytes(this.mmf.getInt(this.offset));
+        }
+        return this.mmf.getInt(this.offset);
+    }
+
+    @Override
+    public long readLong() throws IOException
+    {
+        if (nativeIsLittleEndian)
+        {
+            return Long.reverseBytes(this.mmf.getLong(this.offset));
+        }
+        return this.mmf.getLong(this.offset);
+    }
+
+    @Override
+    public float readFloat() throws IOException
+    {
+        if (nativeIsLittleEndian)
+        {
+            return this.mmf.getDirectByteBuffer(this.offset, Float.BYTES).order(nativeOrder).getFloat();
+        }
+        return this.mmf.getFloat(this.offset);
+    }
+
+    @Override
+    public double readDouble() throws IOException
+    {
+        if (nativeIsLittleEndian)
+        {
+            return this.mmf.getDirectByteBuffer(this.offset, Double.BYTES).order(nativeOrder).getDouble();
+        }
+        return this.mmf.getDouble(this.offset);
+    }
+
+    @Override
+    public void close() throws IOException
+    {
+        this.offset = 0;
+        this.length = 0;
+        this.file = null;
+        this.mmf.unmap();
+        this.mmf = null;
+    }
+
+    @Override
+    public void seek(long offset) throws IOException
+    {
+        checkArgument(offset >= 0 && offset < this.length, "illegal offset:" + offset);
+        this.offset = offset;
+    }
+
+    @Override
+    public long length()
+    {
+        return this.length;
+    }
+
+    @Override
+    public ByteBuffer readFully(int len) throws IOException
+    {
+        return this.mmf.getDirectByteBuffer(this.offset, len);
+    }
+}

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/natives/MappedRandomAccessFile.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/natives/MappedRandomAccessFile.java
@@ -31,14 +31,14 @@ import static io.pixelsdb.pixels.common.utils.JvmUtils.nativeOrder;
  * Created at: 2/21/23
  * Author: hank
  */
-public class MappedPixelsRandomAccessFile implements PixelsRandomAccessFile
+public class MappedRandomAccessFile implements PixelsRandomAccessFile
 {
     private File file;
     private long offset;
     private long length;
     private MemoryMappedFile mmf;
 
-    public MappedPixelsRandomAccessFile(File file) throws IOException
+    public MappedRandomAccessFile(File file) throws IOException
     {
         this.file = file;
         this.offset = 0;

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/natives/MappedRandomAccessFile.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/natives/MappedRandomAccessFile.java
@@ -47,6 +47,12 @@ public class MappedRandomAccessFile implements PixelsRandomAccessFile
     }
 
     @Override
+    public ByteBuffer readFully(int len) throws IOException
+    {
+        return this.mmf.getDirectByteBuffer(this.offset, len);
+    }
+
+    @Override
     public void readFully(byte[] b) throws IOException
     {
         this.mmf.getBytes(this.offset, b);
@@ -176,11 +182,5 @@ public class MappedRandomAccessFile implements PixelsRandomAccessFile
     public long length()
     {
         return this.length;
-    }
-
-    @Override
-    public ByteBuffer readFully(int len) throws IOException
-    {
-        return this.mmf.getDirectByteBuffer(this.offset, len);
     }
 }

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/natives/MemoryMappedFile.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/natives/MemoryMappedFile.java
@@ -29,7 +29,7 @@
  * We changed the visibility of some methods from protect to public,
  * and added direct (i.e. zero-copy) memory access.
  */
-package io.pixelsdb.pixels.cache;
+package io.pixelsdb.pixels.common.physical.natives;
 
 import sun.nio.ch.FileChannelImpl;
 
@@ -39,7 +39,7 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.channels.FileChannel;
 
-import static io.pixelsdb.pixels.common.physical.direct.DirectIoLib.wrapReadOnlyDirectByteBuffer;
+import static io.pixelsdb.pixels.common.physical.natives.DirectIoLib.wrapReadOnlyDirectByteBuffer;
 import static io.pixelsdb.pixels.common.utils.JvmUtils.nativeOrder;
 import static io.pixelsdb.pixels.common.utils.JvmUtils.unsafe;
 

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/natives/PixelsRandomAccessFile.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/natives/PixelsRandomAccessFile.java
@@ -1,0 +1,33 @@
+package io.pixelsdb.pixels.common.physical.natives;
+
+import java.io.Closeable;
+import java.io.DataInput;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+/**
+ * Random access file in pixels, currently it is read-only.
+ * We assume that all the data in this file were written in big endian.
+ * Created at: 2/21/23
+ * Author: hank
+ */
+public interface PixelsRandomAccessFile extends DataInput, Closeable
+{
+    void seek(long offset) throws IOException;
+
+    long length();
+
+    ByteBuffer readFully(int len) throws IOException;
+
+    @Override
+    default String readLine() throws IOException
+    {
+        throw new UnsupportedOperationException("read line is not supported");
+    }
+
+    @Override
+    default String readUTF() throws IOException
+    {
+        throw new UnsupportedOperationException("read UTF is not supported");
+    }
+}

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/storage/LocalFS.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/storage/LocalFS.java
@@ -22,7 +22,7 @@ package io.pixelsdb.pixels.common.physical.storage;
 import io.etcd.jetcd.KeyValue;
 import io.pixelsdb.pixels.common.physical.Status;
 import io.pixelsdb.pixels.common.physical.Storage;
-import io.pixelsdb.pixels.common.physical.direct.DirectRandomAccessFile;
+import io.pixelsdb.pixels.common.physical.natives.DirectRandomAccessFile;
 import io.pixelsdb.pixels.common.utils.ConfigFactory;
 import io.pixelsdb.pixels.common.utils.EtcdUtil;
 

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/storage/LocalFS.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/storage/LocalFS.java
@@ -22,8 +22,8 @@ package io.pixelsdb.pixels.common.physical.storage;
 import io.etcd.jetcd.KeyValue;
 import io.pixelsdb.pixels.common.physical.Status;
 import io.pixelsdb.pixels.common.physical.Storage;
-import io.pixelsdb.pixels.common.physical.natives.DirectPixelsRandomAccessFile;
-import io.pixelsdb.pixels.common.physical.natives.MappedPixelsRandomAccessFile;
+import io.pixelsdb.pixels.common.physical.natives.DirectRandomAccessFile;
+import io.pixelsdb.pixels.common.physical.natives.MappedRandomAccessFile;
 import io.pixelsdb.pixels.common.physical.natives.PixelsRandomAccessFile;
 import io.pixelsdb.pixels.common.utils.ConfigFactory;
 import io.pixelsdb.pixels.common.utils.EtcdUtil;
@@ -325,9 +325,9 @@ public final class LocalFS implements Storage
         }
         if (MmapEnabled)
         {
-            return new MappedPixelsRandomAccessFile(file);
+            return new MappedRandomAccessFile(file);
         }
-        return new DirectPixelsRandomAccessFile(file);
+        return new DirectRandomAccessFile(file);
     }
 
     @Override

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/storage/LocalFS.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/storage/LocalFS.java
@@ -22,12 +22,15 @@ package io.pixelsdb.pixels.common.physical.storage;
 import io.etcd.jetcd.KeyValue;
 import io.pixelsdb.pixels.common.physical.Status;
 import io.pixelsdb.pixels.common.physical.Storage;
-import io.pixelsdb.pixels.common.physical.natives.DirectRandomAccessFile;
+import io.pixelsdb.pixels.common.physical.natives.DirectPixelsRandomAccessFile;
+import io.pixelsdb.pixels.common.physical.natives.MappedPixelsRandomAccessFile;
+import io.pixelsdb.pixels.common.physical.natives.PixelsRandomAccessFile;
 import io.pixelsdb.pixels.common.utils.ConfigFactory;
 import io.pixelsdb.pixels.common.utils.EtcdUtil;
 
 import java.io.*;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -49,10 +52,13 @@ import static java.util.Objects.requireNonNull;
 public final class LocalFS implements Storage
 {
     private final static boolean EnableCache;
+    private final static boolean MmapEnabled;
+
 
     static
     {
         EnableCache = Boolean.parseBoolean(ConfigFactory.Instance().getProperty("cache.enabled"));
+        MmapEnabled = Boolean.parseBoolean(ConfigFactory.Instance().getProperty("localfs.enable.mmap"));
 
         if (EnableCache)
         {
@@ -65,7 +71,7 @@ public final class LocalFS implements Storage
         }
     }
 
-    private static String SchemePrefix = Scheme.file.name() + "://";
+    private static final String SchemePrefix = Scheme.file.name() + "://";
 
     public LocalFS() { }
 
@@ -258,7 +264,7 @@ public final class LocalFS implements Storage
         {
             throw new IOException("File '" + p.realPath + "' doesn't exists.");
         }
-        return new DataInputStream(new FileInputStream(file));
+        return new DataInputStream(Files.newInputStream(file.toPath()));
     }
 
     /**
@@ -301,7 +307,7 @@ public final class LocalFS implements Storage
         return new DataOutputStream(new BufferedOutputStream(new FileOutputStream(file), bufferSize));
     }
 
-    public DirectRandomAccessFile openRaf(String path) throws IOException
+    public PixelsRandomAccessFile openRaf(String path) throws IOException
     {
         Path p = new Path(path);
         if (!p.valid)
@@ -317,7 +323,11 @@ public final class LocalFS implements Storage
         {
             throw new IOException("File '" + p.realPath + "' doesn't exists.");
         }
-        return new DirectRandomAccessFile(file, true);
+        if (MmapEnabled)
+        {
+            return new MappedPixelsRandomAccessFile(file);
+        }
+        return new DirectPixelsRandomAccessFile(file);
     }
 
     @Override
@@ -356,7 +366,7 @@ public final class LocalFS implements Storage
         {
             EtcdUtil.Instance().deleteByPrefix(getPathKey(path));
         }
-        return subDeleted && new File(path).delete();
+        return subDeleted && file.delete();
     }
 
     @Override

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/utils/JvmUtils.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/utils/JvmUtils.java
@@ -23,6 +23,8 @@ import sun.misc.Unsafe;
 
 import java.lang.reflect.Field;
 import java.nio.ByteOrder;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author hank
@@ -32,7 +34,7 @@ public final class JvmUtils
 {
     public static final Unsafe unsafe;
     public static final ByteOrder nativeOrder;
-
+    public static int JavaVersion = -1;
     public static final boolean nativeIsLittleEndian;
 
     static
@@ -44,6 +46,29 @@ public final class JvmUtils
             unsafe = (Unsafe) singleOneInstanceField.get(null);
             nativeOrder = ByteOrder.nativeOrder();
             nativeIsLittleEndian = (nativeOrder == ByteOrder.LITTLE_ENDIAN);
+
+            List<Integer> versionNumbers = new ArrayList<>();
+            for (String v : System.getProperty("java.version").split("\\.|-"))
+            {
+                if (v.matches("\\d+"))
+                {
+                    versionNumbers.add(Integer.parseInt(v));
+                }
+            }
+            if (versionNumbers.get(0) == 1)
+            {
+                if (versionNumbers.get(1) >= 8)
+                {
+                    JavaVersion = versionNumbers.get(1);
+                }
+            } else if (versionNumbers.get(0) > 8)
+            {
+                JavaVersion = versionNumbers.get(0);
+            }
+            if (JavaVersion < 0)
+            {
+                throw new Exception(String.format("Java version: %s is not supported", System.getProperty("java.version")));
+            }
         }
         catch (Exception e)
         {

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/utils/JvmUtils.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/utils/JvmUtils.java
@@ -33,6 +33,8 @@ public final class JvmUtils
     public static final Unsafe unsafe;
     public static final ByteOrder nativeOrder;
 
+    public static final boolean nativeIsLittleEndian;
+
     static
     {
         try
@@ -41,6 +43,7 @@ public final class JvmUtils
             singleOneInstanceField.setAccessible(true);
             unsafe = (Unsafe) singleOneInstanceField.get(null);
             nativeOrder = ByteOrder.nativeOrder();
+            nativeIsLittleEndian = (nativeOrder == ByteOrder.LITTLE_ENDIAN);
         }
         catch (Exception e)
         {

--- a/pixels-common/src/main/resources/pixels.properties
+++ b/pixels-common/src/main/resources/pixels.properties
@@ -89,6 +89,8 @@ s3.max.pending.requests=100000
 gcs.enable.async=true
 localfs.block.size=4096
 localfs.enable.direct.io=false
+# If mmap is enabled, direct io will be ignored.
+localfs.enable.mmap=false
 
 # pixels executor
 executor.input.storage=s3

--- a/pixels-common/src/test/java/io/pixelsdb/pixels/common/physical/natives/TestDirect.java
+++ b/pixels-common/src/test/java/io/pixelsdb/pixels/common/physical/natives/TestDirect.java
@@ -17,7 +17,7 @@
  * License along with Pixels.  If not, see
  * <https://www.gnu.org/licenses/>.
  */
-package io.pixelsdb.pixels.common.physical.direct;
+package io.pixelsdb.pixels.common.physical.natives;
 
 import org.junit.Test;
 

--- a/pixels-common/src/test/java/io/pixelsdb/pixels/common/physical/natives/TestNatives.java
+++ b/pixels-common/src/test/java/io/pixelsdb/pixels/common/physical/natives/TestNatives.java
@@ -30,7 +30,7 @@ import java.nio.ByteBuffer;
  * Created at: 02/02/2023
  * Author: hank
  */
-public class TestDirect
+public class TestNatives
 {
     @Test
     public void testDirectIoLib() throws IOException, IllegalAccessException, InvocationTargetException
@@ -76,7 +76,7 @@ public class TestDirect
     @Test
     public void testDirectRaf() throws IOException
     {
-        DirectRandomAccessFile raf = new DirectRandomAccessFile(new File("/home/hank/20230126155625_0.pxl"), true);
+        PixelsRandomAccessFile raf = new DirectPixelsRandomAccessFile(new File("/home/hank/20230126155625_0.pxl"));
         raf.seek(raf.length()-8);
         int a = raf.readInt();
         System.out.println(a);
@@ -84,5 +84,19 @@ public class TestDirect
         int b = raf.readInt();
         System.out.println(b);
         System.out.println(raf.length());
+    }
+
+    @Test
+    public void testMappedRaf() throws Exception
+    {
+        PixelsRandomAccessFile raf = new MappedPixelsRandomAccessFile(new File("/home/hank/20230126155625_0.pxl"));
+        raf.seek(raf.length()-8);
+        int a = raf.readInt();
+        System.out.println(a);
+        raf.seek(raf.length()-4);
+        int b = raf.readInt();
+        System.out.println(b);
+        System.out.println(raf.length());
+        raf.close();
     }
 }

--- a/pixels-common/src/test/java/io/pixelsdb/pixels/common/physical/natives/TestNatives.java
+++ b/pixels-common/src/test/java/io/pixelsdb/pixels/common/physical/natives/TestNatives.java
@@ -76,7 +76,7 @@ public class TestNatives
     @Test
     public void testDirectRaf() throws IOException
     {
-        PixelsRandomAccessFile raf = new DirectPixelsRandomAccessFile(new File("/home/hank/20230126155625_0.pxl"));
+        PixelsRandomAccessFile raf = new DirectRandomAccessFile(new File("/home/hank/20230126155625_0.pxl"));
         raf.seek(raf.length()-8);
         int a = raf.readInt();
         System.out.println(a);
@@ -89,7 +89,7 @@ public class TestNatives
     @Test
     public void testMappedRaf() throws Exception
     {
-        PixelsRandomAccessFile raf = new MappedPixelsRandomAccessFile(new File("/home/hank/20230126155625_0.pxl"));
+        PixelsRandomAccessFile raf = new MappedRandomAccessFile(new File("/home/hank/20230126155625_0.pxl"));
         raf.seek(raf.length()-8);
         int a = raf.readInt();
         System.out.println(a);

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/TestByteBuf.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/TestByteBuf.java
@@ -23,7 +23,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.buffer.Unpooled;
-import io.pixelsdb.pixels.common.physical.direct.DirectIoLib;
+import io.pixelsdb.pixels.common.physical.natives.DirectIoLib;
 import org.junit.Test;
 
 import java.io.IOException;


### PR DESCRIPTION
For experimental evaluations, we support reading local files using mmap. This can be disabled by setting `localfs.enable.mmap=false` in `pixels.properties`.