### PR TITLE
[Issue #485] clean metadata cache and make it transactional.

### DIFF
--- a/pixels-cli/src/main/java/io/pixelsdb/pixels/cli/executor/StatExecutor.java
+++ b/pixels-cli/src/main/java/io/pixelsdb/pixels/cli/executor/StatExecutor.java
@@ -21,7 +21,6 @@ package io.pixelsdb.pixels.cli.executor;
 
 import com.facebook.presto.jdbc.PrestoDriver;
 import com.google.common.collect.ImmutableList;
-import io.pixelsdb.pixels.common.metadata.MetadataCache;
 import io.pixelsdb.pixels.common.metadata.MetadataService;
 import io.pixelsdb.pixels.common.metadata.domain.Column;
 import io.pixelsdb.pixels.common.metadata.domain.Layout;
@@ -174,8 +173,11 @@ public class StatExecutor implements CommandExecutor
         /* Set cardinality and null_fraction after the chunk size and column size,
          * because chunk size and column size must exist in the metadata when calculating
          * the cardinality and null_fraction using SQL queries.
+         *
+         * Issue #485:
+         * No need to drop the cached columns here, because metadata cache is only used in
+         * the query engine process during transactional query execution.
          */
-        MetadataCache.Instance().dropCachedColumns();
         try (Connection connection = DriverManager.getConnection(jdbc, properties))
         {
             for (Column column : columns)

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/layout/CostBasedSplitsIndex.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/layout/CostBasedSplitsIndex.java
@@ -37,7 +37,7 @@ import static java.util.Objects.requireNonNull;
 /**
  * The splits index that calculates the split size using the statistics.
  * @author hank
- * @date 13/07/2022
+ * @create 2022-07-13
  */
 public class CostBasedSplitsIndex implements SplitsIndex
 {
@@ -74,7 +74,7 @@ public class CostBasedSplitsIndex implements SplitsIndex
         {
             columns = this.metadataService.getColumns(
                     schemaTableName.getSchemaName(), schemaTableName.getTableName(), true);
-            MetadataCache.Instance().cacheTableColumns(schemaTableName, columns);
+            // Issue #485: metadata cache is refreshed when the table is firstly accessed during query parsing.
         }
         this.columnMap = new HashMap<>(columns.size());
         double rowGroupSize = 0, tableSize = 0;
@@ -95,7 +95,7 @@ public class CostBasedSplitsIndex implements SplitsIndex
             {
                 table = this.metadataService.getTable(
                         schemaTableName.getSchemaName(), schemaTableName.getTableName());
-                MetadataCache.Instance().cacheTable(schemaTableName, table);
+                // Issue #485: metadata cache is refreshed when the table is firstly accessed during query parsing.
             }
             double numRowGroups = Math.ceil(tableSize / rowGroupSize);
             checkArgument(table.getRowCount() > 0,

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/layout/InvertedSplitsIndex.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/layout/InvertedSplitsIndex.java
@@ -21,27 +21,30 @@ package io.pixelsdb.pixels.common.layout;
 
 import java.util.*;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * @author hank
+ * @create 2018-02
  */
 public class InvertedSplitsIndex implements SplitsIndex
 {
-    private int version;
-
+    private final long version;
     private final int maxSplitSize;
 
     /**
      * key: column name;
      * value: bit map
      */
-    private Map<String, BitSet> bitMapIndex;
+    private final Map<String, BitSet> bitMapIndex;
 
-    private List<SplitPattern> querySplitPatterns;
+    private final List<SplitPattern> querySplitPatterns;
 
     private List<String> columnOrder;
 
-    public InvertedSplitsIndex(List<String> columnOrder, List<SplitPattern> patterns, int maxSplitSize)
+    public InvertedSplitsIndex(long version, List<String> columnOrder, List<SplitPattern> patterns, int maxSplitSize)
     {
+        this.version = version;
         this.maxSplitSize = maxSplitSize;
         this.columnOrder = new ArrayList<>(columnOrder);
         this.querySplitPatterns = new ArrayList<>(patterns);
@@ -93,12 +96,12 @@ public class InvertedSplitsIndex implements SplitsIndex
             int minPatternSize = Integer.MAX_VALUE;
             int temp;
 
-            for (int i = 0; i < this.querySplitPatterns.size(); ++i)
+            for (SplitPattern querySplitPattern : this.querySplitPatterns)
             {
-                temp = Math.abs(this.querySplitPatterns.get(i).size() - numColumns);
+                temp = Math.abs(querySplitPattern.size() - numColumns);
                 if (temp < minPatternSize)
                 {
-                    bestPattern = this.querySplitPatterns.get(i);
+                    bestPattern = querySplitPattern;
                     minPatternSize = temp;
                 }
             }
@@ -117,6 +120,7 @@ public class InvertedSplitsIndex implements SplitsIndex
             }
         }
 
+        requireNonNull(bestPattern, "best pattern is not found");
         if (bestPattern.getSplitSize() > maxSplitSize)
         {
             bestPattern.setSplitSize(maxSplitSize);
@@ -126,7 +130,7 @@ public class InvertedSplitsIndex implements SplitsIndex
     }
 
     @Override
-    public int getVersion()
+    public long getVersion()
     {
         return version;
     }
@@ -135,10 +139,5 @@ public class InvertedSplitsIndex implements SplitsIndex
     public int getMaxSplitSize()
     {
         return maxSplitSize;
-    }
-
-    public void setVersion(int version)
-    {
-        this.version = version;
     }
 }

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/layout/SplitsIndex.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/layout/SplitsIndex.java
@@ -34,7 +34,7 @@ public interface SplitsIndex
      */
     SplitPattern search(ColumnSet columnSet);
 
-    int getVersion();
+    long getVersion();
 
     int getMaxSplitSize();
 }

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/metadata/MetadataCache.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/metadata/MetadataCache.java
@@ -31,7 +31,7 @@ import static java.util.Objects.requireNonNull;
 
 /**
  * @author hank
- * @date 13/07/2022
+ * @create 2022-07-13
  */
 public class MetadataCache
 {
@@ -48,19 +48,29 @@ public class MetadataCache
 
     private MetadataCache() { }
 
-    public void cacheTable(SchemaTableName schemaTableName, Table table)
+    /**
+     * Cache the table metadata, refresh the cache if the table already exists.
+     * @param schemaTableName the schema and table name of the table
+     * @param table the metadata of the table
+     */
+    public synchronized void cacheTable(SchemaTableName schemaTableName, Table table)
     {
         requireNonNull(schemaTableName, "schemaTableName is null");
         requireNonNull(table, "table is null");
         this.tableMap.put(schemaTableName, table);
     }
 
-    public Table getTable(SchemaTableName schemaTableName)
+    public synchronized Table getTable(SchemaTableName schemaTableName)
     {
         requireNonNull(schemaTableName, "schemaTableName is null");
         return this.tableMap.get(schemaTableName);
     }
 
+    /**
+     * Cache the metadata of the table's columns, refresh the cache if table columns are already cached.
+     * @param schemaTableName the schema and table name of the table
+     * @param columns the metadata of the table's columns
+     */
     public synchronized void cacheTableColumns(SchemaTableName schemaTableName, List<Column> columns)
     {
         requireNonNull(schemaTableName, "schemaTableName is null");
@@ -79,6 +89,11 @@ public class MetadataCache
         return this.tableColumnsMap.get(schemaTableName);
     }
 
+    /**
+     * Drop the cached columns for all the tables. This should only be used in the scenarios without concurrent access
+     * to the metadata cache (e.g., in pixels-cli).
+     */
+    @Deprecated
     public synchronized void dropCachedColumns()
     {
         this.tableColumnsMap.clear();

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/metadata/MetadataService.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/metadata/MetadataService.java
@@ -38,8 +38,9 @@ import static io.pixelsdb.pixels.common.error.ErrorCode.METADATA_VIEW_NOT_FOUND;
 import static io.pixelsdb.pixels.common.metadata.domain.Permission.convertPermission;
 
 /**
- * Created by hank on 18-6-17.
- * Adapt to GRPC in April 2019.
+ * @author hank
+ * @create 2018-06-17
+ * @update 2019-04 adapt to GRPC.
  */
 public class MetadataService
 {

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/metadata/SchemaTableName.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/metadata/SchemaTableName.java
@@ -22,8 +22,9 @@ package io.pixelsdb.pixels.common.metadata;
 import com.google.common.base.Objects;
 
 /**
- * @author: tao, hank
- * @date: Create in 2018-06-19 14:46
+ * @author tao
+ * @author hank
+ * @create 2018-06-19 14:46
  **/
 public class SchemaTableName
 {

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/SchedulerFactory.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/SchedulerFactory.java
@@ -41,7 +41,7 @@ public class SchedulerFactory
         return instance;
     }
 
-    private Scheduler scheduler;
+    private final Scheduler scheduler;
 
     private SchedulerFactory()
     {

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/transaction/TransService.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/transaction/TransService.java
@@ -23,6 +23,7 @@ import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.pixelsdb.pixels.common.error.ErrorCode;
 import io.pixelsdb.pixels.common.exception.TransException;
+import io.pixelsdb.pixels.common.metadata.MetadataCache;
 import io.pixelsdb.pixels.daemon.TransProto;
 import io.pixelsdb.pixels.daemon.TransServiceGrpc;
 
@@ -68,6 +69,7 @@ public class TransService
         }
         TransContext context = new TransContext(response.getTransId(), response.getTimestamp(), readOnly);
         TransContextCache.Instance().addTransContext(context);
+        MetadataCache.Instance().initCache(context.getTransId());
         return context;
     }
 
@@ -81,6 +83,7 @@ public class TransService
             throw new TransException("failed to commit transaction, error code=" + response.getErrorCode());
         }
         TransContextCache.Instance().setTransCommit(transId);
+        MetadataCache.Instance().dropCache(transId);
         return true;
     }
 
@@ -94,6 +97,7 @@ public class TransService
             throw new TransException("failed to rollback transaction, error code=" + response.getErrorCode());
         }
         TransContextCache.Instance().setTransRollback(transId);
+        MetadataCache.Instance().dropCache(transId);
         return true;
     }
 

