### PR TITLE
[Issue #452] enable reading other storages than s3 in serverless workers.

### DIFF
--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/turbo/Input.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/turbo/Input.java
@@ -24,6 +24,25 @@ package io.pixelsdb.pixels.common.turbo;
  * @author hank
  * @create 2022-06-28
  */
-public class Input
+public abstract class Input
 {
+    /**
+     * The unique id of the query.
+     */
+    private long queryId;
+
+    public Input(long queryId)
+    {
+        this.queryId = queryId;
+    }
+
+    public long getQueryId()
+    {
+        return queryId;
+    }
+
+    public void setQueryId(long queryId)
+    {
+        this.queryId = queryId;
+    }
 }

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/turbo/Output.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/turbo/Output.java
@@ -24,7 +24,7 @@ package io.pixelsdb.pixels.common.turbo;
  * @author hank
  * @create 2022-06-28
  */
-public class Output
+public abstract class Output
 {
     private String requestId;
     private boolean successful;

--- a/pixels-common/src/main/resources/pixels.properties
+++ b/pixels-common/src/main/resources/pixels.properties
@@ -136,10 +136,21 @@ join.partition.size.rows=20480000
 aggr.partition.size.rows=1280000
 
 ### pixels-turbo - query execution ###
-executor.input.storage=s3
-executor.intermediate.storage=s3
-executor.stage.completion.ratio=0.6
+executor.input.storage.scheme=s3
+executor.input.storage.endpoint=input-endpoint-dummy
+executor.input.storage.access.key=input-ak-dummy
+executor.input.storage.secret.key=input-sk-dummy
+executor.intermediate.storage.scheme=s3
+executor.intermediate.storage.endpoint=intermediate-endpoint-dummy
+executor.intermediate.storage.access.key=intermediate-ak-dummy
+executor.intermediate.storage.secret.key=intermediate-sk-dummy
 executor.intermediate.folder=/pixels-lambda-test/
+executor.output.storage.scheme=s3
+executor.output.storage.endpoint=output-endpoint-dummy
+executor.output.storage.access.key=output-ak-dummy
+executor.output.storage.secret.key=output-sk-dummy
+executor.output.folder=/pixels-lambda-test/
+executor.stage.completion.ratio=0.6
 executor.selectivity.enabled=true
 # the number of threads used in each worker
 executor.intra.worker.parallelism=8

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/StarlingPlanner.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/StarlingPlanner.java
@@ -33,6 +33,7 @@ import io.pixelsdb.pixels.common.metadata.domain.Projections;
 import io.pixelsdb.pixels.common.metadata.domain.Splits;
 import io.pixelsdb.pixels.common.physical.Storage;
 import io.pixelsdb.pixels.common.physical.StorageFactory;
+import io.pixelsdb.pixels.planner.plan.physical.domain.StorageInfo;
 import io.pixelsdb.pixels.common.utils.ConfigFactory;
 import io.pixelsdb.pixels.executor.join.JoinAlgorithm;
 import io.pixelsdb.pixels.executor.join.JoinType;
@@ -55,14 +56,14 @@ import static java.util.Objects.requireNonNull;
  * The serverless executor of join and aggregation.
  *
  * @author hank
- * @date 15/08/2022
+ * @create 2022-08-15
  */
 public class StarlingPlanner
 {
     private static final Logger logger = LogManager.getLogger(StarlingPlanner.class);
     private static final boolean enablePartitionProjection = false;
-    private static final Storage.Scheme InputStorage;
-    private static final Storage.Scheme IntermediateStorage;
+    private static final StorageInfo InputStorageInfo;
+    private static final StorageInfo IntermediateStorageInfo;
     private static final String IntermediateFolder;
     private static final int IntraWorkerParallelism;
 
@@ -78,16 +79,24 @@ public class StarlingPlanner
 
     static
     {
-        String storageScheme = ConfigFactory.Instance().getProperty("executor.input.storage");
-        InputStorage = Storage.Scheme.from(storageScheme);
-        storageScheme = ConfigFactory.Instance().getProperty("executor.intermediate.storage");
-        IntermediateStorage = Storage.Scheme.from(storageScheme);
-        String storageFolder = ConfigFactory.Instance().getProperty("executor.intermediate.folder");
-        if (!storageFolder.endsWith("/"))
+        String inputStorageScheme = ConfigFactory.Instance().getProperty("executor.input.storage.scheme");
+        String inputStorageEndpoint = ConfigFactory.Instance().getProperty("executor.input.storage.endpoint");
+        String inputStorageAccessKey = ConfigFactory.Instance().getProperty("executor.input.storage.access.key");
+        String inputStorageSecretKey = ConfigFactory.Instance().getProperty("executor.input.storage.secret.key");
+        InputStorageInfo = new StorageInfo(Storage.Scheme.from(inputStorageScheme),
+                inputStorageEndpoint, inputStorageAccessKey, inputStorageSecretKey);
+        String interStorageScheme = ConfigFactory.Instance().getProperty("executor.intermediate.storage.scheme");
+        String interStorageEndpoint = ConfigFactory.Instance().getProperty("executor.intermediate.storage.endpoint");
+        String interStorageAccessKey = ConfigFactory.Instance().getProperty("executor.intermediate.storage.access.key");
+        String interStorageSecretKey = ConfigFactory.Instance().getProperty("executor.intermediate.storage.secret.key");
+        IntermediateStorageInfo = new StorageInfo(Storage.Scheme.from(interStorageScheme),
+                interStorageEndpoint, interStorageAccessKey, interStorageSecretKey);
+        String interStorageFolder = ConfigFactory.Instance().getProperty("executor.intermediate.folder");
+        if (!interStorageFolder.endsWith("/"))
         {
-            storageFolder += "/";
+            interStorageFolder += "/";
         }
-        IntermediateFolder = storageFolder;
+        IntermediateFolder = interStorageFolder;
         IntraWorkerParallelism = Integer.parseInt(ConfigFactory.Instance()
                 .getProperty("executor.intra.worker.parallelism"));
     }
@@ -122,7 +131,7 @@ public class StarlingPlanner
         this.projectionReadEnabled = Boolean.parseBoolean(config.getProperty("projection.read.enabled"));
         this.orderedPathEnabled = orderedPathEnabled;
         this.compactPathEnabled = compactPathEnabled;
-        this.storage = StorageFactory.Instance().getStorage(InputStorage);
+        this.storage = StorageFactory.Instance().getStorage(InputStorageInfo.getScheme());
     }
 
     public Operator getRootOperator() throws IOException, MetadataException
@@ -194,12 +203,14 @@ public class StarlingPlanner
                 tableInfo.setColumnsToRead(originTable.getColumnNames());
                 tableInfo.setTableName(originTable.getTableName());
                 tableInfo.setFilter(JSON.toJSONString(((BaseTable) originTable).getFilter()));
+                tableInfo.setBase(true);
+                tableInfo.setStorageInfo(InputStorageInfo);
                 partitionInput.setTableInfo(tableInfo);
                 partitionInput.setProjection(scanProjection);
                 partitionInput.setPartitionInfo(partitionInfo);
                 String fileName = intermediateBase + (outputId++) + "/part";
-                StorageInfo storageInfo = new StorageInfo(IntermediateStorage, null, null, null);
-                partitionInput.setOutput(new OutputInfo(fileName, false, storageInfo, true));
+                partitionInput.setOutput(new OutputInfo(fileName, false,
+                        IntermediateStorageInfo, true));
                 partitionInputsBuilder.add(partitionInput);
                 AggrInputFilesBuilder.add(fileName);
             }
@@ -216,8 +227,7 @@ public class StarlingPlanner
                 joinInput.setPartialAggregationInfo(partialAggregationInfo);
                 String fileName = "partial_aggr_" + outputId++;
                 MultiOutputInfo outputInfo = joinInput.getOutput();
-                StorageInfo storageInfo = new StorageInfo(IntermediateStorage, null, null, null);
-                outputInfo.setStorageInfo(storageInfo);
+                outputInfo.setStorageInfo(IntermediateStorageInfo);
                 outputInfo.setPath(intermediateBase);
                 outputInfo.setFileNames(ImmutableList.of(fileName));
                 AggrInputFilesBuilder.add(intermediateBase + fileName);
@@ -234,23 +244,28 @@ public class StarlingPlanner
         {
             AggregationInput finalAggrInput = new AggregationInput();
             finalAggrInput.setQueryId(queryId);
-            finalAggrInput.setInputPartitioned(numPartitions > 1);
-            finalAggrInput.setHashValues(ImmutableList.of(hash));
-            finalAggrInput.setNumPartition(numPartitions);
-            finalAggrInput.setInputFiles(aggrInputFiles);
-            finalAggrInput.setColumnsToRead(originTable.getColumnNames());
-            finalAggrInput.setGroupKeyColumnIds(aggregation.getGroupKeyColumnIds());
-            finalAggrInput.setAggregateColumnIds(aggregation.getAggregateColumnIds());
-            finalAggrInput.setGroupKeyColumnNames(aggregation.getGroupKeyColumnAlias());
-            finalAggrInput.setGroupKeyColumnProjection(aggregation.getGroupKeyColumnProjection());
-            finalAggrInput.setResultColumnNames(aggregation.getResultColumnAlias());
-            finalAggrInput.setResultColumnTypes(aggregation.getResultColumnTypes());
-            finalAggrInput.setFunctionTypes(aggregation.getFunctionTypes());
-            finalAggrInput.setInputStorage(new StorageInfo(IntermediateStorage, null, null, null));
-            StorageInfo outputStorageInfo = new StorageInfo(IntermediateStorage, null, null, null);
-            finalAggrInput.setParallelism(IntraWorkerParallelism);
+            AggregatedTableInfo aggregatedTableInfo = new AggregatedTableInfo();
+            aggregatedTableInfo.setTableName(aggregatedTable.getTableName());
+            aggregatedTableInfo.setBase(false);
+            aggregatedTableInfo.setInputFiles(aggrInputFiles);
+            aggregatedTableInfo.setColumnsToRead(originTable.getColumnNames());
+            aggregatedTableInfo.setStorageInfo(IntermediateStorageInfo);
+            aggregatedTableInfo.setParallelism(IntraWorkerParallelism);
+            finalAggrInput.setAggregatedTableInfo(aggregatedTableInfo);
+            AggregationInfo aggregationInfo = new AggregationInfo();
+            aggregationInfo.setInputPartitioned(numPartitions > 1);
+            aggregationInfo.setHashValues(ImmutableList.of(hash));
+            aggregationInfo.setNumPartition(numPartitions);
+            aggregationInfo.setGroupKeyColumnIds(aggregation.getGroupKeyColumnIds());
+            aggregationInfo.setAggregateColumnIds(aggregation.getAggregateColumnIds());
+            aggregationInfo.setGroupKeyColumnNames(aggregation.getGroupKeyColumnAlias());
+            aggregationInfo.setGroupKeyColumnProjection(aggregation.getGroupKeyColumnProjection());
+            aggregationInfo.setResultColumnNames(aggregation.getResultColumnAlias());
+            aggregationInfo.setResultColumnTypes(aggregation.getResultColumnTypes());
+            aggregationInfo.setFunctionTypes(aggregation.getFunctionTypes());
+            finalAggrInput.setAggregationInfo(aggregationInfo);
             String fileName = intermediateBase + (hash) + "/final_aggr";
-            finalAggrInput.setOutput(new OutputInfo(fileName, false, outputStorageInfo, true));
+            finalAggrInput.setOutput(new OutputInfo(fileName, false, IntermediateStorageInfo, true));
             finalAggrInputsBuilder.add(finalAggrInput);
         }
 
@@ -330,9 +345,7 @@ public class StarlingPlanner
 
                 String path = IntermediateFolder + queryId + "/" + joinedTable.getSchemaName() + "/" +
                         joinedTable.getTableName() + "/";
-                MultiOutputInfo output = new MultiOutputInfo(path,
-                        new StorageInfo(IntermediateStorage, null, null, null),
-                        true, outputs);
+                MultiOutputInfo output = new MultiOutputInfo(path, IntermediateStorageInfo, true, outputs);
 
                 BroadcastJoinInput joinInput = new BroadcastJoinInput(queryId, leftTableInfo, rightTableInfo,
                         joinInfo, false, null, output);
@@ -353,14 +366,16 @@ public class StarlingPlanner
             List<String> leftPartitionedFiles = getPartitionedFiles(leftJoinInputs);
             List<JoinInput> rightJoinInputs = rightOperator.getJoinInputs();
             List<String> rightPartitionedFiles = getPartitionedFiles(rightJoinInputs);
+            boolean leftIsBase = leftTable.getTableType() == Table.TableType.BASE;
             PartitionedTableInfo leftTableInfo = new PartitionedTableInfo(
-                    leftTable.getTableName(), leftTable.getTableType() == Table.TableType.BASE,
-                    leftPartitionedFiles, IntraWorkerParallelism,
-                    leftTable.getColumnNames(), leftKeyColumnIds);
+                    leftTable.getTableName(), leftIsBase, leftTable.getColumnNames(),
+                    leftIsBase ? InputStorageInfo : IntermediateStorageInfo,
+                    leftPartitionedFiles, IntraWorkerParallelism, leftKeyColumnIds);
+            boolean rightIsBase = rightTable.getTableType() == Table.TableType.BASE;
             PartitionedTableInfo rightTableInfo = new PartitionedTableInfo(
-                    rightTable.getTableName(), rightTable.getTableType() == Table.TableType.BASE,
-                    rightPartitionedFiles, IntraWorkerParallelism,
-                    rightTable.getColumnNames(), rightKeyColumnIds);
+                    rightTable.getTableName(), rightIsBase, rightTable.getColumnNames(),
+                    rightIsBase ? InputStorageInfo : IntermediateStorageInfo,
+                    rightPartitionedFiles, IntraWorkerParallelism, rightKeyColumnIds);
 
             int numPartition = PlanOptimizer.Instance().getJoinNumPartition(leftTable, rightTable, join.getJoinEndian());
             List<JoinInput> joinInputs = getPartitionedJoinInputs(
@@ -398,19 +413,23 @@ public class StarlingPlanner
         Join join = requireNonNull(joinedTable.getJoin(), "joinTable.join is null");
         requireNonNull(join.getLeftTable(), "join.leftTable is null");
         requireNonNull(join.getRightTable(), "join.rightTable is null");
-        checkArgument(join.getLeftTable().getTableType() == Table.TableType.BASE || join.getLeftTable().getTableType() == Table.TableType.JOINED,
+        checkArgument(join.getLeftTable().getTableType() == Table.TableType.BASE ||
+                        join.getLeftTable().getTableType() == Table.TableType.JOINED,
                 "join.leftTable is not base or joined table");
-        checkArgument(join.getRightTable().getTableType() == Table.TableType.BASE || join.getRightTable().getTableType() == Table.TableType.JOINED,
+        checkArgument(join.getRightTable().getTableType() == Table.TableType.BASE ||
+                        join.getRightTable().getTableType() == Table.TableType.JOINED,
                 "join.rightTable is not base or joined table");
 
-        if (join.getLeftTable().getTableType() == Table.TableType.JOINED && join.getRightTable().getTableType() == Table.TableType.JOINED)
+        if (join.getLeftTable().getTableType() == Table.TableType.JOINED &&
+                join.getRightTable().getTableType() == Table.TableType.JOINED)
         {
             // Process multi-pipeline join.
             return getMultiPipelineJoinOperator(joinedTable, parent);
         }
 
         Table leftTable = join.getLeftTable();
-        checkArgument(join.getRightTable().getTableType() == Table.TableType.BASE, "join.rightTable is not base table");
+        checkArgument(join.getRightTable().getTableType() == Table.TableType.BASE,
+                "join.rightTable is not base table");
         BaseTable rightTable = (BaseTable) join.getRightTable();
         int[] leftKeyColumnIds = requireNonNull(join.getLeftKeyColumnIds(),
                 "join.leftKeyColumnIds is null");
@@ -536,9 +555,7 @@ public class StarlingPlanner
 
                     String path = IntermediateFolder + queryId + "/" + joinedTable.getSchemaName() + "/" +
                             joinedTable.getTableName() + "/";
-                    MultiOutputInfo output = new MultiOutputInfo(path,
-                            new StorageInfo(IntermediateStorage, null, null, null),
-                            true, outputs);
+                    MultiOutputInfo output = new MultiOutputInfo(path, IntermediateStorageInfo, true, outputs);
 
                     BroadcastJoinInput joinInput = new BroadcastJoinInput(
                             queryId, leftTableInfo, rightTableInfo, joinInfo,
@@ -586,9 +603,7 @@ public class StarlingPlanner
 
                     String path = IntermediateFolder + queryId + "/" + joinedTable.getSchemaName() + "/" +
                             joinedTable.getTableName() + "/";
-                    MultiOutputInfo output = new MultiOutputInfo(path,
-                            new StorageInfo(IntermediateStorage, null, null, null),
-                            true, outputs);
+                    MultiOutputInfo output = new MultiOutputInfo(path, IntermediateStorageInfo, true, outputs);
 
                     BroadcastJoinInput joinInput = new BroadcastJoinInput(
                             queryId, rightTableInfo, leftTableInfo, joinInfo,
@@ -617,10 +632,11 @@ public class StarlingPlanner
             if (childOperator != null)
             {
                 // left side is post partitioned, thus we only partition the right table.
+                boolean leftIsBase = leftTable.getTableType() == Table.TableType.BASE;
                 PartitionedTableInfo leftTableInfo = new PartitionedTableInfo(
-                        leftTable.getTableName(), leftTable.getTableType() == Table.TableType.BASE,
-                        leftPartitionedFiles, IntraWorkerParallelism,
-                        leftTable.getColumnNames(), leftKeyColumnIds);
+                        leftTable.getTableName(), leftIsBase, leftTable.getColumnNames(),
+                        leftIsBase ? InputStorageInfo : IntermediateStorageInfo,
+                        leftPartitionedFiles, IntraWorkerParallelism, leftKeyColumnIds);
 
                 boolean[] rightPartitionProjection = getPartitionProjection(rightTable, join.getRightProjection());
 
@@ -750,17 +766,20 @@ public class StarlingPlanner
     {
         BroadcastTableInfo tableInfo = new BroadcastTableInfo();
         tableInfo.setTableName(table.getTableName());
-        tableInfo.setBase(table.getTableType() == Table.TableType.BASE);
         tableInfo.setInputSplits(inputSplits);
         tableInfo.setColumnsToRead(table.getColumnNames());
         if (table.getTableType() == Table.TableType.BASE)
         {
             tableInfo.setFilter(JSON.toJSONString(((BaseTable) table).getFilter()));
+            tableInfo.setBase(true);
+            tableInfo.setStorageInfo(InputStorageInfo);
         }
         else
         {
             tableInfo.setFilter(JSON.toJSONString(
                     TableScanFilter.empty(table.getSchemaName(), table.getTableName())));
+            tableInfo.setBase(false);
+            tableInfo.setStorageInfo(IntermediateStorageInfo);
         }
         tableInfo.setKeyColumnIds(keyColumnIds);
         return tableInfo;
@@ -924,8 +943,17 @@ public class StarlingPlanner
         int[] newKeyColumnIds = rewriteColumnIdsForPartitionedJoin(keyColumnIds, partitionProjection);
         String[] newColumnsToRead = rewriteColumnsToReadForPartitionedJoin(table.getColumnNames(), partitionProjection);
 
-        return new PartitionedTableInfo(table.getTableName(), table.getTableType() == Table.TableType.BASE,
-                rightPartitionedFiles.build(), IntraWorkerParallelism, newColumnsToRead, newKeyColumnIds);
+        if (table.getTableType() == Table.TableType.BASE)
+        {
+            return new PartitionedTableInfo(table.getTableName(), true,
+                    newColumnsToRead, InputStorageInfo, rightPartitionedFiles.build(),
+                    IntraWorkerParallelism, newKeyColumnIds);
+        } else
+        {
+            return new PartitionedTableInfo(table.getTableName(), false,
+                    newColumnsToRead, IntermediateStorageInfo, rightPartitionedFiles.build(),
+                    IntraWorkerParallelism, newKeyColumnIds);
+        }
     }
 
     private List<PartitionInput> getPartitionInputs(Table inputTable, List<InputSplit> inputSplits, int[] keyColumnIds,
@@ -951,16 +979,20 @@ public class StarlingPlanner
             if (inputTable.getTableType() == Table.TableType.BASE)
             {
                 tableInfo.setFilter(JSON.toJSONString(((BaseTable) inputTable).getFilter()));
+                tableInfo.setBase(true);
+                tableInfo.setStorageInfo(InputStorageInfo);
             }
             else
             {
                 tableInfo.setFilter(JSON.toJSONString(
                         TableScanFilter.empty(inputTable.getSchemaName(), inputTable.getTableName())));
+                tableInfo.setBase(false);
+                tableInfo.setStorageInfo(IntermediateStorageInfo);
             }
             partitionInput.setTableInfo(tableInfo);
             partitionInput.setProjection(partitionProjection);
-            partitionInput.setOutput(new OutputInfo(outputBase + (outputId++) + "/part", false,
-                    new StorageInfo(InputStorage, null, null, null), true));
+            partitionInput.setOutput(new OutputInfo(outputBase + (outputId++) + "/part",
+                    false, InputStorageInfo, true));
             int[] newKeyColumnIds = rewriteColumnIdsForPartitionedJoin(keyColumnIds, partitionProjection);
             partitionInput.setPartitionInfo(new PartitionInfo(newKeyColumnIds, numPartition));
             partitionInputsBuilder.add(partitionInput);
@@ -1023,9 +1055,7 @@ public class StarlingPlanner
 
             String path = IntermediateFolder + queryId + "/" + joinedTable.getSchemaName() + "/" +
                     joinedTable.getTableName() + "/";
-            MultiOutputInfo output = new MultiOutputInfo(path,
-                    new StorageInfo(IntermediateStorage, null, null, null),
-                    true, outputFileNames.build());
+            MultiOutputInfo output = new MultiOutputInfo(path, IntermediateStorageInfo, true, outputFileNames.build());
 
             boolean[] leftProjection = leftPartitionProjection == null ? joinedTable.getJoin().getLeftProjection() :
                     rewriteProjectionForPartitionedJoin(joinedTable.getJoin().getLeftProjection(), leftPartitionProjection);
@@ -1130,6 +1160,11 @@ public class StarlingPlanner
         checkArgument(table.getTableType() == Table.TableType.BASE, "this is not a base table");
         ImmutableList.Builder<InputSplit> splitsBuilder = ImmutableList.builder();
         int splitSize = 0;
+        Storage.Scheme tableStorageScheme = Storage.Scheme.from(
+                metadataService.getTable(table.getSchemaName(), table.getTableName()).getStorageScheme());
+        checkArgument(tableStorageScheme.equals(this.storage.getScheme()), String.format(
+                "the storage scheme of table '%s.%s' is not consistent with the input storage scheme for Pixels Turbo",
+                table.getSchemaName(), table.getTableName()));
         List<Layout> layouts = metadataService.getLayouts(table.getSchemaName(), table.getTableName());
         for (Layout layout : layouts)
         {

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/PlanOptimizer.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/PlanOptimizer.java
@@ -49,7 +49,7 @@ import static io.pixelsdb.pixels.planner.plan.logical.Table.TableType.JOINED;
  * The optimizer for serverless query plan.
  *
  * @author hank
- * @date 6/20/22
+ * @create 2022-06-20
  */
 public class PlanOptimizer
 {

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/AggregationOperator.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/AggregationOperator.java
@@ -36,7 +36,7 @@ import static java.util.Objects.requireNonNull;
 
 /**
  * @author hank
- * @date 05/07/2022
+ * @create 2022-07-05
  */
 public class AggregationOperator extends Operator
 {

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/JoinOperator.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/JoinOperator.java
@@ -28,7 +28,7 @@ import java.util.concurrent.ExecutionException;
 
 /**
  * @author hank
- * @date 05/06/2022
+ * @create 2022-06-05
  */
 public abstract class JoinOperator extends Operator
 {

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/Operator.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/Operator.java
@@ -28,7 +28,7 @@ import static java.util.Objects.requireNonNull;
 
 /**
  * @author hank
- * @date 05/07/2022
+ * @create 2022-07-05
  */
 public abstract class Operator
 {

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/PartitionedJoinOperator.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/PartitionedJoinOperator.java
@@ -40,7 +40,7 @@ import static com.google.common.base.Preconditions.checkArgument;
  * The executor of a partitioned join.
  *
  * @author hank
- * @date 04/06/2022
+ * @create 2022-06-04
  */
 public class PartitionedJoinOperator extends SingleStageJoinOperator
 {

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/SingleStageJoinOperator.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/SingleStageJoinOperator.java
@@ -37,7 +37,7 @@ import java.util.concurrent.ExecutionException;
  * The executor of a single-stage join.
  *
  * @author hank
- * @date 04/06/2022
+ * @create 2022-06-04
  */
 public class SingleStageJoinOperator extends JoinOperator
 {

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/StarlingAggregationOperator.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/StarlingAggregationOperator.java
@@ -36,7 +36,7 @@ import static java.util.Objects.requireNonNull;
 
 /**
  * @author hank
- * @date 05/07/2022
+ * @create 2022-07-05
  */
 public class StarlingAggregationOperator extends Operator
 {

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/domain/AggregatedTableInfo.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/domain/AggregatedTableInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 PixelsDB.
+ * Copyright 2023 PixelsDB.
  *
  * This file is part of Pixels.
  *
@@ -19,41 +19,35 @@
  */
 package io.pixelsdb.pixels.planner.plan.physical.domain;
 
+import io.pixelsdb.pixels.planner.plan.physical.input.AggregationInput;
+
 import java.util.List;
 
 /**
+ * The partial aggregates are seen as a table (i.e., materialized view). This is the
+ * information of the partial aggregates.
  * @author hank
- * @create 2022-06-02
+ * @create 2023-04-29 (move fields from {@link AggregationInput} to here)
  */
-public class PartitionedTableInfo extends TableInfo
+public class AggregatedTableInfo extends TableInfo
 {
     /**
-     * The partitioned file paths of the table.
+     * The paths of the partial aggregated files.
      */
     private List<String> inputFiles;
     /**
-     * The number of threads used to process the table.
+     * The number of threads to scan and aggregate the input files.
      */
     private int parallelism;
 
-    /**
-     * The ids of the join-key columns of the table.
-     */
-    private int[] keyColumnIds;
+    public AggregatedTableInfo() { }
 
-    /**
-     * Default constructor for Jackson.
-     */
-    public PartitionedTableInfo() { }
-
-    public PartitionedTableInfo(String tableName, boolean base, String[] columnsToRead,
-                                StorageInfo storageInfo, List<String> inputFiles,
-                                int parallelism, int[] keyColumnIds)
+    public AggregatedTableInfo(String tableName, boolean base, String[] columnsToRead,
+                               StorageInfo storageInfo, List<String> inputFiles, int parallelism)
     {
         super(tableName, base, columnsToRead, storageInfo);
         this.inputFiles = inputFiles;
         this.parallelism = parallelism;
-        this.keyColumnIds = keyColumnIds;
     }
 
     public List<String> getInputFiles()
@@ -76,13 +70,4 @@ public class PartitionedTableInfo extends TableInfo
         this.parallelism = parallelism;
     }
 
-    public int[] getKeyColumnIds()
-    {
-        return keyColumnIds;
-    }
-
-    public void setKeyColumnIds(int[] keyColumnIds)
-    {
-        this.keyColumnIds = keyColumnIds;
-    }
 }

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/domain/AggregatedTableInfo.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/domain/AggregatedTableInfo.java
@@ -69,5 +69,4 @@ public class AggregatedTableInfo extends TableInfo
     {
         this.parallelism = parallelism;
     }
-
 }

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/domain/AggregationInfo.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/domain/AggregationInfo.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2023 PixelsDB.
+ *
+ * This file is part of Pixels.
+ *
+ * Pixels is free software: you can redistribute it and/or modify
+ * it under the terms of the Affero GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * Pixels is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Affero GNU General Public License for more details.
+ *
+ * You should have received a copy of the Affero GNU General Public
+ * License along with Pixels.  If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package io.pixelsdb.pixels.planner.plan.physical.domain;
+
+import io.pixelsdb.pixels.executor.aggregation.FunctionType;
+import io.pixelsdb.pixels.planner.plan.physical.input.AggregationInput;
+
+import java.util.List;
+
+/**
+ * The information of the final aggregation.
+ * @author hank
+ * @create 2023-04-29 (move fields from {@link AggregationInput} to here)
+ */
+public class AggregationInfo
+{
+    /**
+     * Whether the input files are partitioned.
+     */
+    private boolean inputPartitioned;
+    /**
+     * The hash values to be processed by this aggregation worker.
+     */
+    private List<Integer> hashValues;
+    /**
+     * The number of partitions in the input files.
+     */
+    private int numPartition;
+    /**
+     * The column ids of the group-key columns in columnsToRead.
+     */
+    private int[] groupKeyColumnIds;
+    /**
+     * The column ids of the aggregate columns in columnsToRead.
+     */
+    private int[] aggregateColumnIds;
+    /**
+     * The column names of the group-key columns in the aggregation result.
+     */
+    private String[] groupKeyColumnNames;
+    /**
+     * If a group-key column appears in the aggregation result,
+     * the corresponding element in this array should be true, and vice versa.
+     */
+    private boolean[] groupKeyColumnProjection;
+    /**
+     * The column names of the aggregated columns in the aggregation result.
+     */
+    private String[] resultColumnNames;
+    /**
+     * The display name of the data types of the result columns.
+     * They should be parsed by the TypeDescription in Pixels.
+     */
+    private String[] resultColumnTypes;
+    /**
+     * The aggregation functions, in the same order of resultColumnNames.
+     */
+    private FunctionType[] functionTypes;
+
+    public AggregationInfo() { }
+
+    public AggregationInfo(boolean inputPartitioned, List<Integer> hashValues, int numPartition,
+                           int[] groupKeyColumnIds, int[] aggregateColumnIds, String[] groupKeyColumnNames,
+                           boolean[] groupKeyColumnProjection, String[] resultColumnNames,
+                           String[] resultColumnTypes, FunctionType[] functionTypes)
+    {
+        this.inputPartitioned = inputPartitioned;
+        this.hashValues = hashValues;
+        this.numPartition = numPartition;
+        this.groupKeyColumnIds = groupKeyColumnIds;
+        this.aggregateColumnIds = aggregateColumnIds;
+        this.groupKeyColumnNames = groupKeyColumnNames;
+        this.groupKeyColumnProjection = groupKeyColumnProjection;
+        this.resultColumnNames = resultColumnNames;
+        this.resultColumnTypes = resultColumnTypes;
+        this.functionTypes = functionTypes;
+    }
+
+    public boolean isInputPartitioned()
+    {
+        return inputPartitioned;
+    }
+
+    public void setInputPartitioned(boolean inputPartitioned)
+    {
+        this.inputPartitioned = inputPartitioned;
+    }
+
+    public List<Integer> getHashValues()
+    {
+        return hashValues;
+    }
+
+    public void setHashValues(List<Integer> hashValues)
+    {
+        this.hashValues = hashValues;
+    }
+
+    public int getNumPartition()
+    {
+        return numPartition;
+    }
+
+    public void setNumPartition(int numPartition)
+    {
+        this.numPartition = numPartition;
+    }
+
+    public int[] getGroupKeyColumnIds()
+    {
+        return groupKeyColumnIds;
+    }
+
+    public void setGroupKeyColumnIds(int[] groupKeyColumnIds)
+    {
+        this.groupKeyColumnIds = groupKeyColumnIds;
+    }
+
+    public int[] getAggregateColumnIds()
+    {
+        return aggregateColumnIds;
+    }
+
+    public void setAggregateColumnIds(int[] aggregateColumnIds)
+    {
+        this.aggregateColumnIds = aggregateColumnIds;
+    }
+
+    public String[] getGroupKeyColumnNames()
+    {
+        return groupKeyColumnNames;
+    }
+
+    public void setGroupKeyColumnNames(String[] groupKeyColumnNames)
+    {
+        this.groupKeyColumnNames = groupKeyColumnNames;
+    }
+
+    public boolean[] getGroupKeyColumnProjection()
+    {
+        return groupKeyColumnProjection;
+    }
+
+    public void setGroupKeyColumnProjection(boolean[] groupKeyColumnProjection)
+    {
+        this.groupKeyColumnProjection = groupKeyColumnProjection;
+    }
+
+    public String[] getResultColumnNames()
+    {
+        return resultColumnNames;
+    }
+
+    public void setResultColumnNames(String[] resultColumnNames)
+    {
+        this.resultColumnNames = resultColumnNames;
+    }
+
+    public String[] getResultColumnTypes()
+    {
+        return resultColumnTypes;
+    }
+
+    public void setResultColumnTypes(String[] resultColumnTypes)
+    {
+        this.resultColumnTypes = resultColumnTypes;
+    }
+
+    public FunctionType[] getFunctionTypes()
+    {
+        return functionTypes;
+    }
+
+    public void setFunctionTypes(FunctionType[] functionTypes)
+    {
+        this.functionTypes = functionTypes;
+    }
+}

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/domain/BroadcastTableInfo.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/domain/BroadcastTableInfo.java
@@ -23,7 +23,7 @@ import java.util.List;
 
 /**
  * @author hank
- * @date 02/06/2022
+ * @dacreatete 2022-06-02
  */
 public class BroadcastTableInfo extends ScanTableInfo
 {
@@ -37,10 +37,11 @@ public class BroadcastTableInfo extends ScanTableInfo
      */
     public BroadcastTableInfo() { }
 
-    public BroadcastTableInfo(String tableName, boolean base, List<InputSplit> inputs,
-                              String[] cols, String filter, int[] keyColumnIds)
+    public BroadcastTableInfo(String tableName, boolean base, String[] columnsToRead,
+                              StorageInfo storageInfo, List<InputSplit> inputSplits,
+                              String filter, int[] keyColumnIds)
     {
-        super(tableName, base, inputs, cols, filter);
+        super(tableName, base, columnsToRead, storageInfo, inputSplits, filter);
         this.keyColumnIds = keyColumnIds;
     }
 

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/domain/ChainJoinInfo.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/domain/ChainJoinInfo.java
@@ -25,7 +25,7 @@ import java.util.Arrays;
 
 /**
  * @author hank
- * @date 03/06/2022
+ * @create 2022-06-03
  */
 public class ChainJoinInfo extends JoinInfo
 {

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/domain/InputInfo.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/domain/InputInfo.java
@@ -21,7 +21,7 @@ package io.pixelsdb.pixels.planner.plan.physical.domain;
 
 /**
  * @author hank
- * @date 02/06/2022
+ * @create 2022-06-02
  */
 public class InputInfo
 {

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/domain/InputSplit.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/domain/InputSplit.java
@@ -23,7 +23,7 @@ import java.util.List;
 
 /**
  * @author hank
- * @date 02/06/2022
+ * @create 2022-06-02
  */
 public class InputSplit
 {

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/domain/JoinInfo.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/domain/JoinInfo.java
@@ -23,7 +23,7 @@ import io.pixelsdb.pixels.executor.join.JoinType;
 
 /**
  * @author hank
- * @date 02/06/2022
+ * @create 2022-06-02
  */
 public class JoinInfo
 {

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/domain/MultiOutputInfo.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/domain/MultiOutputInfo.java
@@ -23,7 +23,7 @@ import java.util.List;
 
 /**
  * @author hank
- * @date 02/06/2022
+ * @create 2022-06-02
  */
 public class MultiOutputInfo extends OutputInfo
 {

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/domain/OutputInfo.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/domain/OutputInfo.java
@@ -21,7 +21,7 @@ package io.pixelsdb.pixels.planner.plan.physical.domain;
 
 /**
  * @author hank
- * @date 02/06/2022
+ * @create 2022-06-02
  */
 public class OutputInfo
 {

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/domain/PartialAggregationInfo.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/domain/PartialAggregationInfo.java
@@ -23,7 +23,7 @@ import io.pixelsdb.pixels.executor.aggregation.FunctionType;
 
 /**
  * @author hank
- * @date 05/07/2022
+ * @create 2022-07-05
  */
 public class PartialAggregationInfo
 {

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/domain/PartitionInfo.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/domain/PartitionInfo.java
@@ -21,7 +21,7 @@ package io.pixelsdb.pixels.planner.plan.physical.domain;
 
 /**
  * @author hank
- * @date 02/06/2022
+ * @create 2022-06-02
  */
 public class PartitionInfo
 {

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/domain/PartitionedJoinInfo.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/domain/PartitionedJoinInfo.java
@@ -25,7 +25,7 @@ import java.util.List;
 
 /**
  * @author hank
- * @date 02/06/2022
+ * @create 2022-06-02
  */
 public class PartitionedJoinInfo extends JoinInfo
 {

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/domain/ScanTableInfo.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/domain/ScanTableInfo.java
@@ -23,7 +23,7 @@ import java.util.List;
 
 /**
  * @author hank
- * @date 02/06/2022
+ * @create 2022-06-02
  */
 public class ScanTableInfo extends TableInfo
 {
@@ -41,10 +41,10 @@ public class ScanTableInfo extends TableInfo
      */
     public ScanTableInfo() { }
 
-    public ScanTableInfo(String tableName, boolean base, List<InputSplit> inputSplits,
-                         String[] columnsToRead, String filter)
+    public ScanTableInfo(String tableName, boolean base, String[] columnsToRead,
+                         StorageInfo storageInfo, List<InputSplit> inputSplits, String filter)
     {
-        super(tableName, base, columnsToRead);
+        super(tableName, base, columnsToRead, storageInfo);
         this.inputSplits = inputSplits;
         this.filter = filter;
     }

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/domain/StorageInfo.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/domain/StorageInfo.java
@@ -24,7 +24,7 @@ import io.pixelsdb.pixels.common.physical.Storage;
 /**
  * The information of the storage endpoint, such as S3 or Minio.
  * @author hank
- * @date 06/07/2022
+ * @create 2022-07-06
  */
 public class StorageInfo
 {

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/domain/TableInfo.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/domain/TableInfo.java
@@ -21,9 +21,9 @@ package io.pixelsdb.pixels.planner.plan.physical.domain;
 
 /**
  * @author hank
- * @date 02/06/2022
+ * @create 2022-06-02
  */
-public class TableInfo
+public abstract class TableInfo
 {
     private String tableName;
 
@@ -39,15 +39,21 @@ public class TableInfo
     private String[] columnsToRead;
 
     /**
+     * The information of the storage endpoint.
+     */
+    private StorageInfo storageInfo;
+
+    /**
      * Default constructor for Jackson.
      */
     public TableInfo() { }
 
-    public TableInfo(String tableName, boolean base, String[] columnsToRead)
+    public TableInfo(String tableName, boolean base, String[] columnsToRead, StorageInfo storageInfo)
     {
         this.tableName = tableName;
         this.base = base;
         this.columnsToRead = columnsToRead;
+        this.storageInfo = storageInfo;
     }
 
     public String getTableName()
@@ -78,5 +84,15 @@ public class TableInfo
     public void setColumnsToRead(String[] columnsToRead)
     {
         this.columnsToRead = columnsToRead;
+    }
+
+    public StorageInfo getStorageInfo()
+    {
+        return storageInfo;
+    }
+
+    public void setStorageInfo(StorageInfo storageInfo)
+    {
+        this.storageInfo = storageInfo;
     }
 }

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/input/AggregationInput.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/input/AggregationInput.java
@@ -20,80 +20,27 @@
 package io.pixelsdb.pixels.planner.plan.physical.input;
 
 import io.pixelsdb.pixels.common.turbo.Input;
-import io.pixelsdb.pixels.executor.aggregation.FunctionType;
+import io.pixelsdb.pixels.planner.plan.physical.domain.AggregatedTableInfo;
+import io.pixelsdb.pixels.planner.plan.physical.domain.AggregationInfo;
 import io.pixelsdb.pixels.planner.plan.physical.domain.OutputInfo;
-import io.pixelsdb.pixels.planner.plan.physical.domain.StorageInfo;
-
-import java.util.List;
 
 /**
  * The input for the final aggregation.
  *
  * @author hank
- * @date 05/07/2022
+ * @create 05/07/2022
+ * @update 2023-04-29 move some fields to {@link AggregatedTableInfo} and {@link AggregationInfo}
  */
 public class AggregationInput extends Input
 {
-    private long queryId;
     /**
-     * Whether the input files are partitioned.
+     * The information of the aggregation input.
      */
-    private boolean inputPartitioned;
+    private AggregatedTableInfo aggregatedTableInfo;
     /**
-     * The hash values to be processed by this aggregation worker.
+     * The information of the aggregate operation.
      */
-    private List<Integer> hashValues;
-    /**
-     * The number of partitions in the input files.
-     */
-    private int numPartition;
-    /**
-     * The name of the columns to read from the input files.
-     */
-    private String[] columnsToRead;
-    /**
-     * The column ids of the group-key columns in {@link #columnsToRead}.
-     */
-    private int[] groupKeyColumnIds;
-    /**
-     * The column ids of the aggregate columns in {@link #columnsToRead}.
-     */
-    private int[] aggregateColumnIds;
-    /**
-     * The column names of the group-key columns in the aggregation result.
-     */
-    private String[] groupKeyColumnNames;
-    /**
-     * If a group-key column appears in the aggregation output,
-     * the corresponding element in this array should be true, and vice versa.
-     */
-    private boolean[] groupKeyColumnProjection;
-    /**
-     * The column names of the aggregated columns in the aggregation result.
-     */
-    private String[] resultColumnNames;
-    /**
-     * The display name of the data types of the result columns.
-     * They should be parsed by the TypeDescription in Pixels.
-     */
-    private String[] resultColumnTypes;
-    /**
-     * The aggregation functions, in the same order of resultColumnNames.
-     */
-    private FunctionType[] functionTypes;
-    /**
-     * The paths of the partial aggregated files.
-     */
-    private List<String> inputFiles;
-    /**
-     * The information of the input storage.
-     */
-    private StorageInfo inputStorage;
-    /**
-     * The number of threads to scan and aggregate the input files.
-     */
-    private int parallelism;
-
+    private AggregationInfo aggregationInfo;
     /**
      * The output of the aggregation.
      */
@@ -102,180 +49,38 @@ public class AggregationInput extends Input
     /**
      * Default constructor for Jackson.
      */
-    public AggregationInput() { }
-
-    public AggregationInput(long queryId, boolean inputPartitioned, List<Integer> hashValues, int numPartition,
-                            String[] columnsToRead, int[] groupKeyColumnIds, int[] aggregateColumnIds,
-                            String[] groupKeyColumnNames, boolean[] groupKeyColumnProjection, String[] resultColumnNames,
-                            String[] resultColumnTypes, FunctionType[] functionTypes, List<String> inputFiles,
-                            StorageInfo inputStorage, int parallelism, OutputInfo output)
+    public AggregationInput()
     {
-        this.queryId = queryId;
-        this.inputPartitioned = inputPartitioned;
-        this.hashValues = hashValues;
-        this.numPartition = numPartition;
-        this.columnsToRead = columnsToRead;
-        this.groupKeyColumnIds = groupKeyColumnIds;
-        this.aggregateColumnIds = aggregateColumnIds;
-        this.groupKeyColumnNames = groupKeyColumnNames;
-        this.groupKeyColumnProjection = groupKeyColumnProjection;
-        this.resultColumnNames = resultColumnNames;
-        this.resultColumnTypes = resultColumnTypes;
-        this.functionTypes = functionTypes;
-        this.inputFiles = inputFiles;
-        this.inputStorage = inputStorage;
-        this.parallelism = parallelism;
+        super(-1);
+    }
+
+    public AggregationInput(long queryId, AggregatedTableInfo aggregatedTableInfo,
+                            AggregationInfo aggregationInfo, OutputInfo output)
+    {
+        super(queryId);
+        this.aggregatedTableInfo = aggregatedTableInfo;
+        this.aggregationInfo = aggregationInfo;
         this.output = output;
     }
 
-    public long getQueryId()
+    public AggregatedTableInfo getAggregatedTableInfo()
     {
-        return queryId;
+        return aggregatedTableInfo;
     }
 
-    public void setQueryId(long queryId)
+    public void setAggregatedTableInfo(AggregatedTableInfo aggregatedTableInfo)
     {
-        this.queryId = queryId;
+        this.aggregatedTableInfo = aggregatedTableInfo;
     }
 
-    public boolean isInputPartitioned()
+    public AggregationInfo getAggregationInfo()
     {
-        return inputPartitioned;
+        return aggregationInfo;
     }
 
-    public void setInputPartitioned(boolean inputPartitioned)
+    public void setAggregationInfo(AggregationInfo aggregationInfo)
     {
-        this.inputPartitioned = inputPartitioned;
-    }
-
-    public List<Integer> getHashValues()
-    {
-        return hashValues;
-    }
-
-    public void setHashValues(List<Integer> hashValues)
-    {
-        this.hashValues = hashValues;
-    }
-
-    public int getNumPartition()
-    {
-        return numPartition;
-    }
-
-    public void setNumPartition(int numPartition)
-    {
-        this.numPartition = numPartition;
-    }
-
-    public String[] getColumnsToRead()
-    {
-        return columnsToRead;
-    }
-
-    public void setColumnsToRead(String[] columnsToRead)
-    {
-        this.columnsToRead = columnsToRead;
-    }
-
-    public int[] getGroupKeyColumnIds()
-    {
-        return groupKeyColumnIds;
-    }
-
-    public void setGroupKeyColumnIds(int[] groupKeyColumnIds)
-    {
-        this.groupKeyColumnIds = groupKeyColumnIds;
-    }
-
-    public int[] getAggregateColumnIds()
-    {
-        return aggregateColumnIds;
-    }
-
-    public void setAggregateColumnIds(int[] aggregateColumnIds)
-    {
-        this.aggregateColumnIds = aggregateColumnIds;
-    }
-
-    public String[] getGroupKeyColumnNames()
-    {
-        return groupKeyColumnNames;
-    }
-
-    public void setGroupKeyColumnNames(String[] groupKeyColumnNames)
-    {
-        this.groupKeyColumnNames = groupKeyColumnNames;
-    }
-
-    public boolean[] getGroupKeyColumnProjection()
-    {
-        return groupKeyColumnProjection;
-    }
-
-    public void setGroupKeyColumnProjection(boolean[] groupKeyColumnProjection)
-    {
-        this.groupKeyColumnProjection = groupKeyColumnProjection;
-    }
-
-    public String[] getResultColumnNames()
-    {
-        return resultColumnNames;
-    }
-
-    public void setResultColumnNames(String[] resultColumnNames)
-    {
-        this.resultColumnNames = resultColumnNames;
-    }
-
-    public String[] getResultColumnTypes()
-    {
-        return resultColumnTypes;
-    }
-
-    public void setResultColumnTypes(String[] resultColumnTypes)
-    {
-        this.resultColumnTypes = resultColumnTypes;
-    }
-
-    public FunctionType[] getFunctionTypes()
-    {
-        return functionTypes;
-    }
-
-    public void setFunctionTypes(FunctionType[] functionTypes)
-    {
-        this.functionTypes = functionTypes;
-    }
-
-    public List<String> getInputFiles()
-    {
-        return inputFiles;
-    }
-
-    public void setInputFiles(List<String> inputFiles)
-    {
-        this.inputFiles = inputFiles;
-    }
-
-    public StorageInfo getInputStorage()
-    {
-        return inputStorage;
-    }
-
-    public void setInputStorage(StorageInfo inputStorage)
-    {
-        this.inputStorage = inputStorage;
-    }
-
-    public int getParallelism()
-    {
-        return parallelism;
-    }
-
-    public void setParallelism(int parallelism)
-    {
-        this.parallelism = parallelism;
+        this.aggregationInfo = aggregationInfo;
     }
 
     public OutputInfo getOutput()

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/input/BroadcastChainJoinInput.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/input/BroadcastChainJoinInput.java
@@ -27,11 +27,10 @@ import java.util.List;
  * The input format of the chained broadcast join.
  *
  * @author hank
- * @date 03/06/2022
+ * @create 2022-06-03
  */
 public class BroadcastChainJoinInput extends JoinInput
 {
-    private long queryId;
     /**
      * The information of the chain tables that are broadcast in the chain join.
      */
@@ -68,19 +67,13 @@ public class BroadcastChainJoinInput extends JoinInput
      */
     public BroadcastChainJoinInput() { }
 
-    public BroadcastChainJoinInput(long queryId,
-                                   List<BroadcastTableInfo> chainTables,
-                                   List<ChainJoinInfo> chainJoinInfos,
-                                   BroadcastTableInfo largeTable,
-                                   JoinInfo joinInfo, boolean postChainJoinsPresent,
-                                   List<BroadcastTableInfo> postSmallTables,
-                                   List<ChainJoinInfo> postChainJoinInfos,
-                                   boolean partialAggregationPresent,
-                                   PartialAggregationInfo partialAggregationInfo,
+    public BroadcastChainJoinInput(long queryId, List<BroadcastTableInfo> chainTables, List<ChainJoinInfo> chainJoinInfos,
+                                   BroadcastTableInfo largeTable, JoinInfo joinInfo, boolean postChainJoinsPresent,
+                                   List<BroadcastTableInfo> postSmallTables, List<ChainJoinInfo> postChainJoinInfos,
+                                   boolean partialAggregationPresent, PartialAggregationInfo partialAggregationInfo,
                                    MultiOutputInfo output)
     {
-        super(partialAggregationPresent, partialAggregationInfo, output);
-        this.queryId = queryId;
+        super(queryId, partialAggregationPresent, partialAggregationInfo, output);
         this.chainTables = chainTables;
         this.chainJoinInfos = chainJoinInfos;
         this.largeTable = largeTable;
@@ -89,17 +82,6 @@ public class BroadcastChainJoinInput extends JoinInput
         this.postSmallTables = postSmallTables;
         this.postChainJoinInfos = postChainJoinInfos;
     }
-
-    public long getQueryId()
-    {
-        return queryId;
-    }
-
-    public void setQueryId(long queryId)
-    {
-        this.queryId = queryId;
-    }
-
     public List<BroadcastTableInfo> getChainTables()
     {
         return chainTables;
@@ -182,11 +164,9 @@ public class BroadcastChainJoinInput extends JoinInput
         private Builder(BroadcastChainJoinInput instance)
         {
             this.builderInstance = new BroadcastChainJoinInput(
-                    instance.queryId, instance.chainTables, instance.chainJoinInfos,
-                    instance.largeTable, instance.joinInfo, instance.postChainJoinsPresent,
-                    instance.postSmallTables, instance.postChainJoinInfos,
-                    instance.isPartialAggregationPresent(), instance.getPartialAggregationInfo(),
-                    instance.getOutput());
+                    instance.getQueryId(), instance.chainTables, instance.chainJoinInfos, instance.largeTable,
+                    instance.joinInfo, instance.postChainJoinsPresent, instance.postSmallTables, instance.postChainJoinInfos,
+                    instance.isPartialAggregationPresent(), instance.getPartialAggregationInfo(), instance.getOutput());
         }
 
         public Builder setLargeTable(BroadcastTableInfo largeTable)

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/input/BroadcastJoinInput.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/input/BroadcastJoinInput.java
@@ -26,15 +26,10 @@ import io.pixelsdb.pixels.planner.plan.physical.domain.PartialAggregationInfo;
 
 /**
  * @author hank
- * @date 07/05/2022
+ * @create 2022-05-07
  */
 public class BroadcastJoinInput extends JoinInput
 {
-    /**
-     * The unique id of the query.
-     */
-    private long queryId;
-
     /**
      * The small (i.e., broadcast) table.
      */
@@ -53,27 +48,14 @@ public class BroadcastJoinInput extends JoinInput
      */
     public BroadcastJoinInput() { }
 
-    public BroadcastJoinInput(long queryId, BroadcastTableInfo smallTable,
-                              BroadcastTableInfo largeTable, JoinInfo joinInfo,
-                              boolean partialAggregationPresent,
-                              PartialAggregationInfo partialAggregationInfo,
-                              MultiOutputInfo output)
+    public BroadcastJoinInput(long queryId, BroadcastTableInfo smallTable, BroadcastTableInfo largeTable,
+                              JoinInfo joinInfo, boolean partialAggregationPresent,
+                              PartialAggregationInfo partialAggregationInfo, MultiOutputInfo output)
     {
-        super(partialAggregationPresent, partialAggregationInfo, output);
-        this.queryId = queryId;
+        super(queryId, partialAggregationPresent, partialAggregationInfo, output);
         this.smallTable = smallTable;
         this.largeTable = largeTable;
         this.joinInfo = joinInfo;
-    }
-
-    public long getQueryId()
-    {
-        return queryId;
-    }
-
-    public void setQueryId(long queryId)
-    {
-        this.queryId = queryId;
     }
 
     public BroadcastTableInfo getSmallTable()

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/input/JoinInput.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/input/JoinInput.java
@@ -25,9 +25,9 @@ import io.pixelsdb.pixels.planner.plan.physical.domain.PartialAggregationInfo;
 
 /**
  * @author hank
- * @date 22/05/2022
+ * @create 2022-05-22
  */
-public class JoinInput extends Input
+public abstract class JoinInput extends Input
 {
     /**
      * Whether the partial aggregation exists.
@@ -48,10 +48,15 @@ public class JoinInput extends Input
     /**
      * Default constructor for Jackson.
      */
-    public JoinInput() {}
-
-    public JoinInput(boolean partialAggregationPresent, PartialAggregationInfo partialAggregationInfo, MultiOutputInfo output)
+    public JoinInput()
     {
+        super(-1);
+    }
+
+    public JoinInput(long queryId, boolean partialAggregationPresent,
+                     PartialAggregationInfo partialAggregationInfo, MultiOutputInfo output)
+    {
+        super(queryId);
         this.partialAggregationPresent = partialAggregationPresent;
         this.partialAggregationInfo = partialAggregationInfo;
         this.output = output;

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/input/PartitionInput.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/input/PartitionInput.java
@@ -30,14 +30,10 @@ import io.pixelsdb.pixels.planner.plan.physical.domain.ScanTableInfo;
  * hash partitioning input shares some fields with the scan input.
  *
  * @author hank
- * @date 07/05/2022
+ * @create 2022-05-07
  */
 public class PartitionInput extends Input
 {
-    /**
-     * The unique id of the query.
-     */
-    private long queryId;
     /**
      * The information of the table to scan and partition.
      */
@@ -59,26 +55,19 @@ public class PartitionInput extends Input
     /**
      * Default constructor for Jackson.
      */
-    public PartitionInput() { }
+    public PartitionInput()
+    {
+        super(-1);
+    }
 
     public PartitionInput(long queryId, ScanTableInfo tableInfo, boolean[] projection,
                           OutputInfo output, PartitionInfo partitionInfo)
     {
-        this.queryId = queryId;
+        super(queryId);
         this.tableInfo = tableInfo;
         this.projection = projection;
         this.output = output;
         this.partitionInfo = partitionInfo;
-    }
-
-    public long getQueryId()
-    {
-        return queryId;
-    }
-
-    public void setQueryId(long queryId)
-    {
-        this.queryId = queryId;
     }
 
     public ScanTableInfo getTableInfo()

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/input/PartitionedChainJoinInput.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/input/PartitionedChainJoinInput.java
@@ -26,14 +26,10 @@ import java.util.List;
 /**
  * The input format of the chained partitioned join.
  * @author hank
- * @date 25/06/2022
+ * @create 2022-06-25
  */
 public class PartitionedChainJoinInput extends JoinInput
 {
-    /**
-     * The unique id of the query.
-     */
-    private long queryId;
     /**
      * The information of the chain tables that are broadcast in the chain join.
      */
@@ -72,33 +68,17 @@ public class PartitionedChainJoinInput extends JoinInput
      */
     public PartitionedChainJoinInput() { }
 
-    public PartitionedChainJoinInput(long queryId,
-                                     List<BroadcastTableInfo> chainTables,
-                                     List<ChainJoinInfo> chainJoinInfos,
-                                     PartitionedTableInfo smallTable,
-                                     PartitionedTableInfo largeTable,
-                                     PartitionedJoinInfo joinInfo,
-                                     boolean partialAggregationPresent,
-                                     PartialAggregationInfo partialAggregationInfo,
-                                     MultiOutputInfo output)
+    public PartitionedChainJoinInput(long queryId, List<BroadcastTableInfo> chainTables, List<ChainJoinInfo> chainJoinInfos,
+                                     PartitionedTableInfo smallTable, PartitionedTableInfo largeTable,
+                                     PartitionedJoinInfo joinInfo, boolean partialAggregationPresent,
+                                     PartialAggregationInfo partialAggregationInfo, MultiOutputInfo output)
     {
-        super(partialAggregationPresent, partialAggregationInfo, output);
-        this.queryId = queryId;
+        super(queryId, partialAggregationPresent, partialAggregationInfo, output);
         this.chainTables = chainTables;
         this.chainJoinInfos = chainJoinInfos;
         this.smallTable = smallTable;
         this.largeTable = largeTable;
         this.joinInfo = joinInfo;
-    }
-
-    public long getQueryId()
-    {
-        return queryId;
-    }
-
-    public void setQueryId(long queryId)
-    {
-        this.queryId = queryId;
     }
 
     public List<BroadcastTableInfo> getChainTables()
@@ -163,10 +143,9 @@ public class PartitionedChainJoinInput extends JoinInput
         private Builder(PartitionedChainJoinInput instance)
         {
             this.builderInstance = new PartitionedChainJoinInput(
-                    instance.queryId, instance.chainTables, instance.chainJoinInfos,
-                    instance.smallTable, instance.largeTable, instance.joinInfo,
-                    instance.isPartialAggregationPresent(), instance.getPartialAggregationInfo(),
-                    instance.getOutput());
+                    instance.getQueryId(), instance.chainTables, instance.chainJoinInfos, instance.smallTable,
+                    instance.largeTable, instance.joinInfo, instance.isPartialAggregationPresent(),
+                    instance.getPartialAggregationInfo(), instance.getOutput());
         }
 
         public Builder setLargeTable(PartitionedTableInfo largeTable)

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/input/PartitionedJoinInput.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/input/PartitionedJoinInput.java
@@ -26,14 +26,10 @@ import io.pixelsdb.pixels.planner.plan.physical.domain.PartitionedTableInfo;
 
 /**
  * @author hank
- * @date 07/05/2022
+ * @create 2022-05-07
  */
 public class PartitionedJoinInput extends JoinInput
 {
-    /**
-     * The unique id of the query.
-     */
-    private long queryId;
     /**
      * The information of the small partitioned table.
      */
@@ -52,27 +48,14 @@ public class PartitionedJoinInput extends JoinInput
      */
     public PartitionedJoinInput() { }
 
-    public PartitionedJoinInput(long queryId, PartitionedTableInfo smallTable,
-                                PartitionedTableInfo largeTable, PartitionedJoinInfo joinInfo,
-                                boolean partialAggregationPresent,
-                                PartialAggregationInfo partialAggregationInfo,
-                                MultiOutputInfo output)
+    public PartitionedJoinInput(long queryId, PartitionedTableInfo smallTable, PartitionedTableInfo largeTable,
+                                PartitionedJoinInfo joinInfo, boolean partialAggregationPresent,
+                                PartialAggregationInfo partialAggregationInfo, MultiOutputInfo output)
     {
-        super(partialAggregationPresent, partialAggregationInfo, output);
-        this.queryId = queryId;
+        super(queryId, partialAggregationPresent, partialAggregationInfo, output);
         this.smallTable = smallTable;
         this.largeTable = largeTable;
         this.joinInfo = joinInfo;
-    }
-
-    public long getQueryId()
-    {
-        return queryId;
-    }
-
-    public void setQueryId(long queryId)
-    {
-        this.queryId = queryId;
     }
 
     public PartitionedTableInfo getSmallTable()

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/input/ScanInput.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/input/ScanInput.java
@@ -27,14 +27,10 @@ import io.pixelsdb.pixels.planner.plan.physical.domain.ScanTableInfo;
 /**
  * The input format for table scan.
  * @author hank
- * Created at: 11/04/2022
+ * @create 2022-04-11
  */
 public class ScanInput extends Input
 {
-    /**
-     * The unique id of the query.
-     */
-    private long queryId;
     /**
      * The information of the table to scan.
      */
@@ -60,27 +56,20 @@ public class ScanInput extends Input
     /**
      * Default constructor for Jackson.
      */
-    public ScanInput() { }
+    public ScanInput()
+    {
+        super(-1);
+    }
 
     public ScanInput(long queryId, ScanTableInfo tableInfo, boolean[] scanProjection,
                      boolean partialAggregationPresent, PartialAggregationInfo partialAggregationInfo, OutputInfo output)
     {
-        this.queryId = queryId;
+        super(queryId);
         this.tableInfo = tableInfo;
         this.scanProjection = scanProjection;
         this.partialAggregationPresent = partialAggregationPresent;
         this.partialAggregationInfo = partialAggregationInfo;
         this.output = output;
-    }
-
-    public long getQueryId()
-    {
-        return queryId;
-    }
-
-    public void setQueryId(long queryId)
-    {
-        this.queryId = queryId;
     }
 
     public ScanTableInfo getTableInfo()

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/output/JoinOutput.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/output/JoinOutput.java
@@ -23,7 +23,7 @@ package io.pixelsdb.pixels.planner.plan.physical.output;
  * The output format for both broadcast and hash partitioned join.
  *
  * @author hank
- * @date 07/05/2022
+ * @create 2022-05-07
  */
 public class JoinOutput extends NonPartitionOutput
 {

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/output/NonPartitionOutput.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/output/NonPartitionOutput.java
@@ -26,9 +26,9 @@ import java.util.ArrayList;
 /**
  * The output format for serverless operators.
  * @author hank
- * Created at: 11/04/2022
+ * @create 2022-04-11
  */
-public class NonPartitionOutput extends Output
+public abstract class NonPartitionOutput extends Output
 {
     /**
      * The path of the result files. No need to contain endpoint information.

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/output/PartitionOutput.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/output/PartitionOutput.java
@@ -26,7 +26,7 @@ import java.util.Set;
 /**
  * The output format of the hash partitioning.
  * @author hank
- * @date 07/05/2022
+ * @create 2022-05-07
  */
 public class PartitionOutput extends Output
 {

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/output/ScanOutput.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/output/ScanOutput.java
@@ -22,7 +22,7 @@ package io.pixelsdb.pixels.planner.plan.physical.output;
 /**
  * The output format for table scan.
  * @author hank
- * Created at: 11/04/2022
+ * @create 2022-04-11
  */
 public class ScanOutput extends NonPartitionOutput
 {

--- a/pixels-planner/src/test/java/io/pixelsdb/pixels/planner/TestOutput.java
+++ b/pixels-planner/src/test/java/io/pixelsdb/pixels/planner/TestOutput.java
@@ -25,7 +25,7 @@ import org.junit.Test;
 
 /**
  * @author hank
- * Created at: 11/04/2022
+ * @create 2022-04-11
  */
 public class TestOutput
 {

--- a/pixels-planner/src/test/java/io/pixelsdb/pixels/planner/TestPixelsPlanner.java
+++ b/pixels-planner/src/test/java/io/pixelsdb/pixels/planner/TestPixelsPlanner.java
@@ -35,7 +35,7 @@ import java.util.Optional;
 
 /**
  * @author hank
- * @date 06/06/2022
+ * @create 2022-06-06
  */
 public class TestPixelsPlanner
 {

--- a/pixels-turbo/pixels-invoker-lambda/src/test/java/io/pixelsdb/pixels/invoker/lambda/TestAggregationLambdaInvoker.java
+++ b/pixels-turbo/pixels-invoker-lambda/src/test/java/io/pixelsdb/pixels/invoker/lambda/TestAggregationLambdaInvoker.java
@@ -25,6 +25,8 @@ import io.pixelsdb.pixels.common.physical.Storage;
 import io.pixelsdb.pixels.common.turbo.InvokerFactory;
 import io.pixelsdb.pixels.common.turbo.WorkerType;
 import io.pixelsdb.pixels.executor.aggregation.FunctionType;
+import io.pixelsdb.pixels.planner.plan.physical.domain.AggregatedTableInfo;
+import io.pixelsdb.pixels.planner.plan.physical.domain.AggregationInfo;
 import io.pixelsdb.pixels.planner.plan.physical.domain.OutputInfo;
 import io.pixelsdb.pixels.planner.plan.physical.domain.StorageInfo;
 import io.pixelsdb.pixels.planner.plan.physical.input.AggregationInput;
@@ -45,9 +47,10 @@ public class TestAggregationLambdaInvoker
     {
         AggregationInput aggregationInput = new AggregationInput();
         aggregationInput.setQueryId(123456);
-        aggregationInput.setParallelism(8);
-        aggregationInput.setInputStorage(new StorageInfo(Storage.Scheme.s3, null, null, null));
-        aggregationInput.setInputFiles(Arrays.asList(
+        AggregatedTableInfo aggregatedTableInfo = new AggregatedTableInfo();
+        aggregatedTableInfo.setParallelism(8);
+        aggregatedTableInfo.setStorageInfo(new StorageInfo(Storage.Scheme.s3, null, null, null));
+        aggregatedTableInfo.setInputFiles(Arrays.asList(
                 "pixels-lambda-test/unit_tests/orders_partial_aggr_0",
                 "pixels-lambda-test/unit_tests/orders_partial_aggr_1",
                 "pixels-lambda-test/unit_tests/orders_partial_aggr_2",
@@ -56,14 +59,19 @@ public class TestAggregationLambdaInvoker
                 "pixels-lambda-test/unit_tests/orders_partial_aggr_5",
                 "pixels-lambda-test/unit_tests/orders_partial_aggr_6",
                 "pixels-lambda-test/unit_tests/orders_partial_aggr_7"));
-        aggregationInput.setColumnsToRead(new String[] {"sum_o_orderkey_0", "o_orderstatus_2", "o_orderdate_3"});
-        aggregationInput.setGroupKeyColumnIds(new int[] {1, 2});
-        aggregationInput.setAggregateColumnIds(new int[] {0});
-        aggregationInput.setGroupKeyColumnNames(new String[] {"o_orderstatus", "o_orderdate"});
-        aggregationInput.setGroupKeyColumnProjection(new boolean[] {true, true});
-        aggregationInput.setResultColumnNames(new String[] {"sum_o_orderkey"});
-        aggregationInput.setResultColumnTypes(new String[] {"bigint"});
-        aggregationInput.setFunctionTypes(new FunctionType[] {FunctionType.SUM});
+        aggregatedTableInfo.setColumnsToRead(new String[] {"sum_o_orderkey_0", "o_orderstatus_2", "o_orderdate_3"});
+        aggregatedTableInfo.setBase(false);
+        aggregatedTableInfo.setTableName("aggregate_orders");
+        aggregationInput.setAggregatedTableInfo(aggregatedTableInfo);
+        AggregationInfo aggregationInfo = new AggregationInfo();
+        aggregationInfo.setGroupKeyColumnIds(new int[] {1, 2});
+        aggregationInfo.setAggregateColumnIds(new int[] {0});
+        aggregationInfo.setGroupKeyColumnNames(new String[] {"o_orderstatus", "o_orderdate"});
+        aggregationInfo.setGroupKeyColumnProjection(new boolean[] {true, true});
+        aggregationInfo.setResultColumnNames(new String[] {"sum_o_orderkey"});
+        aggregationInfo.setResultColumnTypes(new String[] {"bigint"});
+        aggregationInfo.setFunctionTypes(new FunctionType[] {FunctionType.SUM});
+        aggregationInput.setAggregationInfo(aggregationInfo);
         aggregationInput.setOutput(new OutputInfo("pixels-lambda-test/unit_tests/orders_final_aggr", false,
                 new StorageInfo(Storage.Scheme.s3, null, null, null), true));
 

--- a/pixels-turbo/pixels-invoker-lambda/src/test/java/io/pixelsdb/pixels/invoker/lambda/TestBroadcastChainJoinLambdaInvoker.java
+++ b/pixels-turbo/pixels-invoker-lambda/src/test/java/io/pixelsdb/pixels/invoker/lambda/TestBroadcastChainJoinLambdaInvoker.java
@@ -20,6 +20,7 @@
 package io.pixelsdb.pixels.invoker.lambda;
 
 import com.alibaba.fastjson.JSON;
+import com.google.common.base.Joiner;
 import io.pixelsdb.pixels.common.physical.Storage;
 import io.pixelsdb.pixels.common.turbo.InvokerFactory;
 import io.pixelsdb.pixels.common.turbo.WorkerType;
@@ -62,6 +63,7 @@ public class TestBroadcastChainJoinLambdaInvoker
         region.setInputSplits(Arrays.asList(
                 new InputSplit(Arrays.asList(new InputInfo("pixels-tpch/region/v-0-order/20230416153117_0.pxl", 0, 4)))));
         region.setFilter(regionFilter);
+        region.setStorageInfo(new StorageInfo(Storage.Scheme.s3, null, null, null));
         leftTables.add(region);
 
         BroadcastTableInfo nation = new BroadcastTableInfo();
@@ -72,6 +74,7 @@ public class TestBroadcastChainJoinLambdaInvoker
         nation.setInputSplits(Arrays.asList(
                 new InputSplit(Arrays.asList(new InputInfo("pixels-tpch/nation/v-0-order/20230416135645_0.pxl", 0, 4)))));
         nation.setFilter(nationFilter);
+        nation.setStorageInfo(new StorageInfo(Storage.Scheme.s3, null, null, null));
         leftTables.add(nation);
 
         ChainJoinInfo chainJoinInfo0 = new ChainJoinInfo();
@@ -92,6 +95,7 @@ public class TestBroadcastChainJoinLambdaInvoker
         supplier.setInputSplits(Arrays.asList(
                 new InputSplit(Arrays.asList(new InputInfo("pixels-tpch/supplier/v-0-compact/20230416155327_0_compact.pxl", 0, 4)))));
         supplier.setFilter(supplierFilter);
+        supplier.setStorageInfo(new StorageInfo(Storage.Scheme.s3, null, null, null));
         leftTables.add(supplier);
 
         ChainJoinInfo chainJoinInfo1 = new ChainJoinInfo();
@@ -122,6 +126,7 @@ public class TestBroadcastChainJoinLambdaInvoker
                 new InputSplit(Arrays.asList(new InputInfo("pixels-tpch/lineitem/v-0-compact/20230416153320_0_compact.pxl", 24, 4))),
                 new InputSplit(Arrays.asList(new InputInfo("pixels-tpch/lineitem/v-0-compact/20230416153320_0_compact.pxl", 28, 4)))));
         lineitem.setFilter(lineitemFilter);
+        lineitem.setStorageInfo(new StorageInfo(Storage.Scheme.s3, null, null, null));
         joinInput.setLargeTable(lineitem);
 
         JoinInfo joinInfo = new JoinInfo();
@@ -142,11 +147,7 @@ public class TestBroadcastChainJoinLambdaInvoker
         JoinOutput output = (JoinOutput) InvokerFactory.Instance()
                 .getInvoker(WorkerType.BROADCAST_CHAIN_JOIN).invoke(joinInput).get();
         System.out.println(output.getOutputs().size());
-        for (int i = 0; i < output.getOutputs().size(); ++i)
-        {
-            System.out.println(output.getOutputs().get(i));
-            System.out.println(output.getRowGroupNums().get(i));
-            System.out.println();
-        }
+        System.out.println(Joiner.on(",").join(output.getOutputs()));
+        System.out.println(Joiner.on(",").join(output.getRowGroupNums()));
     }
 }

--- a/pixels-turbo/pixels-invoker-lambda/src/test/java/io/pixelsdb/pixels/invoker/lambda/TestBroadcastJoinLambdaInvoker.java
+++ b/pixels-turbo/pixels-invoker-lambda/src/test/java/io/pixelsdb/pixels/invoker/lambda/TestBroadcastJoinLambdaInvoker.java
@@ -20,6 +20,7 @@
 package io.pixelsdb.pixels.invoker.lambda;
 
 import com.alibaba.fastjson.JSON;
+import com.google.common.base.Joiner;
 import io.pixelsdb.pixels.common.physical.Storage;
 import io.pixelsdb.pixels.common.turbo.InvokerFactory;
 import io.pixelsdb.pixels.common.turbo.WorkerType;
@@ -74,6 +75,7 @@ public class TestBroadcastJoinLambdaInvoker
                 new InputSplit(Arrays.asList(new InputInfo("pixels-tpch/part/v-0-compact/20230416155202_0_compact.pxl", 24, 4))),
                 new InputSplit(Arrays.asList(new InputInfo("pixels-tpch/part/v-0-compact/20230416155202_0_compact.pxl", 28, 4)))));
         leftTable.setFilter(leftFilter);
+        leftTable.setStorageInfo(new StorageInfo(Storage.Scheme.s3, null, null, null));
         joinInput.setSmallTable(leftTable);
 
         BroadcastTableInfo rightTable = new BroadcastTableInfo();
@@ -91,6 +93,7 @@ public class TestBroadcastJoinLambdaInvoker
                 new InputSplit(Arrays.asList(new InputInfo("pixels-tpch/lineitem/v-0-compact/20230416153320_0_compact.pxl", 24, 4))),
                 new InputSplit(Arrays.asList(new InputInfo("pixels-tpch/lineitem/v-0-compact/20230416153320_0_compact.pxl", 28, 4)))));
         rightTable.setFilter(rightFilter);
+        rightTable.setStorageInfo(new StorageInfo(Storage.Scheme.s3, null, null, null));
         joinInput.setLargeTable(rightTable);
 
         JoinInfo joinInfo = new JoinInfo();
@@ -110,12 +113,8 @@ public class TestBroadcastJoinLambdaInvoker
         JoinOutput output = (JoinOutput) InvokerFactory.Instance()
                 .getInvoker(WorkerType.BROADCAST_JOIN).invoke(joinInput).get();
         System.out.println(output.getOutputs().size());
-        for (int i = 0; i < output.getOutputs().size(); ++i)
-        {
-            System.out.println(output.getOutputs().get(i));
-            System.out.println(output.getRowGroupNums().get(i));
-            System.out.println();
-        }
+        System.out.println(Joiner.on(",").join(output.getOutputs()));
+        System.out.println(Joiner.on(",").join(output.getRowGroupNums()));
     }
 
     @Test

--- a/pixels-turbo/pixels-invoker-lambda/src/test/java/io/pixelsdb/pixels/invoker/lambda/TestPartialAggregationLambdaInvoker.java
+++ b/pixels-turbo/pixels-invoker-lambda/src/test/java/io/pixelsdb/pixels/invoker/lambda/TestPartialAggregationLambdaInvoker.java
@@ -52,6 +52,7 @@ public class TestPartialAggregationLambdaInvoker
             tableInfo.setTableName("orders");
             tableInfo.setColumnsToRead(new String[]{"o_orderkey", "o_custkey", "o_orderstatus", "o_orderdate"});
             tableInfo.setFilter(filter);
+            tableInfo.setBase(true);
             tableInfo.setInputSplits(Arrays.asList(
                     new InputSplit(Arrays.asList(new InputInfo("pixels-tpch/orders/v-0-compact/20230416154127_" + i + "_compact.pxl", 0, 4))),
                     new InputSplit(Arrays.asList(new InputInfo("pixels-tpch/orders/v-0-compact/20230416154127_" + i + "_compact.pxl", 4, 4))),
@@ -61,6 +62,7 @@ public class TestPartialAggregationLambdaInvoker
                     new InputSplit(Arrays.asList(new InputInfo("pixels-tpch/orders/v-0-compact/20230416154127_" + i + "_compact.pxl", 20, 4))),
                     new InputSplit(Arrays.asList(new InputInfo("pixels-tpch/orders/v-0-compact/20230416154127_" + i + "_compact.pxl", 24, 4))),
                     new InputSplit(Arrays.asList(new InputInfo("pixels-tpch/orders/v-0-compact/20230416154127_" + i + "_compact.pxl", 28, 4)))));
+            tableInfo.setStorageInfo(new StorageInfo(Storage.Scheme.s3, null, null, null));
             scanInput.setTableInfo(tableInfo);
             scanInput.setScanProjection(new boolean[]{true, true, true, true});
             scanInput.setPartialAggregationPresent(true);

--- a/pixels-turbo/pixels-invoker-lambda/src/test/java/io/pixelsdb/pixels/invoker/lambda/TestPartitionLambdaInvoker.java
+++ b/pixels-turbo/pixels-invoker-lambda/src/test/java/io/pixelsdb/pixels/invoker/lambda/TestPartitionLambdaInvoker.java
@@ -68,6 +68,8 @@ public class TestPartitionLambdaInvoker
                     new InputSplit(Arrays.asList(new InputInfo("pixels-tpch/orders/v-0-compact/20230416154127_" + i + "_compact.pxl", 28, 4)))));
             tableInfo.setColumnsToRead(new String[]{"o_orderkey", "o_custkey", "o_orderstatus", "o_orderdate"});
             tableInfo.setFilter(filter);
+            tableInfo.setBase(true);
+            tableInfo.setStorageInfo(new StorageInfo(Storage.Scheme.s3, null, null, null));
             input.setTableInfo(tableInfo);
             input.setProjection(new boolean[]{true, true, true, true});
             PartitionInfo partitionInfo = new PartitionInfo();
@@ -107,7 +109,9 @@ public class TestPartitionLambdaInvoker
                     new InputSplit(Arrays.asList(new InputInfo("pixels-tpch/lineitem/v-0-compact/20230416153320_" + i + "_compact.pxl", 24, 4))),
                     new InputSplit(Arrays.asList(new InputInfo("pixels-tpch/lineitem/v-0-compact/20230416153320_" + i + "_compact.pxl", 28, 4)))));
             tableInfo.setFilter(filter);
+            tableInfo.setBase(true);
             tableInfo.setColumnsToRead(new String[]{"l_orderkey", "l_suppkey", "l_extendedprice", "l_discount"});
+            tableInfo.setStorageInfo(new StorageInfo(Storage.Scheme.s3, null, null, null));
             input.setTableInfo(tableInfo);
             input.setProjection(new boolean[]{true, true, true, true});
             PartitionInfo partitionInfo = new PartitionInfo();

--- a/pixels-turbo/pixels-invoker-lambda/src/test/java/io/pixelsdb/pixels/invoker/lambda/TestPartitionedChainJoinLambdaInvoker.java
+++ b/pixels-turbo/pixels-invoker-lambda/src/test/java/io/pixelsdb/pixels/invoker/lambda/TestPartitionedChainJoinLambdaInvoker.java
@@ -20,6 +20,7 @@
 package io.pixelsdb.pixels.invoker.lambda;
 
 import com.alibaba.fastjson.JSON;
+import com.google.common.base.Joiner;
 import io.pixelsdb.pixels.common.physical.Storage;
 import io.pixelsdb.pixels.common.turbo.InvokerFactory;
 import io.pixelsdb.pixels.common.turbo.WorkerType;
@@ -59,6 +60,7 @@ public class TestPartitionedChainJoinLambdaInvoker
         region.setInputSplits(Arrays.asList(
                 new InputSplit(Arrays.asList(new InputInfo("pixels-tpch/region/v-0-order/20230416153117_0.pxl", 0, 4)))));
         region.setFilter(regionFilter);
+        region.setStorageInfo(new StorageInfo(Storage.Scheme.s3, null, null, null));
         chainTables.add(region);
 
         BroadcastTableInfo nation = new BroadcastTableInfo();
@@ -69,6 +71,7 @@ public class TestPartitionedChainJoinLambdaInvoker
         nation.setInputSplits(Arrays.asList(
                 new InputSplit(Arrays.asList(new InputInfo("pixels-tpch/nation/v-0-order/20230416135645_0.pxl", 0, 4)))));
         nation.setFilter(nationFilter);
+        nation.setStorageInfo(new StorageInfo(Storage.Scheme.s3, null, null, null));
         chainTables.add(nation);
 
         ChainJoinInfo chainJoinInfo0 = new ChainJoinInfo();
@@ -89,6 +92,7 @@ public class TestPartitionedChainJoinLambdaInvoker
         supplier.setInputSplits(Arrays.asList(
                 new InputSplit(Arrays.asList(new InputInfo("pixels-tpch/supplier/v-0-compact/20230416155327_0_compact.pxl", 0, 4)))));
         supplier.setFilter(supplierFilter);
+        supplier.setStorageInfo(new StorageInfo(Storage.Scheme.s3, null, null, null));
         chainTables.add(supplier);
 
         ChainJoinInfo chainJoinInfo1 = new ChainJoinInfo();
@@ -122,6 +126,8 @@ public class TestPartitionedChainJoinLambdaInvoker
                 "pixels-lambda-test/unit_tests/orders_part_6",
                 "pixels-lambda-test/unit_tests/orders_part_7"));
         leftTableInfo.setParallelism(8);
+        leftTableInfo.setBase(false);
+        leftTableInfo.setStorageInfo(new StorageInfo(Storage.Scheme.s3, null, null, null));
         joinInput.setSmallTable(leftTableInfo);
 
         PartitionedTableInfo rightTableInfo = new PartitionedTableInfo();
@@ -133,6 +139,8 @@ public class TestPartitionedChainJoinLambdaInvoker
                 "pixels-lambda-test/unit_tests/lineitem_part_0",
                 "pixels-lambda-test/unit_tests/lineitem_part_1"));
         rightTableInfo.setParallelism(2);
+        rightTableInfo.setBase(false);
+        rightTableInfo.setStorageInfo(new StorageInfo(Storage.Scheme.s3, null, null, null));
         joinInput.setLargeTable(rightTableInfo);
 
         PartitionedJoinInfo joinInfo = new PartitionedJoinInfo();
@@ -169,11 +177,7 @@ public class TestPartitionedChainJoinLambdaInvoker
         JoinOutput output = (JoinOutput) InvokerFactory.Instance()
                 .getInvoker(WorkerType.PARTITIONED_CHAIN_JOIN).invoke(joinInput).get();
         System.out.println(output.getOutputs().size());
-        for (int i = 0; i < output.getOutputs().size(); ++i)
-        {
-            System.out.println(output.getOutputs().get(i));
-            System.out.println(output.getRowGroupNums().get(i));
-            System.out.println();
-        }
+        System.out.println(Joiner.on(",").join(output.getOutputs()));
+        System.out.println(Joiner.on(",").join(output.getRowGroupNums()));
     }
 }

--- a/pixels-turbo/pixels-invoker-lambda/src/test/java/io/pixelsdb/pixels/invoker/lambda/TestPartitionedJoinLambdaInvoker.java
+++ b/pixels-turbo/pixels-invoker-lambda/src/test/java/io/pixelsdb/pixels/invoker/lambda/TestPartitionedJoinLambdaInvoker.java
@@ -66,6 +66,8 @@ public class TestPartitionedJoinLambdaInvoker
                 "pixels-lambda-test/unit_tests/orders_part_6",
                 "pixels-lambda-test/unit_tests/orders_part_7"));
         leftTableInfo.setParallelism(8);
+        leftTableInfo.setBase(false);
+        leftTableInfo.setStorageInfo(new StorageInfo(Storage.Scheme.s3, null, null, null));
         joinInput.setSmallTable(leftTableInfo);
 
         PartitionedTableInfo rightTableInfo = new PartitionedTableInfo();
@@ -76,6 +78,8 @@ public class TestPartitionedJoinLambdaInvoker
                 "pixels-lambda-test/unit_tests/lineitem_part_0",
                 "pixels-lambda-test/unit_tests/lineitem_part_1"));
         rightTableInfo.setParallelism(2);
+        rightTableInfo.setBase(false);
+        rightTableInfo.setStorageInfo(new StorageInfo(Storage.Scheme.s3, null, null, null));
         joinInput.setLargeTable(rightTableInfo);
 
         PartitionedJoinInfo joinInfo = new PartitionedJoinInfo();

--- a/pixels-turbo/pixels-scaling-ec2/src/main/scripts/launch-script.sh
+++ b/pixels-turbo/pixels-scaling-ec2/src/main/scripts/launch-script.sh
@@ -25,13 +25,13 @@ sed -i "s/instance-id-dummy/$instance_id/g" /home/ubuntu/opt/trino-server/etc/no
 
 # ~/opt/trino-server-375/etc/catalog/pixels.properties replace output-endpoint-dummy with the local minio endpoint
 private_ip=$(get_private_ip)
-sed -i "s+output-endpoint-dummy+http://$private_ip:9000/+" /home/ubuntu/opt/trino-server/etc/catalog/pixels.properties
+sed -i "s+output-endpoint-dummy+http://$private_ip:9000/+" /home/ubuntu/opt/pixels/pixels.properties
 
 # ~/opt/trino-server-375/etc/catalog/pixels.properties replace output-folder-dummy with the local minio folder
-sed -i "s+output-folder-dummy+pixels-lambda/output+" /home/ubuntu/opt/trino-server/etc/catalog/pixels.properties
+sed -i "s+output-folder-dummy+pixels-lambda/output+" /home/ubuntu/opt/pixels/pixels.properties
 
 # ~/opt/trino-server-375/etc/catalog/pixels.properties set output.scheme to minio
-sed -i "s/output-scheme-dummy/minio/g" /home/ubuntu/opt/trino-server/etc/catalog/pixels.properties
+sed -i "s/output-scheme-dummy/minio/g" /home/ubuntu/opt/pixels/pixels.properties
 
 echo "start trino"
 su ubuntu -c "/home/ubuntu/opt/trino-server/bin/launcher start"


### PR DESCRIPTION
We add the storage info, which contains the information of the storage scheme and endpoint, into the table info of each operator,
allowing each table (base or intermediate) to be stored and read from different storage systems.

Also, fix several minor problems related to file schema parsing in the serverless workers.