### PR TITLE
Pixels Writer endianness change

### DIFF
--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/PixelsWriterImpl.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/PixelsWriterImpl.java
@@ -37,6 +37,7 @@ import org.apache.logging.log4j.Logger;
 import javax.annotation.concurrent.NotThreadSafe;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/DateColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/DateColumnReader.java
@@ -30,6 +30,7 @@ import io.pixelsdb.pixels.core.vector.DateColumnVector;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 
 /**
  * pixels date column reader
@@ -98,6 +99,7 @@ public class DateColumnReader
                 inputStream.close();
             }
             this.inputBuffer = input;
+            this.inputBuffer.order(ByteOrder.LITTLE_ENDIAN);
             inputStream = new ByteBufferInputStream(inputBuffer, inputBuffer.position(), inputBuffer.limit());
             decoder = new RunLenIntDecoder(inputStream, true);
             isNullOffset = inputBuffer.position() + (int) chunkIndex.getIsNullOffset();

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/IntegerColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/IntegerColumnReader.java
@@ -30,6 +30,7 @@ import io.pixelsdb.pixels.core.vector.LongColumnVector;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 
 /**
  * @author guodong
@@ -107,6 +108,7 @@ public class IntegerColumnReader
                 inputStream.close();
             }
             this.inputBuffer = input;
+            this.inputBuffer.order(ByteOrder.LITTLE_ENDIAN);
             inputStream = new ByteBufferInputStream(inputBuffer, inputBuffer.position(), inputBuffer.limit());
             decoder = new RunLenIntDecoder(inputStream, true);
             // isNull
@@ -122,7 +124,7 @@ public class IntegerColumnReader
                  * The position should not be pushed, because the first byte will be read
                  * again for the first pixel (stride).
                  */
-                isLong = inputBuffer.getLong(0) == 1;
+                isLong = type.getCategory() == TypeDescription.Category.LONG;
             }
         }
         // if run length encoded
@@ -176,8 +178,6 @@ public class IntegerColumnReader
                     {
                         int pixelId = elementIndex / pixelStride;
                         hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
-                        // Read the first byte of the pixels (stride).
-                        isLong = inputBuffer.getLong() == 1;
                         if (hasNull && isNullBitIndex > 0)
                         {
                             BitUtils.bitWiseDeCompact(isNull, inputBuffer, isNullOffset++, 1);
@@ -214,8 +214,6 @@ public class IntegerColumnReader
                     {
                         int pixelId = elementIndex / pixelStride;
                         hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
-                        // Read the first byte of the pixels (stride).
-                        isLong = inputBuffer.getLong() == 1;
                         if (hasNull && isNullBitIndex > 0)
                         {
                             BitUtils.bitWiseDeCompact(isNull, inputBuffer, isNullOffset++, 1);

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/DateColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/DateColumnWriter.java
@@ -27,6 +27,7 @@ import io.pixelsdb.pixels.core.vector.DateColumnVector;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 
 /**
  * Date column writer.
@@ -110,6 +111,7 @@ public class DateColumnWriter extends BaseColumnWriter
         {
             ByteBuffer curVecPartitionBuffer =
                     ByteBuffer.allocate(curPixelVectorIndex * Integer.BYTES);
+            curVecPartitionBuffer.order(ByteOrder.LITTLE_ENDIAN);
             for (int i = 0; i < curPixelVectorIndex; i++)
             {
                 curVecPartitionBuffer.putInt(curPixelVector[i]);

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/IntegerColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/IntegerColumnWriter.java
@@ -27,6 +27,7 @@ import io.pixelsdb.pixels.core.vector.LongColumnVector;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 
 /**
  * Integer column writer.
@@ -38,8 +39,7 @@ import java.nio.ByteBuffer;
 public class IntegerColumnWriter extends BaseColumnWriter
 {
     private final long[] curPixelVector = new long[pixelStride];        // current pixel value vector haven't written out yet
-    private final boolean isLong;                                       // current column type is long or int
-
+    private final boolean isLong;                                       // current column type is long or int     // if the current pixel is the first pixel
     public IntegerColumnWriter(TypeDescription type, int pixelStride, boolean isEncoding)
     {
         super(type, pixelStride, isEncoding);
@@ -113,8 +113,8 @@ public class IntegerColumnWriter extends BaseColumnWriter
             ByteBuffer curVecPartitionBuffer;
             if (isLong)
             {
-                curVecPartitionBuffer = ByteBuffer.allocate((curPixelVectorIndex + 1) * Long.BYTES);
-                curVecPartitionBuffer.putLong(1);
+                curVecPartitionBuffer = ByteBuffer.allocate(curPixelVectorIndex * Long.BYTES);
+                curVecPartitionBuffer.order(ByteOrder.LITTLE_ENDIAN);
                 for (int i = 0; i < curPixelVectorIndex; i++)
                 {
                     curVecPartitionBuffer.putLong(curPixelVector[i]);
@@ -122,8 +122,8 @@ public class IntegerColumnWriter extends BaseColumnWriter
             }
             else
             {
-                curVecPartitionBuffer = ByteBuffer.allocate(curPixelVectorIndex * Integer.BYTES + Long.BYTES);
-                curVecPartitionBuffer.putLong(0);
+                curVecPartitionBuffer = ByteBuffer.allocate(curPixelVectorIndex * Integer.BYTES);
+                curVecPartitionBuffer.order(ByteOrder.LITTLE_ENDIAN);
                 for (int i = 0; i < curPixelVectorIndex; i++)
                 {
                     curVecPartitionBuffer.putInt((int) curPixelVector[i]);

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/StringColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/StringColumnWriter.java
@@ -31,6 +31,7 @@ import io.pixelsdb.pixels.core.vector.ColumnVector;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 
 /**
  * String column writer.
@@ -232,6 +233,7 @@ public class StringColumnWriter extends BaseColumnWriter
         outputStream.write(encoder.encode(tmpLens));
 
         ByteBuffer offsetBuf = ByteBuffer.allocate(Integer.BYTES);
+        offsetBuf.order(ByteOrder.LITTLE_ENDIAN);
         offsetBuf.putInt(lensFieldOffset);
         outputStream.write(offsetBuf.array());
     }
@@ -275,6 +277,7 @@ public class StringColumnWriter extends BaseColumnWriter
         outputStream.write(encoder.encode(orders));
 
         ByteBuffer offsetsBuf = ByteBuffer.allocate(3 * Integer.BYTES);
+        offsetsBuf.order(ByteOrder.LITTLE_ENDIAN);
         offsetsBuf.putInt(originsFieldOffset);
         offsetsBuf.putInt(startsFieldOffset);
         offsetsBuf.putInt(ordersFieldOffset);


### PR DESCRIPTION
1. Pixels Writer: change the big endian to small endian (Date, Int, Long, offset in String).
2. Remove the isLong indicator of integer/long column.
3. This commit is only for generating Pixels data for Pixels C++ reader. Pixels Java reader cannot read data generated by this commit