--- a/pixels-common/src/test/java/io/pixelsdb/pixels/common/layout/TestCostBasedSplitsIndex.java
+++ b/pixels-common/src/test/java/io/pixelsdb/pixels/common/layout/TestCostBasedSplitsIndex.java
@@ -38,7 +38,7 @@ public class TestCostBasedSplitsIndex
                 ConfigFactory.Instance().getProperty("metadata.server.host"),
                 Integer.parseInt(ConfigFactory.Instance().getProperty("metadata.server.port")));
 
-        CostBasedSplitsIndex index = new CostBasedSplitsIndex(metadataService,
+        CostBasedSplitsIndex index = new CostBasedSplitsIndex(0L, 0L, metadataService,
                 new SchemaTableName("tpch", "orders"),4, 8);
 
         ColumnSet columnSet = new ColumnSet();

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/PixelsPlanner.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/PixelsPlanner.java
@@ -162,7 +162,7 @@ public class PixelsPlanner
         partialAggregationInfo.setGroupKeyColumnIds(aggregation.getGroupKeyColumnIds());
         partialAggregationInfo.setAggregateColumnIds(aggregation.getAggregateColumnIds());
         partialAggregationInfo.setFunctionTypes(aggregation.getFunctionTypes());
-        int numPartitions = PlanOptimizer.Instance().getAggrNumPartitions(aggregatedTable);
+        int numPartitions = PlanOptimizer.Instance().getAggrNumPartitions(this.transId, aggregatedTable);
         partialAggregationInfo.setPartition(numPartitions > 1);
         partialAggregationInfo.setNumPartition(numPartitions);
 
@@ -324,6 +324,7 @@ public class PixelsPlanner
                     // Note: we must use the parent to calculate the number of partitions for post partitioning.
                     postPartition = true;
                     int numPartition = PlanOptimizer.Instance().getJoinNumPartition(
+                            this.transId,
                             parent.get().getJoin().getLeftTable(),
                             parent.get().getJoin().getRightTable(),
                             parent.get().getJoin().getJoinEndian());
@@ -457,7 +458,8 @@ public class PixelsPlanner
                     rightIsBase ? InputStorageInfo : IntermediateStorageInfo,
                     rightPartitionedFiles, IntraWorkerParallelism, rightKeyColumnIds);
 
