### PR TITLE
[Issue #498] remove the orders array from dictionary encoding.

### DIFF
--- a/docs/TPC-H.md
+++ b/docs/TPC-H.md
@@ -37,7 +37,7 @@ java -jar ./sbin/pixels-cli-*-full.jar
 
 Then use the following commands in pixels-cli to load data for the TPC-H tables:
 ```bash
-LOAD -o file:///data/tpch/100gcustomer/ -s tpch -t customer -n 319150 -r \| -c 1
+LOAD -o file:///data/tpch/100g/customer -s tpch -t customer -n 319150 -r \| -c 1
 LOAD -o file:///data/tpch/100g/lineitem -s tpch -t lineitem -n 600040 -r \| -c 1
 LOAD -o file:///data/tpch/100g/nation -s tpch -t nation -n 100 -r \| -c 1
 LOAD -o file:///data/tpch/100g/orders -s tpch -t orders -n 638300 -r \| -c 1

--- a/docs/TPC-H.md
+++ b/docs/TPC-H.md
@@ -37,7 +37,7 @@ java -jar ./sbin/pixels-cli-*-full.jar
 
 Then use the following commands in pixels-cli to load data for the TPC-H tables:
 ```bash
-LOAD -o file:///scratch/data/tpch-300g/customer/ -s tpch -t customer -n 319150 -r \| -c 1
+LOAD -o file:///data/tpch/100gcustomer/ -s tpch -t customer -n 319150 -r \| -c 1
 LOAD -o file:///data/tpch/100g/lineitem -s tpch -t lineitem -n 600040 -r \| -c 1
 LOAD -o file:///data/tpch/100g/nation -s tpch -t nation -n 100 -r \| -c 1
 LOAD -o file:///data/tpch/100g/orders -s tpch -t orders -n 638300 -r \| -c 1

--- a/docs/TPC-H.md
+++ b/docs/TPC-H.md
@@ -37,7 +37,7 @@ java -jar ./sbin/pixels-cli-*-full.jar
 
 Then use the following commands in pixels-cli to load data for the TPC-H tables:
 ```bash
-LOAD -o file:///data/tpch/100g/customer -s tpch -t customer -n 319150 -r \| -c 1
+LOAD -o file:///scratch/data/tpch-300g/customer/ -s tpch -t customer -n 319150 -r \| -c 1
 LOAD -o file:///data/tpch/100g/lineitem -s tpch -t lineitem -n 600040 -r \| -c 1
 LOAD -o file:///data/tpch/100g/nation -s tpch -t nation -n 100 -r \| -c 1
 LOAD -o file:///data/tpch/100g/orders -s tpch -t orders -n 638300 -r \| -c 1

--- a/pixels-common/src/main/resources/pixels.properties
+++ b/pixels-common/src/main/resources/pixels.properties
@@ -58,6 +58,8 @@ cache.read.direct=false
 # properties for pixels writer
 pixel.stride=10000
 row.group.size=268435456
+# The alignment is for SIMD and its unit is byte
+column.chunk.alignment=32
 block.size=2147483648
 block.replication=1
 block.padding=true

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/PixelsWriterImpl.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/PixelsWriterImpl.java
@@ -23,6 +23,7 @@ import io.pixelsdb.pixels.common.physical.PhysicalWriter;
 import io.pixelsdb.pixels.common.physical.PhysicalWriterUtil;
 import io.pixelsdb.pixels.common.physical.Storage;
 import io.pixelsdb.pixels.common.utils.Constants;
+import io.pixelsdb.pixels.common.utils.ConfigFactory;
 import io.pixelsdb.pixels.core.PixelsProto.CompressionKind;
 import io.pixelsdb.pixels.core.PixelsProto.RowGroupInformation;
 import io.pixelsdb.pixels.core.PixelsProto.RowGroupStatistic;
@@ -99,7 +100,7 @@ public class PixelsWriterImpl implements PixelsWriter
     private final List<TypeDescription> children;
 
     private final ExecutorService columnWriterService = Executors.newCachedThreadPool();
-
+    private int chunkAlignment;
     private PixelsWriterImpl(
             TypeDescription schema,
             int pixelStride,
@@ -124,7 +125,7 @@ public class PixelsWriterImpl implements PixelsWriter
         this.encoding = encoding;
         this.partitioned = partitioned;
         this.partKeyColumnIds = requireNonNull(partKeyColumnIds, "partKeyColumnIds is null");
-
+        this.chunkAlignment = Integer.parseInt(ConfigFactory.Instance().getProperty("column.chunk.alignment"));
         children = schema.getChildren();
         checkArgument(!requireNonNull(children, "schema is null").isEmpty(), "schema is empty");
         this.columnWriters = new ColumnWriter[children.size()];
@@ -519,6 +520,13 @@ public class PixelsWriterImpl implements PixelsWriter
                     byte[] rowGroupBuffer = writer.getColumnChunkContent();
                     physicalWriter.append(rowGroupBuffer, 0, rowGroupBuffer.length);
                     writtenBytes += rowGroupBuffer.length;
+                    // add align bytes to make sure the column size is the multiple of fsBlockSize
+                    if(rowGroupBuffer.length % chunkAlignment != 0) {
+                        int alignByte = chunkAlignment - rowGroupBuffer.length % chunkAlignment;
+                        byte[] emptyArray = new byte[alignByte];
+                        physicalWriter.append(emptyArray, 0, alignByte);
+                        writtenBytes += alignByte;
+                    }
                 }
                 physicalWriter.flush();
             }
@@ -543,6 +551,9 @@ public class PixelsWriterImpl implements PixelsWriter
             chunkIndexBuilder.setChunkOffset(curRowGroupOffset + rowGroupDataLength);
             chunkIndexBuilder.setChunkLength(writer.getColumnChunkSize());
             rowGroupDataLength += writer.getColumnChunkSize();
+            if((curRowGroupOffset + rowGroupDataLength) % chunkAlignment != 0) {
+                rowGroupDataLength += (int) (chunkAlignment - (curRowGroupOffset + rowGroupDataLength) % chunkAlignment);
+            }
             // collect columnChunkIndex from every column chunk into curRowGroupIndex
             curRowGroupIndex.addColumnChunkIndexEntries(chunkIndexBuilder.build());
             // collect columnChunkStatistic into rowGroupStatistic

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/encoding/Dictionary.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/encoding/Dictionary.java
@@ -94,12 +94,6 @@ public interface Dictionary
     interface VisitorContext
     {
         /**
-         * Get the position, i.e., encoded id of the key in the dictionary.
-         * @return the number returned by {@link #add(byte[], int, int)}.
-         */
-        int getKeyPosition();
-
-        /**
          * Write the key to the given output stream.
          * @param out the stream to write to.
          * @throws IOException

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/encoding/Dictionary.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/encoding/Dictionary.java
@@ -17,7 +17,7 @@
  * License along with Pixels.  If not, see
  * <https://www.gnu.org/licenses/>.
  */
-package io.pixelsdb.pixels.core.utils;
+package io.pixelsdb.pixels.core.encoding;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -25,7 +25,7 @@ import java.io.OutputStream;
 /**
  * The dictionary used for string dictionary encoding.
  * @author hank
- * @date 8/15/22
+ * @create 2022-08-15
  */
 public interface Dictionary
 {
@@ -63,6 +63,16 @@ public interface Dictionary
 
     void clear();
 
+    /**
+     * This method prepares a {@link VisitorContext} instance for each item (key) in this dictionary,
+     * and calls {@link Visitor#visit(VisitorContext)} to visit the item.
+     * <p>
+     * The items <b>MUST</b> be visited in the ascending order of the item's key position, i.e., the encoded id of the item in this dictionary.
+     * The visitor can write (serialize) the dictionary item to an output stream.
+     * </p>
+     * @param visitor the visitor that is going to serialize the dictionary to an output stream.
+     * @throws IOException
+     */
     void visit(Visitor visitor) throws IOException;
 
     /**
@@ -71,8 +81,8 @@ public interface Dictionary
     interface Visitor
     {
         /**
-         * Called once for each item in the dictionary.
-         * @param context the information about each item
+         * Called exact once for each item in the dictionary.
+         * @param context the information about each item.
          * @throws IOException
          */
         void visit(VisitorContext context) throws IOException;
@@ -84,13 +94,13 @@ public interface Dictionary
     interface VisitorContext
     {
         /**
-         * Get the position, i.e., id of the key in the dictionary.
+         * Get the position, i.e., encoded id of the key in the dictionary.
          * @return the number returned by {@link #add(byte[], int, int)}.
          */
         int getKeyPosition();
 
         /**
-         * Write the bytes for the string to the given output stream.
+         * Write the key to the given output stream.
          * @param out the stream to write to.
          * @throws IOException
          */

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/encoding/HashTableDictionary.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/encoding/HashTableDictionary.java
@@ -158,7 +158,7 @@ public class HashTableDictionary implements Dictionary
             }
             keyIsFound = false;
             KeyBuffer key = entry.getKey();
-            visitorContext.setKey(key.bytes, key.offset, key.length, position);
+            visitorContext.setKey(key.bytes, key.offset, key.length);
             visitor.visit(visitorContext);
         }
     }
@@ -289,13 +289,6 @@ public class HashTableDictionary implements Dictionary
         private byte[] key;
         private int offset;
         private int length;
-        private int keyPosition;
-
-        @Override
-        public int getKeyPosition()
-        {
-            return keyPosition;
-        }
 
         @Override
         public void writeBytes(OutputStream out) throws IOException
@@ -309,12 +302,11 @@ public class HashTableDictionary implements Dictionary
             return length;
         }
 
-        public void setKey(byte[] key, int offset, int length, int keyPosition)
+        public void setKey(byte[] key, int offset, int length)
         {
             this.key = key;
             this.offset = offset;
             this.length = length;
-            this.keyPosition = keyPosition;
         }
     }
 }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/encoding/HashTableDictionary.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/encoding/HashTableDictionary.java
@@ -116,25 +116,38 @@ public class HashTableDictionary implements Dictionary
         VisitorContextImpl visitorContext = new VisitorContextImpl();
         boolean keyIsFound = false;
         List<Iterator<Map.Entry<KeyBuffer, Integer>>> dictIterators = new ArrayList<>(NUM_DICTIONARIES);
+        List<Map.Entry<KeyBuffer, Integer>> firstEntries = new ArrayList<>(NUM_DICTIONARIES);
         for (int i = 0; i < NUM_DICTIONARIES; ++i)
         {
-            dictIterators.add(this.dictionaries.get(i).entrySet().iterator());
+            Iterator<Map.Entry<KeyBuffer, Integer>> iterator = this.dictionaries.get(i).entrySet().iterator();
+            if (iterator.hasNext())
+            {
+                Map.Entry<KeyBuffer, Integer> entry = iterator.next();
+                firstEntries.add(entry);
+                dictIterators.add(iterator);
+            }
         }
         for (int position = 0; position < this.originalPosition; ++position)
         {
             Map.Entry<KeyBuffer, Integer> entry = null;
-            for (int i = 0; i < dictIterators.size(); ++i)
+            for (int i = 0; i < firstEntries.size(); ++i)
             {
-                Iterator<Map.Entry<KeyBuffer, Integer>> dictIterator = dictIterators.get(i);
-                if (!dictIterator.hasNext())
-                {
-                    // this dictionary has no remaining keys to visit
-                    dictIterators.remove(i--);
-                    continue;
-                }
-                entry = dictIterator.next();
+                entry = firstEntries.get(i);
+                Iterator<Map.Entry<KeyBuffer, Integer>> iterator = dictIterators.get(i);
                 if (entry.getValue() == position)
                 {
+                    // find the right entry (dictionary key with the correct position id)
+                    if (iterator.hasNext())
+                    {
+                        // get the next first key from the iterator
+                        firstEntries.set(i, iterator.next());
+                    }
+                    else
+                    {
+                        // the corresponding iterator has no remaining keys to visit
+                        dictIterators.remove(i);
+                        firstEntries.remove(i);
+                    }
                     keyIsFound = true;
                     break;
                 }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/encoding/HashTableDictionary.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/encoding/HashTableDictionary.java
@@ -161,15 +161,6 @@ public class HashTableDictionary implements Dictionary
             visitorContext.setKey(key.bytes, key.offset, key.length, position);
             visitor.visit(visitorContext);
         }
-/*
-        for (Map<KeyBuffer, Integer> dict : this.dictionaries)
-        for (Map.Entry<KeyBuffer, Integer> entry : dict.entrySet())
-        {
-            KeyBuffer key = entry.getKey();
-            visitorContext.setKey(key.bytes, key.offset, key.length, entry.getValue());
-            visitor.visit(visitorContext);
-        }
- */
     }
 
     private static class KeyBuffer implements Comparable<KeyBuffer>

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/encoding/RedBlackTree.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/encoding/RedBlackTree.java
@@ -17,7 +17,9 @@
  * License along with Pixels.  If not, see
  * <https://www.gnu.org/licenses/>.
  */
-package io.pixelsdb.pixels.core.utils;
+package io.pixelsdb.pixels.core.encoding;
+
+import io.pixelsdb.pixels.core.utils.DynamicIntArray;
 
 /**
  * red-black tree from apache orc project
@@ -25,6 +27,9 @@ package io.pixelsdb.pixels.core.utils;
  * A memory efficient red-black tree that does not allocate any objects per
  * an element. This class is abstract and assumes that the child class
  * handles the key and comparisons with the key.
+ *
+ * @author guodong
+ * @author hank
  */
 abstract class RedBlackTree
 {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/encoding/StringRedBlackTree.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/encoding/StringRedBlackTree.java
@@ -184,7 +184,6 @@ public class StringRedBlackTree extends RedBlackTree implements Dictionary
         private int start;
         private int end;
 
-        @Override
         public int getKeyPosition()
         {
             return keyPosition;

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/LongDecimalColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/LongDecimalColumnReader.java
@@ -32,7 +32,7 @@ import java.nio.ByteOrder;
 /**
  * The column reader of long decimals with max precision and scale 38.
  *
- * @date 03/07/2022
+ * @date 2022-07-03
  * @author hank
  */
 public class LongDecimalColumnReader

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/StringColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/StringColumnReader.java
@@ -334,8 +334,8 @@ public class StringColumnReader
                 inputBuffer.getBytes(originsOffset, bytes, 0, startsOffset - originsOffset);
                 originsBuf = Unpooled.wrappedBuffer(bytes);
             }
-            // read starts
-            ByteBuf startsBuf = inputBuffer.slice(startsOffset, inputLength - startsOffset - 3 * Integer.BYTES);
+            // read starts, the last two integers (8 bytes) are the origin offset and starts offset
+            ByteBuf startsBuf = inputBuffer.slice(startsOffset, inputLength - startsOffset - 2 * Integer.BYTES);
 
             // DO NOT use originsOffset as bufferStart, as multiple input buffers read
             // from disk (not from pixels cache) may share the same backing array, each starting

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/StringColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/StringColumnReader.java
@@ -335,7 +335,7 @@ public class StringColumnReader
                 originsBuf = Unpooled.wrappedBuffer(bytes);
             }
             // read starts
-            ByteBuf startsBuf = inputBuffer.slice(startsOffset, inputLength - startsOffset);
+            ByteBuf startsBuf = inputBuffer.slice(startsOffset, inputLength - startsOffset - 3 * Integer.BYTES);
 
             // DO NOT use originsOffset as bufferStart, as multiple input buffers read
             // from disk (not from pixels cache) may share the same backing array, each starting

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/StringColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/StringColumnReader.java
@@ -54,17 +54,9 @@ public class StringColumnReader
      */
     private ByteBuf originsBuf = null;
     /**
-     * Mapping encoded dictionary id to element index in origins.
-     */
-    private int[] orders = null;
-    /**
      * elements' ABSOLUTE start offsets in originsBuf.
      */
     private int[] starts = null;
-    /**
-     * Number of origin elements in dictionary.
-     */
-    private int originNum;
 
     private byte[] isNull = new byte[8];
     /**
@@ -122,7 +114,6 @@ public class StringColumnReader
         this.contentBuf = null;
         this.inputBuffer = null;
         this.originsBuf = null;
-        this.orders = null;
         this.starts = null;
         this.isNull = null;
         if (this.contentDecoder != null)
@@ -203,7 +194,7 @@ public class StringColumnReader
                         columnVector.noNulls = false;
                     } else
                     {
-                        int originId = orders[(int) contentDecoder.next()];
+                        int originId = (int) contentDecoder.next();
                         int tmpLen = starts[originId + 1] - starts[originId];
                         // use setRef instead of setVal to reduce memory copy.
                         columnVector.setRef(i + vectorIndex, buffer, starts[originId], tmpLen);
@@ -291,7 +282,7 @@ public class StringColumnReader
                     columnVector.noNulls = false;
                 } else
                 {
-                    int originId = orders[(int) contentDecoder.next()];
+                    int originId = (int) contentDecoder.next();
                     columnVector.setId(i + vectorIndex, originId);
                 }
                 if (hasNull)
@@ -320,7 +311,6 @@ public class StringColumnReader
             inputBuffer.skipBytes(inputLength - 3 * Integer.BYTES);
             originsOffset = inputBuffer.readInt();
             startsOffset = inputBuffer.readInt();
-            int ordersOffset = inputBuffer.readInt();
             inputBuffer.resetReaderIndex();
             // read buffers
             contentBuf = inputBuffer.slice(0, originsOffset);
@@ -344,9 +334,8 @@ public class StringColumnReader
                 inputBuffer.getBytes(originsOffset, bytes, 0, startsOffset - originsOffset);
                 originsBuf = Unpooled.wrappedBuffer(bytes);
             }
-            // read starts and orders
-            ByteBuf startsBuf = inputBuffer.slice(startsOffset, ordersOffset - startsOffset);
-            ByteBuf ordersBuf = inputBuffer.slice(ordersOffset, inputLength - ordersOffset);
+            // read starts
+            ByteBuf startsBuf = inputBuffer.slice(startsOffset, inputLength - startsOffset);
 
             // DO NOT use originsOffset as bufferStart, as multiple input buffers read
             // from disk (not from pixels cache) may share the same backing array, each starting
@@ -380,13 +369,12 @@ public class StringColumnReader
                 starts = startsArray.toArray();
             }
 
-            this.originNum = starts.length - 1;
-            RunLenIntDecoder ordersDecoder = new RunLenIntDecoder(new ByteBufInputStream(ordersBuf), false);
-            orders = new int[originNum];
-            for (int i = 0; i < originNum && ordersDecoder.hasNext(); i++)
-            {
-                orders[i] = (int) ordersDecoder.next();
-            }
+            /*
+             * Issue #498:
+             * We no longer read the orders array (encoded-id to key-index mapping) from files.
+             * Encoded id is exactly the index of the key in the dictionary.
+             */
+
             contentDecoder = new RunLenIntDecoder(new ByteBufInputStream(contentBuf), false);
         }
         else

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/utils/BitUtils.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/utils/BitUtils.java
@@ -179,7 +179,8 @@ public class BitUtils
     /**
      * Bit de-compaction, this method does not modify the current position in input byte buffer.
      *
-     * @param input input byte buffer, which can be direct.
+     * @param bits the de-compact (decode) result, each element is either 0 (false) or 1 (true)
+     * @param input input byte buffer, which can be direct
      * @param offset starting offset of the input
      * @param length byte length of the input
      * @return de-compacted bits

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/StringColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/StringColumnWriter.java
@@ -22,10 +22,10 @@ package io.pixelsdb.pixels.core.writer;
 import io.pixelsdb.pixels.common.utils.Constants;
 import io.pixelsdb.pixels.core.PixelsProto;
 import io.pixelsdb.pixels.core.TypeDescription;
-import io.pixelsdb.pixels.core.encoding.RunLenIntEncoder;
 import io.pixelsdb.pixels.core.encoding.Dictionary;
+import io.pixelsdb.pixels.core.encoding.RunLenIntEncoder;
+import io.pixelsdb.pixels.core.encoding.StringRedBlackTree;
 import io.pixelsdb.pixels.core.utils.DynamicIntArray;
-import io.pixelsdb.pixels.core.encoding.HashTableDictionary;
 import io.pixelsdb.pixels.core.vector.BinaryColumnVector;
 import io.pixelsdb.pixels.core.vector.ColumnVector;
 
@@ -56,7 +56,7 @@ public class StringColumnWriter extends BaseColumnWriter
 {
     private final long[] curPixelVector = new long[pixelStride];      // current vector holding encoded values of string
     private final DynamicIntArray lensArray = new DynamicIntArray();  // lengths of each string when un-encoded
-    private final Dictionary dictionary = new HashTableDictionary(Constants.INIT_DICT_SIZE);
+    private final Dictionary dictionary = new StringRedBlackTree(Constants.INIT_DICT_SIZE);
     private boolean futureUseDictionaryEncoding;
     private boolean currentUseDictionaryEncoding;
     private boolean doneDictionaryEncodingCheck = false;

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/StringColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/StringColumnWriter.java
@@ -23,9 +23,9 @@ import io.pixelsdb.pixels.common.utils.Constants;
 import io.pixelsdb.pixels.core.PixelsProto;
 import io.pixelsdb.pixels.core.TypeDescription;
 import io.pixelsdb.pixels.core.encoding.RunLenIntEncoder;
-import io.pixelsdb.pixels.core.utils.Dictionary;
+import io.pixelsdb.pixels.core.encoding.Dictionary;
 import io.pixelsdb.pixels.core.utils.DynamicIntArray;
-import io.pixelsdb.pixels.core.utils.HashTableDictionary;
+import io.pixelsdb.pixels.core.encoding.HashTableDictionary;
 import io.pixelsdb.pixels.core.vector.BinaryColumnVector;
 import io.pixelsdb.pixels.core.vector.ColumnVector;
 

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/StringColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/StringColumnWriter.java
@@ -241,10 +241,8 @@ public class StringColumnWriter extends BaseColumnWriter
     {
         int originsFieldOffset;
         int startsFieldOffset;
-        int ordersFieldOffset;
         int size = dictionary.size();
         long[] starts = new long[size];
-        long[] orders = new long[size];
 
         originsFieldOffset = outputStream.size();
 
@@ -259,9 +257,8 @@ public class StringColumnWriter extends BaseColumnWriter
                     throws IOException
             {
                 context.writeBytes(outputStream);
-                starts[currentId] = initStart;
+                starts[currentId++] = initStart;
                 initStart += context.getLength();
-                orders[context.getKeyPosition()] = currentId++;
             }
         });
 
@@ -269,15 +266,16 @@ public class StringColumnWriter extends BaseColumnWriter
 
         // write out run length starts array
         outputStream.write(encoder.encode(starts));
-        ordersFieldOffset = outputStream.size();
 
-        // write out run length orders array
-        outputStream.write(encoder.encode(orders));
+        /*
+         * Issue #498:
+         * We no longer write the orders array (encoded-id to key-index mapping) to files.
+         * Encoded id is exactly the index of the key in the dictionary.
+         */
 
         ByteBuffer offsetsBuf = ByteBuffer.allocate(3 * Integer.BYTES);
         offsetsBuf.putInt(originsFieldOffset);
         offsetsBuf.putInt(startsFieldOffset);
-        offsetsBuf.putInt(ordersFieldOffset);
         outputStream.write(offsetsBuf.array());
     }
 

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/StringColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/StringColumnWriter.java
@@ -273,7 +273,7 @@ public class StringColumnWriter extends BaseColumnWriter
          * Encoded id is exactly the index of the key in the dictionary.
          */
 
-        ByteBuffer offsetsBuf = ByteBuffer.allocate(3 * Integer.BYTES);
+        ByteBuffer offsetsBuf = ByteBuffer.allocate(2 * Integer.BYTES);
         offsetsBuf.putInt(originsFieldOffset);
         offsetsBuf.putInt(startsFieldOffset);
         outputStream.write(offsetsBuf.array());

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/StringColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/StringColumnWriter.java
@@ -23,8 +23,8 @@ import io.pixelsdb.pixels.common.utils.Constants;
 import io.pixelsdb.pixels.core.PixelsProto;
 import io.pixelsdb.pixels.core.TypeDescription;
 import io.pixelsdb.pixels.core.encoding.Dictionary;
+import io.pixelsdb.pixels.core.encoding.HashTableDictionary;
 import io.pixelsdb.pixels.core.encoding.RunLenIntEncoder;
-import io.pixelsdb.pixels.core.encoding.StringRedBlackTree;
 import io.pixelsdb.pixels.core.utils.DynamicIntArray;
 import io.pixelsdb.pixels.core.vector.BinaryColumnVector;
 import io.pixelsdb.pixels.core.vector.ColumnVector;
@@ -56,7 +56,7 @@ public class StringColumnWriter extends BaseColumnWriter
 {
     private final long[] curPixelVector = new long[pixelStride];      // current vector holding encoded values of string
     private final DynamicIntArray lensArray = new DynamicIntArray();  // lengths of each string when un-encoded
-    private final Dictionary dictionary = new StringRedBlackTree(Constants.INIT_DICT_SIZE);
+    private final Dictionary dictionary = new HashTableDictionary(Constants.INIT_DICT_SIZE);
     private boolean futureUseDictionaryEncoding;
     private boolean currentUseDictionaryEncoding;
     private boolean doneDictionaryEncodingCheck = false;

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/utils/TestDictionary.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/utils/TestDictionary.java
@@ -20,6 +20,9 @@
 package io.pixelsdb.pixels.core.utils;
 
 import io.pixelsdb.pixels.common.utils.Constants;
+import io.pixelsdb.pixels.core.encoding.Dictionary;
+import io.pixelsdb.pixels.core.encoding.HashTableDictionary;
+import io.pixelsdb.pixels.core.encoding.StringRedBlackTree;
 import org.junit.Test;
 
 import java.lang.management.GarbageCollectorMXBean;


### PR DESCRIPTION
Previously, the orders array was the mapping from the encoded id to the key index in the dictionary. We remove the orders array from the pixels file by enforcing the dictionary to be written in the order of encoded id.
This helps improve writing and reading performance, as it reduces the CPU costs on array encoding/decoding and the IO costs.