### PR TITLE
[Issue #468] improve operator name setting.

### DIFF
--- a/docs/TPC-H.md
+++ b/docs/TPC-H.md
@@ -68,7 +68,13 @@ Connect to trino-cli:
 cd ~/opt/trino-server
 ./bin/trino --server localhost:8080 --catalog pixels --schema tpch
 ```
-Execute the TPC-H queries in trino-cli.
+In trino-cli, select the ordered data layout by setting the two session properties:
+```sql
+set session pixels.ordered_path_enabled=true
+set session pixels.compact_path_enabled=false
+```
+By default, both paths are enabled. You can also enable the compact path and disable the ordered path when [data compaction](#data-compaction) is done.
+After selecting the data layout, execute the TPC-H queries in trino-cli.
 
 ## Data Compaction*
 This is optional. It is only needed if we want to test the query performance on the compact layout.
@@ -76,9 +82,11 @@ In pixels-cli, use the following commands to compact the files in the ordered pa
 ```bash
 COMPACT -s tpch -t customer -n no -c 2
 COMPACT -s tpch -t lineitem -n no -c 16
+COMPACT -s tpch -t nation -n no -c 1
 COMPACT -s tpch -t orders -n no -c 8
 COMPACT -s tpch -t part -n no -c 1
 COMPACT -s tpch -t partsupp -n no -c 8
+COMPACT -s tpch -t region -n no -c 1
 COMPACT -s tpch -t supplier -n no -c 1
 ```
 The tables `nation` and `region` are too small, no need to compact them.

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/AggregationOperator.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/AggregationOperator.java
@@ -70,6 +70,11 @@ public class AggregationOperator extends Operator
         requireNonNull(finalAggrInputs, "finalAggrInputs is null");
         checkArgument(!finalAggrInputs.isEmpty(), "finalAggrInputs is empty");
         this.finalAggrInputs = ImmutableList.copyOf(finalAggrInputs);
+        for (AggregationInput aggrInput : this.finalAggrInputs)
+        {
+            aggrInput.setOperatorName(name);
+        }
+
         if (scanInputs == null || scanInputs.isEmpty())
         {
             this.scanInputs = ImmutableList.of();
@@ -77,6 +82,10 @@ public class AggregationOperator extends Operator
         else
         {
             this.scanInputs = ImmutableList.copyOf(scanInputs);
+            for (ScanInput scanInput : this.scanInputs)
+            {
+                scanInput.setOperatorName(name);
+            }
         }
     }
 
@@ -122,7 +131,6 @@ public class AggregationOperator extends Operator
                 int i = 0;
                 for (AggregationInput preAggrInput : this.finalAggrInputs)
                 {
-                    preAggrInput.setOperatorName(this.getName());
                     this.finalAggrOutputs[i++] = InvokerFactory.Instance()
                             .getInvoker(WorkerType.AGGREGATION).invoke(preAggrInput);
                 }
@@ -157,7 +165,6 @@ public class AggregationOperator extends Operator
                     int i = 0;
                     for (ScanInput scanInput : this.scanInputs)
                     {
-                        scanInput.setOperatorName(this.getName());
                         this.scanOutputs[i++] = InvokerFactory.Instance()
                                 .getInvoker(WorkerType.SCAN).invoke(scanInput);
                     }

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/PartitionedJoinOperator.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/PartitionedJoinOperator.java
@@ -66,6 +66,10 @@ public class PartitionedJoinOperator extends SingleStageJoinOperator
         else
         {
             this.smallPartitionInputs = ImmutableList.copyOf(smallPartitionInputs);
+            for (PartitionInput partitionInput : this.smallPartitionInputs)
+            {
+                partitionInput.setOperatorName(name);
+            }
         }
         if (largePartitionInputs == null || largePartitionInputs.isEmpty())
         {
@@ -74,6 +78,10 @@ public class PartitionedJoinOperator extends SingleStageJoinOperator
         else
         {
             this.largePartitionInputs = ImmutableList.copyOf(largePartitionInputs);
+            for (PartitionInput partitionInput : this.largePartitionInputs)
+            {
+                partitionInput.setOperatorName(name);
+            }
         }
     }
 
@@ -139,7 +147,6 @@ public class PartitionedJoinOperator extends SingleStageJoinOperator
             for (int i = 0; i < joinInputs.size(); ++i)
             {
                 JoinInput joinInput = joinInputs.get(i);
-                joinInput.setOperatorName(this.getName());
                 if (joinAlgo == JoinAlgorithm.PARTITIONED)
                 {
                     joinOutputs[i] = InvokerFactory.Instance()
@@ -191,7 +198,6 @@ public class PartitionedJoinOperator extends SingleStageJoinOperator
                     int i = 0;
                     for (PartitionInput partitionInput : largePartitionInputs)
                     {
-                        partitionInput.setOperatorName(this.getName());
                         largePartitionOutputs[i++] = InvokerFactory.Instance()
                                 .getInvoker(WorkerType.PARTITION).invoke((partitionInput));
                     }
@@ -210,7 +216,6 @@ public class PartitionedJoinOperator extends SingleStageJoinOperator
                     int i = 0;
                     for (PartitionInput partitionInput : smallPartitionInputs)
                     {
-                        partitionInput.setOperatorName(this.getName());
                         smallPartitionOutputs[i++] = InvokerFactory.Instance()
                                 .getInvoker(WorkerType.PARTITION).invoke((partitionInput));
                     }
@@ -228,7 +233,6 @@ public class PartitionedJoinOperator extends SingleStageJoinOperator
                     int i = 0;
                     for (PartitionInput partitionInput : smallPartitionInputs)
                     {
-                        partitionInput.setOperatorName(this.getName());
                         smallPartitionOutputs[i++] = InvokerFactory.Instance()
                                 .getInvoker(WorkerType.PARTITION).invoke((partitionInput));
                     }
@@ -239,7 +243,6 @@ public class PartitionedJoinOperator extends SingleStageJoinOperator
                     i = 0;
                     for (PartitionInput partitionInput : largePartitionInputs)
                     {
-                        partitionInput.setOperatorName(this.getName());
                         largePartitionOutputs[i++] = InvokerFactory.Instance()
                                 .getInvoker(WorkerType.PARTITION).invoke((partitionInput));
                     }

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/SingleStageJoinOperator.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/SingleStageJoinOperator.java
@@ -51,6 +51,8 @@ public class SingleStageJoinOperator extends JoinOperator
     public SingleStageJoinOperator(String name, JoinInput joinInput, JoinAlgorithm joinAlgo)
     {
         super(name);
+        // ImmutableList.of() add the reference of joinInput into the returned list
+        joinInput.setOperatorName(name);
         this.joinInputs = ImmutableList.of(joinInput);
         this.joinAlgo = joinAlgo;
     }
@@ -59,6 +61,10 @@ public class SingleStageJoinOperator extends JoinOperator
     {
         super(name);
         this.joinInputs = ImmutableList.copyOf(joinInputs);
+        for (JoinInput joinInput : this.joinInputs)
+        {
+            joinInput.setOperatorName(name);
+        }
         this.joinAlgo = joinAlgo;
     }
 
@@ -116,7 +122,6 @@ public class SingleStageJoinOperator extends JoinOperator
             for (int i = 0; i < joinInputs.size(); ++i)
             {
                 JoinInput joinInput = joinInputs.get(i);
-                joinInput.setOperatorName(this.getName());
                 if (joinAlgo == JoinAlgorithm.BROADCAST)
                 {
                     joinOutputs[i] = InvokerFactory.Instance()

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/StarlingAggregationOperator.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/StarlingAggregationOperator.java
@@ -71,6 +71,10 @@ public class StarlingAggregationOperator extends Operator
         requireNonNull(finalAggrInputs, "finalAggrInputs is null");
         checkArgument(!finalAggrInputs.isEmpty(), "finalAggrInputs is empty");
         this.finalAggrInputs = ImmutableList.copyOf(finalAggrInputs);
+        for (AggregationInput aggrInput : this.finalAggrInputs)
+        {
+            aggrInput.setOperatorName(name);
+        }
         if (partitionInputs == null || partitionInputs.isEmpty())
         {
             this.partitionInputs = ImmutableList.of();
@@ -78,6 +82,10 @@ public class StarlingAggregationOperator extends Operator
         else
         {
             this.partitionInputs = ImmutableList.copyOf(partitionInputs);
+            for (PartitionInput partitionInput : this.partitionInputs)
+            {
+                partitionInput.setOperatorName(name);
+            }
         }
     }
 
@@ -123,7 +131,6 @@ public class StarlingAggregationOperator extends Operator
                 int i = 0;
                 for (AggregationInput preAggrInput : this.finalAggrInputs)
                 {
-                    preAggrInput.setOperatorName(this.getName());
                     this.finalAggrOutputs[i++] = InvokerFactory.Instance()
                             .getInvoker(WorkerType.AGGREGATION).invoke(preAggrInput);
                 }
@@ -158,7 +165,6 @@ public class StarlingAggregationOperator extends Operator
                     int i = 0;
                     for (PartitionInput partitionInput : this.partitionInputs)
                     {
-                        partitionInput.setOperatorName(this.getName());
                         this.partitionOutputs[i++] = InvokerFactory.Instance()
                                 .getInvoker(WorkerType.PARTITION).invoke(partitionInput);
                     }

--- a/pixels-planner/src/test/java/io/pixelsdb/pixels/planner/TestOutput.java
+++ b/pixels-planner/src/test/java/io/pixelsdb/pixels/planner/TestOutput.java
@@ -19,7 +19,9 @@
  */
 package io.pixelsdb.pixels.planner;
 
+import com.alibaba.fastjson.JSON;
 import com.google.gson.Gson;
+import io.pixelsdb.pixels.planner.plan.physical.input.ScanInput;
 import io.pixelsdb.pixels.planner.plan.physical.output.ScanOutput;
 import org.junit.Test;
 
@@ -41,5 +43,16 @@ public class TestOutput
         String json = gson.toJson(scanOutput);
         assert json != null && !json.isEmpty();
         System.out.println(json);
+    }
+
+    @Test
+    public void testEncodeScanInput()
+    {
+        ScanInput scanInput = new ScanInput();
+        scanInput.setTransId(1);
+        //scanInput.setOperatorName("scan");
+        System.out.println(JSON.toJSONString(scanInput));
+        ScanInput scanInput1 = JSON.parseObject(JSON.toJSONString(scanInput), ScanInput.class);
+        System.out.println(scanInput1.getOperatorName());
     }
 }

--- a/pixels-planner/src/test/java/io/pixelsdb/pixels/planner/TestOutput.java
+++ b/pixels-planner/src/test/java/io/pixelsdb/pixels/planner/TestOutput.java
@@ -50,9 +50,13 @@ public class TestOutput
     {
         ScanInput scanInput = new ScanInput();
         scanInput.setTransId(1);
-        //scanInput.setOperatorName("scan");
+        scanInput.setOperatorName("scan");
         System.out.println(JSON.toJSONString(scanInput));
+        Gson gson = new Gson();
+        System.out.println(gson.toJson(scanInput));
         ScanInput scanInput1 = JSON.parseObject(JSON.toJSONString(scanInput), ScanInput.class);
+        ScanInput scanInput2 = gson.fromJson(gson.toJson(scanInput), ScanInput.class);
         System.out.println(scanInput1.getOperatorName());
+        System.out.println(scanInput2.getOperatorName());
     }
 }

--- a/pixels-turbo/pixels-worker-vhive/src/main/java/io/pixelsdb/pixels/worker/vhive/utils/ServiceImpl.java
+++ b/pixels-turbo/pixels-worker-vhive/src/main/java/io/pixelsdb/pixels/worker/vhive/utils/ServiceImpl.java
@@ -72,9 +72,9 @@ public class ServiceImpl<T extends RequestHandler<I, O>, I extends Input, O exte
                 output = handler.handleRequest(input);
                 Utils.stopProfile(JFRFilename);
 
-                Utils.upload(JFRFilename, String.format("%s_%s/%s",
+                Utils.upload(JFRFilename, String.format("%s/%s/%s",
                         input.getTransId(), notNullOrElse(input.getOperatorName(), "default"), JFRFilename));
-                log.info(String.format("upload JFR file to experiments/%s_%s/%s successfully",
+                log.info(String.format("upload JFR file to experiments/%s/%s/%s successfully",
                         input.getTransId(),  notNullOrElse(input.getOperatorName(), "default"), JFRFilename));
             } else
             {
@@ -83,9 +83,9 @@ public class ServiceImpl<T extends RequestHandler<I, O>, I extends Input, O exte
                 output = handler.handleRequest(input);
             }
             Utils.dump(JSONFilename, input, output);
-            Utils.upload(JSONFilename, String.format("%s_%s/%s",
+            Utils.upload(JSONFilename, String.format("%s/%s/%s",
                     input.getTransId(),  notNullOrElse(input.getOperatorName(), "default"), JSONFilename));
-            log.info(String.format("upload JSON file to experiments/%s_%s/%s successfully",
+            log.info(String.format("upload JSON file to experiments/%s/%s/%s successfully",
                     input.getTransId(),  notNullOrElse(input.getOperatorName(), "default"), JSONFilename));
 
             log.info(String.format("get output successfully: %s", JSON.toJSONString(output)));

--- a/pixels-turbo/pixels-worker-vhive/src/main/java/io/pixelsdb/pixels/worker/vhive/utils/ServiceImpl.java
+++ b/pixels-turbo/pixels-worker-vhive/src/main/java/io/pixelsdb/pixels/worker/vhive/utils/ServiceImpl.java
@@ -84,9 +84,9 @@ public class ServiceImpl<T extends RequestHandler<I, O>, I extends Input, O exte
             }
             Utils.dump(JSONFilename, input, output);
             Utils.upload(JSONFilename, String.format("%s_%s/%s",
-                    input.getTransId(),  notNullOrElse(input.getOperatorName(), "none"), JSONFilename));
+                    input.getTransId(),  notNullOrElse(input.getOperatorName(), "default"), JSONFilename));
             log.info(String.format("upload JSON file to experiments/%s_%s/%s successfully",
-                    input.getTransId(),  notNullOrElse(input.getOperatorName(), "none"), JSONFilename));
+                    input.getTransId(),  notNullOrElse(input.getOperatorName(), "default"), JSONFilename));
 
             log.info(String.format("get output successfully: %s", JSON.toJSONString(output)));
         } catch (Exception e)


### PR DESCRIPTION
Ensure that the operator name is set for serverless worker inputs when the inputs are added to an operator.