### PR TITLE
[Issue #468] add operator name to the input of the cloud function workers.

### DIFF
--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/turbo/Input.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/turbo/Input.java
@@ -19,6 +19,8 @@
  */
 package io.pixelsdb.pixels.common.turbo;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * The base class for the input of a cloud function.
  * @author hank
@@ -31,9 +33,13 @@ public abstract class Input
      */
     private long transId;
 
+    private String operatorName;
+
     public Input(long transId)
     {
         this.transId = transId;
+        // Issue #468: operatorName is optional, it is to be set by the setter.
+        this.operatorName = null;
     }
 
     public long getTransId()
@@ -44,5 +50,19 @@ public abstract class Input
     public void setTransId(long transId)
     {
         this.transId = transId;
+    }
+
+    /**
+     * Operator name is optional, it might be null if not set.
+     * @return the operator name.
+     */
+    public String getOperatorName()
+    {
+        return operatorName;
+    }
+
+    public void setOperatorName(String operatorName)
+    {
+        this.operatorName = requireNonNull(operatorName, "operatorName is null");
     }
 }

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/turbo/WorkerType.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/turbo/WorkerType.java
@@ -25,21 +25,14 @@ package io.pixelsdb.pixels.common.turbo;
  */
 public enum WorkerType
 {
-    UNKNOWN("UNKNOWN"), // The first enum value is the default value.
-    SCAN("SCAN"),
-    PARTITION("PARTITION"),
-    BROADCAST_JOIN("BROADCAST_JOIN"),
-    BROADCAST_CHAIN_JOIN("BROADCAST_CHAIN_JOIN"),
-    PARTITIONED_JOIN("PARTITIONED_JOIN"),
-    PARTITIONED_CHAIN_JOIN("PARTITIONED_CHAIN_JOIN"),
-    AGGREGATION("AGGREGATION");
-
-    private final String value;
-
-    WorkerType(String value)
-    {
-        this.value = value;
-    }
+    UNKNOWN, // The first enum value is the default value.
+    SCAN,
+    PARTITION,
+    BROADCAST_JOIN,
+    BROADCAST_CHAIN_JOIN,
+    PARTITIONED_JOIN,
+    PARTITIONED_CHAIN_JOIN,
+    AGGREGATION;
 
     public static WorkerType from(String value)
     {
@@ -55,11 +48,5 @@ public enum WorkerType
     {
         // enums in Java can be compared using '=='.
         return this == other;
-    }
-
-    @Override
-    public String toString()
-    {
-        return value;
     }
 }

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/utils/StringUtil.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/utils/StringUtil.java
@@ -29,6 +29,11 @@ public class StringUtil
     {
     }
 
+    public static String notNullOrElse(String nullable, String elseValue)
+    {
+        return nullable != null ? nullable : elseValue;
+    }
+
     public static String replaceAll(String text, String searchString, String replacement)
     {
         if (text.isEmpty() || searchString.isEmpty() || replacement.isEmpty())

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/AggregationOperator.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/AggregationOperator.java
@@ -122,6 +122,7 @@ public class AggregationOperator extends Operator
                 int i = 0;
                 for (AggregationInput preAggrInput : this.finalAggrInputs)
                 {
+                    preAggrInput.setOperatorName(this.getName());
                     this.finalAggrOutputs[i++] = InvokerFactory.Instance()
                             .getInvoker(WorkerType.AGGREGATION).invoke(preAggrInput);
                 }
@@ -156,6 +157,7 @@ public class AggregationOperator extends Operator
                     int i = 0;
                     for (ScanInput scanInput : this.scanInputs)
                     {
+                        scanInput.setOperatorName(this.getName());
                         this.scanOutputs[i++] = InvokerFactory.Instance()
                                 .getInvoker(WorkerType.SCAN).invoke(scanInput);
                     }

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/PartitionedJoinOperator.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/PartitionedJoinOperator.java
@@ -138,15 +138,17 @@ public class PartitionedJoinOperator extends SingleStageJoinOperator
             joinOutputs = new CompletableFuture[joinInputs.size()];
             for (int i = 0; i < joinInputs.size(); ++i)
             {
+                JoinInput joinInput = joinInputs.get(i);
+                joinInput.setOperatorName(this.getName());
                 if (joinAlgo == JoinAlgorithm.PARTITIONED)
                 {
                     joinOutputs[i] = InvokerFactory.Instance()
-                            .getInvoker(WorkerType.PARTITIONED_JOIN).invoke(joinInputs.get(i));
+                            .getInvoker(WorkerType.PARTITIONED_JOIN).invoke(joinInput);
                 }
                 else if (joinAlgo == JoinAlgorithm.PARTITIONED_CHAIN)
                 {
                     joinOutputs[i] = InvokerFactory.Instance()
-                            .getInvoker(WorkerType.PARTITIONED_JOIN).invoke(joinInputs.get(i));
+                            .getInvoker(WorkerType.PARTITIONED_JOIN).invoke(joinInput);
                 }
                 else
                 {
@@ -189,6 +191,7 @@ public class PartitionedJoinOperator extends SingleStageJoinOperator
                     int i = 0;
                     for (PartitionInput partitionInput : largePartitionInputs)
                     {
+                        partitionInput.setOperatorName(this.getName());
                         largePartitionOutputs[i++] = InvokerFactory.Instance()
                                 .getInvoker(WorkerType.PARTITION).invoke((partitionInput));
                     }
@@ -207,6 +210,7 @@ public class PartitionedJoinOperator extends SingleStageJoinOperator
                     int i = 0;
                     for (PartitionInput partitionInput : smallPartitionInputs)
                     {
+                        partitionInput.setOperatorName(this.getName());
                         smallPartitionOutputs[i++] = InvokerFactory.Instance()
                                 .getInvoker(WorkerType.PARTITION).invoke((partitionInput));
                     }
@@ -224,6 +228,7 @@ public class PartitionedJoinOperator extends SingleStageJoinOperator
                     int i = 0;
                     for (PartitionInput partitionInput : smallPartitionInputs)
                     {
+                        partitionInput.setOperatorName(this.getName());
                         smallPartitionOutputs[i++] = InvokerFactory.Instance()
                                 .getInvoker(WorkerType.PARTITION).invoke((partitionInput));
                     }
@@ -234,6 +239,7 @@ public class PartitionedJoinOperator extends SingleStageJoinOperator
                     i = 0;
                     for (PartitionInput partitionInput : largePartitionInputs)
                     {
+                        partitionInput.setOperatorName(this.getName());
                         largePartitionOutputs[i++] = InvokerFactory.Instance()
                                 .getInvoker(WorkerType.PARTITION).invoke((partitionInput));
                     }

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/SingleStageJoinOperator.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/SingleStageJoinOperator.java
@@ -115,15 +115,17 @@ public class SingleStageJoinOperator extends JoinOperator
             joinOutputs = new CompletableFuture[joinInputs.size()];
             for (int i = 0; i < joinInputs.size(); ++i)
             {
+                JoinInput joinInput = joinInputs.get(i);
+                joinInput.setOperatorName(this.getName());
                 if (joinAlgo == JoinAlgorithm.BROADCAST)
                 {
                     joinOutputs[i] = InvokerFactory.Instance()
-                            .getInvoker(WorkerType.BROADCAST_JOIN).invoke(joinInputs.get(i));
+                            .getInvoker(WorkerType.BROADCAST_JOIN).invoke(joinInput);
                 }
                 else if (joinAlgo == JoinAlgorithm.BROADCAST_CHAIN)
                 {
                     joinOutputs[i] = InvokerFactory.Instance()
-                            .getInvoker(WorkerType.BROADCAST_CHAIN_JOIN).invoke(joinInputs.get(i));
+                            .getInvoker(WorkerType.BROADCAST_CHAIN_JOIN).invoke(joinInput);
                 }
                 else
                 {

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/StarlingAggregationOperator.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/StarlingAggregationOperator.java
@@ -123,6 +123,7 @@ public class StarlingAggregationOperator extends Operator
                 int i = 0;
                 for (AggregationInput preAggrInput : this.finalAggrInputs)
                 {
+                    preAggrInput.setOperatorName(this.getName());
                     this.finalAggrOutputs[i++] = InvokerFactory.Instance()
                             .getInvoker(WorkerType.AGGREGATION).invoke(preAggrInput);
                 }
@@ -157,6 +158,7 @@ public class StarlingAggregationOperator extends Operator
                     int i = 0;
                     for (PartitionInput partitionInput : this.partitionInputs)
                     {
+                        partitionInput.setOperatorName(this.getName());
                         this.partitionOutputs[i++] = InvokerFactory.Instance()
                                 .getInvoker(WorkerType.PARTITION).invoke(partitionInput);
                     }

--- a/pixels-turbo/pixels-worker-vhive/src/main/java/io/pixelsdb/pixels/worker/vhive/utils/ServiceImpl.java
+++ b/pixels-turbo/pixels-worker-vhive/src/main/java/io/pixelsdb/pixels/worker/vhive/utils/ServiceImpl.java
@@ -32,6 +32,8 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.UUID;
 
+import static io.pixelsdb.pixels.common.utils.StringUtil.notNullOrElse;
+
 public class ServiceImpl<T extends RequestHandler<I, O>, I extends Input, O extends Output>
 {
     private static final Logger log = LogManager.getLogger(ServiceImpl.class);
@@ -70,16 +72,21 @@ public class ServiceImpl<T extends RequestHandler<I, O>, I extends Input, O exte
                 output = handler.handleRequest(input);
                 Utils.stopProfile(JFRFilename);
 
-                Utils.upload(JFRFilename, String.format("%s/%s", input.getTransId(), JFRFilename));
-                log.info(String.format("upload JFR file to experiments/%s/%s successfully", input.getTransId(), JFRFilename));
+                Utils.upload(JFRFilename, String.format("%s_%s/%s",
+                        input.getTransId(), notNullOrElse(input.getOperatorName(), "default"), JFRFilename));
+                log.info(String.format("upload JFR file to experiments/%s_%s/%s successfully",
+                        input.getTransId(),  notNullOrElse(input.getOperatorName(), "default"), JFRFilename));
             } else
             {
-                log.info(String.format("disable profile to execute input: %s", JSON.toJSONString(input, SerializerFeature.DisableCircularReferenceDetect)));
+                log.info(String.format("disable profile to execute input: %s",
+                        JSON.toJSONString(input, SerializerFeature.DisableCircularReferenceDetect)));
                 output = handler.handleRequest(input);
             }
             Utils.dump(JSONFilename, input, output);
-            Utils.upload(JSONFilename, String.format("%s/%s", input.getTransId(), JSONFilename));
-            log.info(String.format("upload JSON file to experiments/%s/%s successfully", input.getTransId(), JSONFilename));
+            Utils.upload(JSONFilename, String.format("%s_%s/%s",
+                    input.getTransId(),  notNullOrElse(input.getOperatorName(), "none"), JSONFilename));
+            log.info(String.format("upload JSON file to experiments/%s_%s/%s successfully",
+                    input.getTransId(),  notNullOrElse(input.getOperatorName(), "none"), JSONFilename));
 
             log.info(String.format("get output successfully: %s", JSON.toJSONString(output)));
         } catch (Exception e)


### PR DESCRIPTION
The operator name is set in the operators before calling invoke.
For scan-only queries, the scan workers are not invoked by an operator, hence the operator name is not set by default.