-            int numPartition = PlanOptimizer.Instance().getJoinNumPartition(leftTable, rightTable, join.getJoinEndian());
+            int numPartition = PlanOptimizer.Instance().getJoinNumPartition(
+                    this.transId, leftTable, rightTable, join.getJoinEndian());
             List<JoinInput> joinInputs = getPartitionedJoinInputs(
                     joinedTable, parent, numPartition, leftTableInfo, rightTableInfo,
                     null, null);
@@ -621,6 +623,7 @@ public class PixelsPlanner
                         // Note: we must use the parent to calculate the number of partitions for post partitioning.
                         postPartition = true;
                         int numPartition = PlanOptimizer.Instance().getJoinNumPartition(
+                                this.transId,
                                 parent.get().getJoin().getLeftTable(),
                                 parent.get().getJoin().getRightTable(),
                                 parent.get().getJoin().getJoinEndian());
@@ -718,6 +721,7 @@ public class PixelsPlanner
                 postPartition = true;
                 // Note: we must use the parent to calculate the number of partitions for post partitioning.
                 int numPartition = PlanOptimizer.Instance().getJoinNumPartition(
+                        this.transId,
                         parent.get().getJoin().getLeftTable(),
                         parent.get().getJoin().getRightTable(),
                         parent.get().getJoin().getJoinEndian());
