### PR TITLE
[docs] Update install.md: Maven version should be above or equal to 3.6.

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -32,8 +32,7 @@ Oracle JDK 17.0, Azul Zulu JDK 17, or GraalVM 22 for Java 17 also works.
 
 ## Install Maven
 
-Pixels requires maven 3 to build the source code. 
-On some old operating systems, the maven installed by `apt` or `yum` might be incompatible with new JDKs such as 17. 
+Pixels requires maven 3.6 to build the source code (maven 3.1-3.5 might work, but we didn't test them yet). On some old operating systems, the maven installed by `apt` or `yum` might be incompatible with new JDKs such as 17. 
 In this case, you need to install a later maven that is compatible with your JDK manually. 
 
 ## Setup AWS Credentials*


### PR DESCRIPTION
In order to compile Pixels, the Maven version should be >= 3.6. 