### PR TITLE
[Issue #493] Align the location of column byte buffer in pxl file.

### DIFF
--- a/pixels-common/src/main/resources/pixels.properties
+++ b/pixels-common/src/main/resources/pixels.properties
@@ -58,6 +58,7 @@ cache.read.direct=false
 # properties for pixels writer
 pixel.stride=10000
 row.group.size=268435456
+row.group.align=32
 block.size=2147483648
 block.replication=1
 block.padding=true

--- a/pixels-common/src/main/resources/pixels.properties
+++ b/pixels-common/src/main/resources/pixels.properties
@@ -58,7 +58,8 @@ cache.read.direct=false
 # properties for pixels writer
 pixel.stride=10000
 row.group.size=268435456
-row.group.align=32
+# The alignment is for SIMD and its unit is byte
+column.chunk.alignment=32
 block.size=2147483648
 block.replication=1
 block.padding=true

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/PixelsWriterImpl.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/PixelsWriterImpl.java
@@ -521,7 +521,7 @@ public class PixelsWriterImpl implements PixelsWriter
                     physicalWriter.append(rowGroupBuffer, 0, rowGroupBuffer.length);
                     writtenBytes += rowGroupBuffer.length;
                     int alignment = Integer.parseInt(ConfigFactory.Instance().getProperty("row.group.align"));
-                    // add align bytes to make sure the column size is the multiple of fsBlockSize
+                    // add align bytes to make sure the column size is the multiple of `alignment`
                     if(rowGroupBuffer.length % alignment != 0) {
                         int alignByte = alignment - rowGroupBuffer.length % alignment;
                         byte[] emptyArray = new byte[alignByte];


### PR DESCRIPTION
Unaligned read causes error for SIMD instructions. For example, is the address of a long column vector is 0x0c, it would have unalign read (the address should be the multiple of 8). In the normal instruction it would affect the performance adversely, but we don't know how much performance degrade would happen, but at least here is no correctness issue. However, if we use SIMD, the unalign read is erroneous, so we have to fix it.

We add a parameter in pixels.properties so that we can adjust the alignment value. The default one is 32. It is aligned for avx2(256 bit) SIMD instruction.

Closes #493.