@@ -859,7 +863,8 @@ public class PixelsPlanner
         {
             // process partitioned join.
             PartitionedJoinOperator joinOperator;
-            int numPartition = PlanOptimizer.Instance().getJoinNumPartition(leftTable, rightTable, join.getJoinEndian());
+            int numPartition = PlanOptimizer.Instance().getJoinNumPartition(
+                    this.transId, leftTable, rightTable, join.getJoinEndian());
             if (childOperator != null)
             {
                 // left side is post partitioned, thus we only partition the right table.
@@ -1236,6 +1241,7 @@ public class PixelsPlanner
             postPartition = true;
             // Note: DO NOT use numPartition as the number of partitions for post partitioning.
             int numPostPartition = PlanOptimizer.Instance().getJoinNumPartition(
+                    this.transId,
                     parent.get().getJoin().getLeftTable(),
                     parent.get().getJoin().getRightTable(),
                     parent.get().getJoin().getJoinEndian());
@@ -1306,8 +1312,8 @@ public class PixelsPlanner
      * @throws InvalidProtocolBufferException
      * @throws MetadataException
      */
-    private List<InputSplit> adjustInputSplitsForBroadcastJoin(Table smallTable, Table largeTable,
-                                                               List<InputSplit> largeInputSplits)
+    private List<InputSplit> adjustInputSplitsForBroadcastJoin(
+            Table smallTable, Table largeTable, List<InputSplit> largeInputSplits)
             throws InvalidProtocolBufferException, MetadataException
     {
         int numWorkers = largeInputSplits.size() / IntraWorkerParallelism;
@@ -1316,8 +1322,8 @@ public class PixelsPlanner
             // There are less than 32 workers, they are not likely to affect the performance.
             return largeInputSplits;
         }
-        double smallSelectivity = PlanOptimizer.Instance().getTableSelectivity(smallTable);
-        double largeSelectivity = PlanOptimizer.Instance().getTableSelectivity(largeTable);
+        double smallSelectivity = PlanOptimizer.Instance().getTableSelectivity(this.transId, smallTable);
+        double largeSelectivity = PlanOptimizer.Instance().getTableSelectivity(this.transId, largeTable);
         if (smallSelectivity >= 0 && largeSelectivity > 0 && smallSelectivity < largeSelectivity)
         {
             // Adjust the input split size if the small table has a lower selectivity.
@@ -1399,20 +1405,20 @@ public class PixelsPlanner
                 if (splitsIndex == null)
                 {
                     logger.debug("splits index not exist in factory, building index...");
-                    splitsIndex = buildSplitsIndex(ordered, splits, schemaTableName);
+                    splitsIndex = buildSplitsIndex(version, ordered, splits, schemaTableName);
                 } else
                 {
-                    int indexVersion = splitsIndex.getVersion();
+                    long indexVersion = splitsIndex.getVersion();
                     if (indexVersion < version)
                     {
                         logger.debug("splits index version is not up-to-date, updating index...");
-                        splitsIndex = buildSplitsIndex(ordered, splits, schemaTableName);
+                        splitsIndex = buildSplitsIndex(version, ordered, splits, schemaTableName);
                     }
                 }
                 SplitPattern bestSplitPattern = splitsIndex.search(columnSet);
                 splitSize = bestSplitPattern.getSplitSize();
                 logger.debug("split size for table '" + table.getTableName() + "': " + splitSize + " from splits index");
-                double selectivity = PlanOptimizer.Instance().getTableSelectivity(table);
+                double selectivity = PlanOptimizer.Instance().getTableSelectivity(this.transId, table);
                 if (selectivity >= 0)
                 {
                     // Increasing split size according to the selectivity.
@@ -1517,7 +1523,7 @@ public class PixelsPlanner
         return splitsBuilder.build();
     }
 
-    private SplitsIndex buildSplitsIndex(Ordered ordered, Splits splits, SchemaTableName schemaTableName)
+    private SplitsIndex buildSplitsIndex(long version, Ordered ordered, Splits splits, SchemaTableName schemaTableName)
             throws MetadataException
     {
         List<String> columnOrder = ordered.getColumnOrder();
@@ -1527,11 +1533,11 @@ public class PixelsPlanner
         switch (indexType)
         {
             case INVERTED:
-                index = new InvertedSplitsIndex(columnOrder, SplitPattern.buildPatterns(columnOrder, splits),
-                        splits.getNumRowGroupInFile());
+                index = new InvertedSplitsIndex(version, columnOrder,
+                        SplitPattern.buildPatterns(columnOrder, splits), splits.getNumRowGroupInFile());
                 break;
             case COST_BASED:
-                index = new CostBasedSplitsIndex(this.metadataService, schemaTableName,
+                index = new CostBasedSplitsIndex(this.transId, version, this.metadataService, schemaTableName,
                         splits.getNumRowGroupInFile(), splits.getNumRowGroupInFile());
                 break;
             default:
@@ -1542,7 +1548,8 @@ public class PixelsPlanner
         return index;
     }
 
-    private ProjectionsIndex buildProjectionsIndex(Ordered ordered, Projections projections, SchemaTableName schemaTableName) {
+    private ProjectionsIndex buildProjectionsIndex(Ordered ordered, Projections projections, SchemaTableName schemaTableName)
+    {
         List<String> columnOrder = ordered.getColumnOrder();
         ProjectionsIndex index;
         index = new InvertedProjectionsIndex(columnOrder, ProjectionPattern.buildPatterns(columnOrder, projections));

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/StarlingPlanner.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/StarlingPlanner.java
@@ -163,7 +163,7 @@ public class StarlingPlanner
         partialAggregationInfo.setGroupKeyColumnIds(aggregation.getGroupKeyColumnIds());
         partialAggregationInfo.setAggregateColumnIds(aggregation.getAggregateColumnIds());
         partialAggregationInfo.setFunctionTypes(aggregation.getFunctionTypes());
-        int numPartitions = PlanOptimizer.Instance().getAggrNumPartitions(aggregatedTable);
+        int numPartitions = PlanOptimizer.Instance().getAggrNumPartitions(this.transId, aggregatedTable);
         partialAggregationInfo.setPartition(numPartitions > 1);
         partialAggregationInfo.setNumPartition(numPartitions);
 
@@ -303,6 +303,7 @@ public class StarlingPlanner
                 // Note: we must use the parent to calculate the number of partitions for post partitioning.
                 postPartition = true;
                 int numPartition = PlanOptimizer.Instance().getJoinNumPartition(
+                        this.transId,
                         parent.get().getJoin().getLeftTable(),
                         parent.get().getJoin().getRightTable(),
                         parent.get().getJoin().getJoinEndian());
@@ -372,7 +373,8 @@ public class StarlingPlanner
                     rightIsBase ? InputStorageInfo : IntermediateStorageInfo,
                     rightPartitionedFiles, IntraWorkerParallelism, rightKeyColumnIds);
 
-            int numPartition = PlanOptimizer.Instance().getJoinNumPartition(leftTable, rightTable, join.getJoinEndian());
+            int numPartition = PlanOptimizer.Instance().getJoinNumPartition(
+                    this.transId, leftTable, rightTable, join.getJoinEndian());
             List<JoinInput> joinInputs = getPartitionedJoinInputs(
                     joinedTable, parent, numPartition, leftTableInfo, rightTableInfo,
                     null, null);
@@ -482,6 +484,7 @@ public class StarlingPlanner
                 postPartition = true;
                 // Note: we must use the parent to calculate the number of partitions for post partitioning.
                 int numPartition = PlanOptimizer.Instance().getJoinNumPartition(
+                        this.transId,
                         parent.get().getJoin().getLeftTable(),
                         parent.get().getJoin().getRightTable(),
                         parent.get().getJoin().getJoinEndian());
@@ -623,7 +626,8 @@ public class StarlingPlanner
         {
             // process partitioned join.
             PartitionedJoinOperator joinOperator;
-            int numPartition = PlanOptimizer.Instance().getJoinNumPartition(leftTable, rightTable, join.getJoinEndian());
+            int numPartition = PlanOptimizer.Instance().getJoinNumPartition(
+                    this.transId, leftTable, rightTable, join.getJoinEndian());
             if (childOperator != null)
             {
                 // left side is post partitioned, thus we only partition the right table.
@@ -1020,6 +1024,7 @@ public class StarlingPlanner
             postPartition = true;
             // Note: DO NOT use numPartition as the number of partitions for post partitioning.
             int numPostPartition = PlanOptimizer.Instance().getJoinNumPartition(
+                    this.transId,
                     parent.get().getJoin().getLeftTable(),
                     parent.get().getJoin().getRightTable(),
                     parent.get().getJoin().getJoinEndian());
@@ -1100,8 +1105,8 @@ public class StarlingPlanner
             // There are less than 32 workers, they are not likely to affect the performance.
             return largeInputSplits;
         }
-        double smallSelectivity = PlanOptimizer.Instance().getTableSelectivity(smallTable);
-        double largeSelectivity = PlanOptimizer.Instance().getTableSelectivity(largeTable);
+        double smallSelectivity = PlanOptimizer.Instance().getTableSelectivity(this.transId, smallTable);
+        double largeSelectivity = PlanOptimizer.Instance().getTableSelectivity(this.transId, largeTable);
         if (smallSelectivity >= 0 && largeSelectivity > 0 && smallSelectivity < largeSelectivity)
         {
             // Adjust the input split size if the small table has a lower selectivity.
@@ -1183,20 +1188,20 @@ public class StarlingPlanner
                 if (splitsIndex == null)
                 {
                     logger.debug("splits index not exist in factory, building index...");
-                    splitsIndex = buildSplitsIndex(ordered, splits, schemaTableName);
+                    splitsIndex = buildSplitsIndex(version, ordered, splits, schemaTableName);
                 } else
                 {
-                    int indexVersion = splitsIndex.getVersion();
+                    long indexVersion = splitsIndex.getVersion();
                     if (indexVersion < version)
                     {
                         logger.debug("splits index version is not up-to-date, updating index...");
-                        splitsIndex = buildSplitsIndex(ordered, splits, schemaTableName);
+                        splitsIndex = buildSplitsIndex(version, ordered, splits, schemaTableName);
                     }
                 }
                 SplitPattern bestSplitPattern = splitsIndex.search(columnSet);
                 splitSize = bestSplitPattern.getSplitSize();
                 logger.debug("split size for table '" + table.getTableName() + "': " + splitSize + " from splits index");
-                double selectivity = PlanOptimizer.Instance().getTableSelectivity(table);
+                double selectivity = PlanOptimizer.Instance().getTableSelectivity(this.transId, table);
                 if (selectivity >= 0)
                 {
                     // Increasing split size according to the selectivity.
@@ -1301,7 +1306,7 @@ public class StarlingPlanner
         return splitsBuilder.build();
     }
 
-    private SplitsIndex buildSplitsIndex(Ordered ordered, Splits splits, SchemaTableName schemaTableName)
+    private SplitsIndex buildSplitsIndex(long version, Ordered ordered, Splits splits, SchemaTableName schemaTableName)
             throws MetadataException
     {
         List<String> columnOrder = ordered.getColumnOrder();
@@ -1311,11 +1316,11 @@ public class StarlingPlanner
         switch (indexType)
         {
             case INVERTED:
-                index = new InvertedSplitsIndex(columnOrder, SplitPattern.buildPatterns(columnOrder, splits),
+                index = new InvertedSplitsIndex(version, columnOrder, SplitPattern.buildPatterns(columnOrder, splits),
                         splits.getNumRowGroupInFile());
                 break;
             case COST_BASED:
-                index = new CostBasedSplitsIndex(this.metadataService, schemaTableName,
+                index = new CostBasedSplitsIndex(this.transId, version, this.metadataService, schemaTableName,
                         splits.getNumRowGroupInFile(), splits.getNumRowGroupInFile());
                 break;
             default:

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/PlanOptimizer.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/PlanOptimizer.java
@@ -350,9 +350,8 @@ public class PlanOptimizer
                     MetadataCache.Instance().getTable(schemaTableName);
             if (metadataTable == null)
             {
-                metadataTable = metadataService.getTable(
-                        table.getSchemaName(), table.getTableName());
-                MetadataCache.Instance().cacheTable(schemaTableName, metadataTable);
+                metadataTable = metadataService.getTable(table.getSchemaName(), table.getTableName());
+                // Issue #485: metadata cache is refreshed when the table is firstly accessed during query parsing.
             }
             return metadataTable.getRowCount();
         }
@@ -389,8 +388,9 @@ public class PlanOptimizer
                     if (columnStats.hasDateStatistics())
                     {
                         PixelsProto.DateStatistic dateStatistic = columnStats.getDateStatistics();
-                        logger.debug("column " + column.getName() + " min: " + dateStatistic.getMinimum() + ", max: " + dateStatistic.getMaximum()
-                        + ", selectivity: " + s + ", columnFilter: " + JSON.toJSONString(columnFilter));
+                        logger.debug(String.format("column %s min: %d, max: %d, selectivity: %f, columnFilter: %s",
+                                column.getName(), dateStatistic.getMinimum(), dateStatistic.getMaximum(),
+                                s, JSON.toJSONString(columnFilter)));
                     }
                     if (s >= 0 && s < selectivity)
                     {
@@ -422,9 +422,8 @@ public class PlanOptimizer
             List<Column> columns = MetadataCache.Instance().getTableColumns(schemaTableName);
             if (columns == null)
             {
-                columns = metadataService.getColumns(
-                        table.getSchemaName(), table.getTableName(), true);
-                MetadataCache.Instance().cacheTableColumns(schemaTableName, columns);
+                columns = metadataService.getColumns(table.getSchemaName(), table.getTableName(), true);
+                // Issue #485: metadata cache is refreshed when the table is firstly accessed during query parsing.
             }
             columnMap = new HashMap<>(columns.size());
             for (Column column : columns)

--- a/pixels-turbo/pixels-worker-vhive/README.md
+++ b/pixels-turbo/pixels-worker-vhive/README.md
@@ -5,7 +5,7 @@ Run `mvn package` to generate the executable JAR file in `target/pixels-worker-v
 
 ## Docker Build
 
-After `docker` installation, use the `Dockerfile` under the root directory of `pixels-worker-hive` to build the docker image:
+After `docker` installation, use the `Dockerfile` under the root directory of `pixels-worker-vhive` to build the docker image:
 
 ```bash
 # run the following command under the root directory of pixels-worker-vhive module


### PR DESCRIPTION
Ensure the metadata cache is not modified except at the beginning of a query.
Make the metadata cache transactional, so that concurrent queries do not interfere with each other.