### PR TITLE
[Issue #419] remove timezone offset for date column.

### DIFF
--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/stats/DateStatsRecorder.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/stats/DateStatsRecorder.java
@@ -24,7 +24,7 @@ import io.pixelsdb.pixels.core.PixelsProto;
 import java.sql.Date;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static io.pixelsdb.pixels.core.utils.DatetimeUtils.sqlDateToDay;
+import static io.pixelsdb.pixels.core.utils.DatetimeUtils.millisToDay;
 
 /**
  * pixels
@@ -101,7 +101,7 @@ public class DateStatsRecorder
     @Override
     public void updateDate(Date value)
     {
-        this.updateDate(sqlDateToDay(value));
+        this.updateDate(millisToDay(value.getTime()));
     }
 
     @Override

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/stats/DateStatsRecorder.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/stats/DateStatsRecorder.java
@@ -24,7 +24,7 @@ import io.pixelsdb.pixels.core.PixelsProto;
 import java.sql.Date;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static io.pixelsdb.pixels.core.utils.DatetimeUtils.millisToDay;
+import static io.pixelsdb.pixels.core.utils.DatetimeUtils.sqlDateToDay;
 
 /**
  * pixels
@@ -101,7 +101,7 @@ public class DateStatsRecorder
     @Override
     public void updateDate(Date value)
     {
-        this.updateDate(millisToDay(value.getTime()));
+        this.updateDate(sqlDateToDay(value));
     }
 
     @Override

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/utils/DatetimeUtils.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/utils/DatetimeUtils.java
@@ -21,6 +21,7 @@ package io.pixelsdb.pixels.core.utils;
 
 import java.sql.Date;
 import java.time.LocalDate;
+import java.util.TimeZone;
 
 /**
  * @author hank
@@ -28,11 +29,11 @@ import java.time.LocalDate;
  */
 public class DatetimeUtils
 {
-    private static final long TIME_OFFSET;
+    private static long TIMEZONE_OFFSET = TimeZone.getDefault().getRawOffset();
 
-    static
+    public static void resetTimezoneOffset()
     {
-        TIME_OFFSET = Date.valueOf("1970-01-01").getTime();
+        TIMEZONE_OFFSET = TimeZone.getDefault().getRawOffset();
     }
 
     /**
@@ -53,18 +54,18 @@ public class DatetimeUtils
     /**
      * Convert the milliseconds to days, both since the Unix epoch ('1970-01-01 00:00:00 UTC').
      * Leap seconds are not considered.
+     * <b>If the default timezone is changed, must call {@link #resetTimezoneOffset()} before this method.</b>
      */
-    @Deprecated
     public static int millisToDay (long millis)
     {
-        // TODO: more tests on this method.
-        return Math.round((millis - TIME_OFFSET) / 86400000f);
+        // TODO: add leap seconds.
+        return Math.round((millis + TIMEZONE_OFFSET) / 86400000f);
     }
 
     /**
      * Convert the {@link Date} of local time to the days since the Unix epoch ('1970-01-01 00:00:00 UTC').
-     * @param date
-     * @return
+     * This method produces more temporary objects than:<br/>
+     * {@code millisToDay(date.getTime())}.
      */
     public static int sqlDateToDay (Date date)
     {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/utils/DatetimeUtils.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/utils/DatetimeUtils.java
@@ -19,36 +19,50 @@
  */
 package io.pixelsdb.pixels.core.utils;
 
+import java.sql.Date;
+import java.time.LocalDate;
+
 /**
  * @author hank
  * @create 2021-04-26
  */
 public class DatetimeUtils
 {
-    // TODO: currently we assume there are 86400000 millis in a day, without dealing with leap second.
-
+    /**
+     * Convert the days to milliseconds, both since the Unix epoch ('1970-01-01 00:00:00 UTC').
+     */
     public static long dayToMillis (int day)
     {
         /**
          * Issue #419:
-         * In SQL, Date (day) does not have time zone, hence we do not need to add timezone offset.
+         * No need to add the timezone offset, because both days and milliseconds
+         * are since the Unix epoch.
          */
         return day * 86400000L;
     }
 
     /**
-     * Convert the milliseconds to the days, both since the Unix epoch ('1970-01-01 00:00:00'),
-     * without considering the effect of timezone.
-     * @param millis the milliseconds since the Unix epoch.
-     * @return the days since the Unix epoch.
+     * Convert the {@link Date} of local time to the days since the Unix epoch ('1970-01-01 00:00:00 UTC').
+     * @param date
+     * @return
      */
-    public static int millisToDay (long millis)
+    public static int sqlDateToDay (Date date)
     {
-        return (int)((millis) / 86400000);
+        return (int) date.toLocalDate().toEpochDay();
+    }
+
+    /**
+     * Convert the {@link Date} of local time to the days since the Unix epoch ('1970-01-01 00:00:00 UTC').
+     * @param date
+     * @return
+     */
+    public static int stringToDay (String date)
+    {
+        return (int) LocalDate.parse(date).toEpochDay();
     }
 
     public static int roundSqlTime (long millis)
     {
-        return (int)(millis%86400000);
+        return (int)(millis % 86400000);
     }
 }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/utils/DatetimeUtils.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/utils/DatetimeUtils.java
@@ -19,32 +19,32 @@
  */
 package io.pixelsdb.pixels.core.utils;
 
-import java.util.Calendar;
-
 /**
- * Created at: 26/04/2021
- * Author: hank
+ * @author hank
+ * @create 2021-04-26
  */
 public class DatetimeUtils
 {
     // TODO: currently we assume there are 86400000 millis in a day, without dealing with leap second.
-    private static final int TIMEZONE_OFFSET;
-
-    static
-    {
-        Calendar calendar = Calendar.getInstance();
-        TIMEZONE_OFFSET = -(calendar.get(Calendar.ZONE_OFFSET) +
-                calendar.get(Calendar.DST_OFFSET)) / (60 * 1000);
-    }
 
     public static long dayToMillis (int day)
     {
-        return day*86400000L+TIMEZONE_OFFSET;
+        /**
+         * Issue #419:
+         * In SQL, Date (day) does not have time zone, hence we do not need to add timezone offset.
+         */
+        return day * 86400000L;
     }
 
+    /**
+     * Convert the milliseconds to the days, both since the Unix epoch ('1970-01-01 00:00:00'),
+     * without considering the effect of timezone.
+     * @param millis the milliseconds since the Unix epoch.
+     * @return the days since the Unix epoch.
+     */
     public static int millisToDay (long millis)
     {
-        return (int)((millis-TIMEZONE_OFFSET)/86400000);
+        return (int)((millis) / 86400000);
     }
 
     public static int roundSqlTime (long millis)

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/utils/DatetimeUtils.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/utils/DatetimeUtils.java
@@ -28,8 +28,16 @@ import java.time.LocalDate;
  */
 public class DatetimeUtils
 {
+    private static final long TIME_OFFSET;
+
+    static
+    {
+        TIME_OFFSET = Date.valueOf("1970-01-01").getTime();
+    }
+
     /**
      * Convert the days to milliseconds, both since the Unix epoch ('1970-01-01 00:00:00 UTC').
+     * Leap seconds are not considered.
      */
     public static long dayToMillis (int day)
     {
@@ -37,8 +45,20 @@ public class DatetimeUtils
          * Issue #419:
          * No need to add the timezone offset, because both days and milliseconds
          * are since the Unix epoch.
+         * TODO: add leap seconds.
          */
         return day * 86400000L;
+    }
+
+    /**
+     * Convert the milliseconds to days, both since the Unix epoch ('1970-01-01 00:00:00 UTC').
+     * Leap seconds are not considered.
+     */
+    @Deprecated
+    public static int millisToDay (long millis)
+    {
+        // TODO: more tests on this method.
+        return Math.round((millis - TIME_OFFSET) / 86400000f);
     }
 
     /**

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/DateColumnVector.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/DateColumnVector.java
@@ -430,7 +430,7 @@ public class DateColumnVector extends ColumnVector
         }
         else
         {
-            this.dates[elementNum] = sqlDateToDay(date);
+            this.dates[elementNum] = millisToDay(date.getTime());
             this.isNull[elementNum] = false;
         }
     }
@@ -463,7 +463,7 @@ public class DateColumnVector extends ColumnVector
         {
             writeIndex = elementNum + 1;
         }
-        this.dates[elementNum] = sqlDateToDay(scratchDate);
+        this.dates[elementNum] = millisToDay(scratchDate.getTime());
         this.isNull[elementNum] = false;
     }
 
@@ -492,7 +492,7 @@ public class DateColumnVector extends ColumnVector
     {
         noNulls = true;
         isRepeating = true;
-        dates[0] = sqlDateToDay(date);
+        dates[0] = millisToDay(date.getTime());
     }
 
     @Override

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/DateColumnVector.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/DateColumnVector.java
@@ -43,8 +43,8 @@ import static java.util.Objects.requireNonNull;
  * Generally, the caller will fill in a scratch date object with values from a row, work
  * using the scratch date, and then perhaps update the column vector row with a result.
  *
- * 2021-04-24
  * @author hank
+ * @create 2021-04-24
  */
 public class DateColumnVector extends ColumnVector
 {
@@ -154,7 +154,6 @@ public class DateColumnVector extends ColumnVector
      */
     public void dateUpdate(Date date, int elementNum)
     {
-
         date.setTime(dayToMillis(this.dates[elementNum]));
     }
 
@@ -172,21 +171,20 @@ public class DateColumnVector extends ColumnVector
     }
 
     /**
-     * Return a long representation of a date.
+     * Return a long representation, i.e., the seconds since the Unix epoch ('1970-01-01 00:00:00' UTC/GMT), of the element.
      *
-     * @param elementNum
+     * @param elementNum the index of the element in this vector
      * @return
      */
     public long getDateAsLong(int elementNum)
     {
-        scratchDate.setTime(dayToMillis(dates[elementNum]));
-        return getDateAsLong(scratchDate);
+        return millisToSeconds(dayToMillis(dates[elementNum]));
     }
 
     /**
-     * Return a long representation of a Date.
+     * Return a long representation, i.e., the seconds since the Unix epoch ('1970-01-01 00:00:00' UTC/GMT), of a Date.
      *
-     * @param date
+     * @param date the date
      * @return
      */
     public static long getDateAsLong(Date date)
@@ -222,7 +220,7 @@ public class DateColumnVector extends ColumnVector
      */
     public int compareTo(int elementNum, Date date)
     {
-        return asScratchDate(elementNum).compareTo(date);
+        return Long.compare(getDateAsLong(elementNum), getDateAsLong(date));
     }
 
     /**
@@ -235,7 +233,7 @@ public class DateColumnVector extends ColumnVector
      */
     public int compareTo(Date date, int elementNum)
     {
-        return date.compareTo(asScratchDate(elementNum));
+        return Long.compare(getDateAsLong(date), getDateAsLong(elementNum));
     }
 
     /**
@@ -388,7 +386,8 @@ public class DateColumnVector extends ColumnVector
         {
             ensureSize(writeIndex * 2, true);
         }
-        this.dates[writeIndex] = millisToDay(value);
+        // Issue #419: value is already the days since the Unix epoch, no need to convert.
+        this.dates[writeIndex] = value;
         this.isNull[writeIndex++] = false;
     }
 
@@ -438,7 +437,7 @@ public class DateColumnVector extends ColumnVector
     }
 
     /**
-     * Set a row from a value, which is the days from 1970-1-1 UTC.
+     * Set a row from a value, which is the days since 1970-1-1 UTC.
      * We assume the entry has already been isRepeated adjusted.
      *
      * @param elementNum

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/DateColumnVector.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/DateColumnVector.java
@@ -25,8 +25,7 @@ import java.sql.Date;
 import java.util.Arrays;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static io.pixelsdb.pixels.core.utils.DatetimeUtils.dayToMillis;
-import static io.pixelsdb.pixels.core.utils.DatetimeUtils.millisToDay;
+import static io.pixelsdb.pixels.core.utils.DatetimeUtils.*;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -408,7 +407,7 @@ public class DateColumnVector extends ColumnVector
         {
             ensureSize(writeIndex * 2, true);
         }
-        set(writeIndex++, Date.valueOf(value));
+        set(writeIndex++, stringToDay(value));
     }
 
     /**
@@ -431,7 +430,7 @@ public class DateColumnVector extends ColumnVector
         }
         else
         {
-            this.dates[elementNum] = millisToDay(date.getTime());
+            this.dates[elementNum] = sqlDateToDay(date);
             this.isNull[elementNum] = false;
         }
     }
@@ -464,7 +463,7 @@ public class DateColumnVector extends ColumnVector
         {
             writeIndex = elementNum + 1;
         }
-        this.dates[elementNum] = millisToDay(scratchDate.getTime());
+        this.dates[elementNum] = sqlDateToDay(scratchDate);
         this.isNull[elementNum] = false;
     }
 
@@ -493,7 +492,7 @@ public class DateColumnVector extends ColumnVector
     {
         noNulls = true;
         isRepeating = true;
-        dates[0] = millisToDay(date.getTime());
+        dates[0] = sqlDateToDay(date);
     }
 
     @Override

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/utils/TestBitmap.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/utils/TestBitmap.java
@@ -22,8 +22,8 @@ package io.pixelsdb.pixels.core.utils;
 import org.junit.Test;
 
 /**
- * Created at: 09/04/2022
- * Author: hank
+ * @create 2022-04-09
+ * @author hank
  */
 public class TestBitmap
 {

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/utils/TestDateTimeUtils.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/utils/TestDateTimeUtils.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022 PixelsDB.
+ *
+ * This file is part of Pixels.
+ *
+ * Pixels is free software: you can redistribute it and/or modify
+ * it under the terms of the Affero GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * Pixels is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Affero GNU General Public License for more details.
+ *
+ * You should have received a copy of the Affero GNU General Public
+ * License along with Pixels.  If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package io.pixelsdb.pixels.core.utils;
+
+/**
+ * @author hank
+ * @create 2023-04-18
+ */
+public class TestDateTimeUtils
+{
+}

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/utils/TestDateTimeUtils.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/utils/TestDateTimeUtils.java
@@ -19,10 +19,89 @@
  */
 package io.pixelsdb.pixels.core.utils;
 
+import org.junit.Test;
+
+import java.sql.Date;
+import java.util.TimeZone;
+
 /**
  * @author hank
  * @create 2023-04-18
  */
 public class TestDateTimeUtils
 {
+    @Test
+    public void testGetDaysSinceEpoch()
+    {
+        int day1, day2, day3;
+        System.out.println(TimeZone.getDefault().getDisplayName() + ", offset=" +
+                TimeZone.getDefault().getRawOffset());
+        day1 = DatetimeUtils.sqlDateToDay(Date.valueOf("2023-03-05"));
+        day2 = DatetimeUtils.stringToDay("2023-03-05");
+        day3 = DatetimeUtils.millisToDay(Date.valueOf("2023-03-05").getTime());
+        assert day1 == day2 && day2 == day3;
+
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+        System.out.println(TimeZone.getDefault().getDisplayName() + ", offset=" +
+                TimeZone.getDefault().getRawOffset());
+        DatetimeUtils.resetTimezoneOffset();
+        day1 = DatetimeUtils.sqlDateToDay(Date.valueOf("2023-03-05"));
+        day2 = DatetimeUtils.stringToDay("2023-03-05");
+        day3 = DatetimeUtils.millisToDay(Date.valueOf("2023-03-05").getTime());
+        assert day1 == day2 && day2 == day3;
+
+        TimeZone.setDefault(TimeZone.getTimeZone("GMT+8:00"));
+        System.out.println(TimeZone.getDefault().getDisplayName() + ", offset=" +
+                TimeZone.getDefault().getRawOffset());
+        DatetimeUtils.resetTimezoneOffset();
+        day1 = DatetimeUtils.sqlDateToDay(Date.valueOf("2023-03-05"));
+        day2 = DatetimeUtils.stringToDay("2023-03-05");
+        day3 = DatetimeUtils.millisToDay(Date.valueOf("2023-03-05").getTime());
+        assert day1 == day2 && day2 == day3;
+
+        TimeZone.setDefault(TimeZone.getTimeZone("GMT+12:00"));
+        System.out.println(TimeZone.getDefault().getDisplayName() + ", offset=" +
+                TimeZone.getDefault().getRawOffset());
+        DatetimeUtils.resetTimezoneOffset();
+        day1 = DatetimeUtils.sqlDateToDay(Date.valueOf("2023-03-05"));
+        day2 = DatetimeUtils.stringToDay("2023-03-05");
+        day3 = DatetimeUtils.millisToDay(Date.valueOf("2023-03-05").getTime());
+        assert day1 == day2 && day2 == day3;
+
+        TimeZone.setDefault(TimeZone.getTimeZone("GMT+14:00"));
+        System.out.println(TimeZone.getDefault().getDisplayName() + ", offset=" +
+                TimeZone.getDefault().getRawOffset());
+        DatetimeUtils.resetTimezoneOffset();
+        day1 = DatetimeUtils.sqlDateToDay(Date.valueOf("2023-03-05"));
+        day2 = DatetimeUtils.stringToDay("2023-03-05");
+        day3 = DatetimeUtils.millisToDay(Date.valueOf("2023-03-05").getTime());
+        assert day1 == day2 && day2 == day3;
+
+        TimeZone.setDefault(TimeZone.getTimeZone("GMT-8:00"));
+        System.out.println(TimeZone.getDefault().getDisplayName() + ", offset=" +
+                TimeZone.getDefault().getRawOffset());
+        DatetimeUtils.resetTimezoneOffset();
+        day1 = DatetimeUtils.sqlDateToDay(Date.valueOf("2023-03-05"));
+        day2 = DatetimeUtils.stringToDay("2023-03-05");
+        day3 = DatetimeUtils.millisToDay(Date.valueOf("2023-03-05").getTime());
+        assert day1 == day2 && day2 == day3;
+
+        TimeZone.setDefault(TimeZone.getTimeZone("GMT-12:00"));
+        System.out.println(TimeZone.getDefault().getDisplayName() + ", offset=" +
+                TimeZone.getDefault().getRawOffset());
+        DatetimeUtils.resetTimezoneOffset();
+        day1 = DatetimeUtils.sqlDateToDay(Date.valueOf("2023-03-05"));
+        day2 = DatetimeUtils.stringToDay("2023-03-05");
+        day3 = DatetimeUtils.millisToDay(Date.valueOf("2023-03-05").getTime());
+        assert day1 == day2 && day2 == day3;
+
+        TimeZone.setDefault(TimeZone.getTimeZone("GMT-14:00"));
+        System.out.println(TimeZone.getDefault().getDisplayName() + ", offset=" +
+                TimeZone.getDefault().getRawOffset());
+        DatetimeUtils.resetTimezoneOffset();
+        day1 = DatetimeUtils.sqlDateToDay(Date.valueOf("2023-03-05"));
+        day2 = DatetimeUtils.stringToDay("2023-03-05");
+        day3 = DatetimeUtils.millisToDay(Date.valueOf("2023-03-05").getTime());
+        assert day1 == day2 && day2 == day3;
+    }
 }


### PR DESCRIPTION
In SQL query engines (at least Trino), the Date type does not have a timezone; hence we do not need to add the timezone offset when converting day to milliseconds and vice versa.

With this fix, the query result of the `test_date` table is consistent with the input data in Issue #419.