### PR TITLE
[Issue #491] fix query service and revise comments.

### DIFF
--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/balance/AbsoluteBalancer.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/balance/AbsoluteBalancer.java
@@ -27,8 +27,8 @@ import java.util.*;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Created at: 19-7-28
- * Author: hank
+ * @author hank
+ * @create 2019-07-28
  */
 public class AbsoluteBalancer extends Balancer
 {

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/balance/Balancer.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/balance/Balancer.java
@@ -28,8 +28,8 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Created at: 19-7-28
- * Author: hank
+ * @author hank
+ * @create 2019-07-28
  */
 public abstract class Balancer
 {

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/balance/ReplicaBalancer.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/balance/ReplicaBalancer.java
@@ -28,8 +28,8 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Created at: 19-7-28
- * Author: hank
+ * @author hank
+ * @create 2019-07-28
  */
 public class ReplicaBalancer extends Balancer
 {

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/error/ErrorCode.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/error/ErrorCode.java
@@ -20,8 +20,8 @@
 package io.pixelsdb.pixels.common.error;
 
 /**
- * Created at: 19-4-19
- * Author: hank
+ * @author hank
+ * @create 2019-04-19
  */
 public class ErrorCode
 {

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/exception/BalancerException.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/exception/BalancerException.java
@@ -20,8 +20,8 @@
 package io.pixelsdb.pixels.common.exception;
 
 /**
- * Created at: 18-12-2
- * Author: hank
+ * @author hank
+ * @create 2018-12-02
  */
 public class BalancerException extends Exception
 {

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/exception/CacheException.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/exception/CacheException.java
@@ -20,8 +20,8 @@
 package io.pixelsdb.pixels.common.exception;
 
 /**
- * Created at: 2020-09-10 @ Chavannes.
- * Author: hank
+ * @author hank
+ * @create 2020-09-10 @ Chavannes
  */
 public class CacheException extends Exception
 {

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/exception/FSException.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/exception/FSException.java
@@ -20,8 +20,8 @@
 package io.pixelsdb.pixels.common.exception;
 
 /**
- * Created at: 18-10-17
- * Author: hank
+ * @author hank
+ * @create 2018-10-17
  */
 public class FSException extends Exception
 {

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/exception/InvalidArgumentException.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/exception/InvalidArgumentException.java
@@ -21,7 +21,7 @@ package io.pixelsdb.pixels.common.exception;
 
 /**
  * @author hank
- * @date 5/10/22
+ * @create 2022-05-10
  */
 public class InvalidArgumentException extends RuntimeException
 {

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/exception/StorageException.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/exception/StorageException.java
@@ -22,8 +22,8 @@ package io.pixelsdb.pixels.common.exception;
 import java.io.IOException;
 
 /**
- * Created at: 4/1/22
- * Author: hank
+ * @author hank
+ * @create 2022-04-01
  */
 public class StorageException extends IOException
 {

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/exception/TransException.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/exception/TransException.java
@@ -20,8 +20,8 @@
 package io.pixelsdb.pixels.common.exception;
 
 /**
- * Created at: 20/02/2022
- * Author: hank
+ * @author hank
+ * @create 2022-02-20
  */
 public class TransException extends Exception
 {

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/layout/InvertedProjectionsIndex.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/layout/InvertedProjectionsIndex.java
@@ -22,8 +22,8 @@ package io.pixelsdb.pixels.common.layout;
 import java.util.*;
 
 /**
- * Created at: 20/10/2021
- * Author: hank
+ * @author hank
+ * @create 2021-10-20
  */
 public class InvertedProjectionsIndex implements ProjectionsIndex
 {

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/layout/ProjectionPattern.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/layout/ProjectionPattern.java
@@ -28,8 +28,8 @@ import java.util.List;
 import java.util.Set;
 
 /**
- * Created at: 20/10/2021
- * Author: hank
+ * @author hank
+ * @create 2021-10-20
  */
 public class ProjectionPattern
 {

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/layout/ProjectionsIndex.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/layout/ProjectionsIndex.java
@@ -20,8 +20,8 @@
 package io.pixelsdb.pixels.common.layout;
 
 /**
- * Created at: 20/10/2021
- * Author: hank
+ * @author hank
+ * @create 2021-10-20
  */
 public interface ProjectionsIndex
 {

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/lock/EtcdAutoIncrement.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/lock/EtcdAutoIncrement.java
@@ -27,8 +27,8 @@ import org.apache.logging.log4j.Logger;
 import static io.pixelsdb.pixels.common.utils.Constants.AI_LOCK_PATH_PREFIX;
 
 /**
- * @create 2021-08-29
  * @author hank
+ * @create 2021-08-29
  */
 public class EtcdAutoIncrement
 {

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/metrics/NamedCount.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/metrics/NamedCount.java
@@ -21,7 +21,7 @@ package io.pixelsdb.pixels.common.metrics;
 
 /**
  * @author hank
- * @date 1/2/23
+ * @create 2023-01-03
  */
 public class NamedCount
 {

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/Location.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/Location.java
@@ -33,8 +33,9 @@ import java.net.URI;
  * blocks and each block has its own location. For these storage systems,
  * the file's locations are the locations of the blocks.
  * <p/>
- * @create 2021-08-20
+ *
  * @author hank
+ * @create 2021-08-20
  */
 public class Location
 {

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/Scheduler.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/Scheduler.java
@@ -42,8 +42,7 @@ public interface Scheduler
      * @param transId
      * @throws IOException
      */
-    void executeBatch(PhysicalReader reader, RequestBatch batch, long transId)
-            throws IOException;
+    void executeBatch(PhysicalReader reader, RequestBatch batch, long transId) throws IOException;
 
     class Request implements Comparable<Request>
     {

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/natives/DirectBuffer.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/natives/DirectBuffer.java
@@ -32,8 +32,8 @@ import static com.google.common.base.Preconditions.checkArgument;
  * The buffer that is allocated in off-heap memory. We need more controls on the buffer,
  * so we do not used jdk's DirectByteBuffer.
  * <br/>
- * Created at: 02/02/2023
- * Author: hank
+ * @author hank
+ * @create 2023-02-02
  */
 public class DirectBuffer implements Closeable
 {

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/natives/DirectIoLib.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/natives/DirectIoLib.java
@@ -46,8 +46,8 @@ import static io.pixelsdb.pixels.common.utils.JvmUtils.JavaVersion;
  * We replaced the complex buffer implementation with java direct byte buffer, thus we
  * can directly return the byte buffer to the calling program without memory copying.
  * <p>
- * Created at: 02/02/2023
- * Author: hank
+ * @author hank
+ * @create 2023-02-02
  */
 public class DirectIoLib
 {

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/natives/DirectRandomAccessFile.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/natives/DirectRandomAccessFile.java
@@ -28,8 +28,8 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 /**
  * The random accessible file that can be opened with o_direct flag.
  *
- * Created at: 02/02/2023
- * Author: hank
+ * @author hank
+ * @create 2023-02-02
  */
 public class DirectRandomAccessFile implements PixelsRandomAccessFile
 {

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/natives/MappedRandomAccessFile.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/natives/MappedRandomAccessFile.java
@@ -28,8 +28,8 @@ import static io.pixelsdb.pixels.common.utils.JvmUtils.nativeIsLittleEndian;
 import static io.pixelsdb.pixels.common.utils.JvmUtils.nativeOrder;
 
 /**
- * Created at: 2/21/23
- * Author: hank
+ * @author hank
+ * @create 2023-02-21
  */
 public class MappedRandomAccessFile implements PixelsRandomAccessFile
 {

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/natives/PixelsRandomAccessFile.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/natives/PixelsRandomAccessFile.java
@@ -8,8 +8,9 @@ import java.nio.ByteBuffer;
 /**
  * Random access file in pixels, currently it is read-only.
  * We assume that all the data in this file were written in big endian.
- * Created at: 2/21/23
- * Author: hank
+ *
+ * @author hank
+ * @create 2023-02-21
  */
 public interface PixelsRandomAccessFile extends DataInput, Closeable
 {

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/scheduler/NoopScheduler.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/scheduler/NoopScheduler.java
@@ -35,8 +35,8 @@ import java.util.concurrent.CompletableFuture;
  * If the reader supports asynchronous read, noop scheduler will do asynchronous read.
  * Request sort and request merge are not implemented in noop.
  *
- * Created at: 9/10/21
- * Author: hank
+ * @author hank
+ * @create 2021-09-10
  */
 public class NoopScheduler implements Scheduler
 {

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/scheduler/RateLimitedScheduler.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/scheduler/RateLimitedScheduler.java
@@ -43,8 +43,8 @@ import java.util.Random;
  *     performance stable.
  * </p>
  *
- * Created at: 16/10/2021
- * Author: hank
+ * @author hank
+ * @create 2021-10-16
  */
 public class RateLimitedScheduler extends SortMergeScheduler
 {

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/scheduler/RetryPolicy.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/scheduler/RetryPolicy.java
@@ -31,7 +31,7 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * @author hank
- * @date 8/11/22
+ * @create 2022-08-11
  */
 public class RetryPolicy
 {

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/scheduler/SortMergeScheduler.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/scheduler/SortMergeScheduler.java
@@ -36,8 +36,8 @@ import java.util.concurrent.CompletableFuture;
 /**
  * SortMerge scheduler firstly sorts the requests in the batch by the start offset,
  * then it tries to merge the requests that can be read sequentially from the reader.
- * Created at: 9/12/21
- * Author: hank
+ * @author hank
+ * @create 2021-09-12
  */
 public class SortMergeScheduler implements Scheduler
 {

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/utils/EtcdUtil.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/utils/EtcdUtil.java
@@ -38,13 +38,13 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
 /**
- * @create 2018-10-14
  * @author hank
+ * @create 2018-10-14
  */
 public class EtcdUtil
 {
-    private static Logger logger = LogManager.getLogger(EtcdUtil.class);
-    private static EtcdUtil instance = new EtcdUtil();
+    private static final Logger logger = LogManager.getLogger(EtcdUtil.class);
+    private static final EtcdUtil instance = new EtcdUtil();
     private Client client = null;
     private boolean lockHeld;
 
@@ -174,7 +174,7 @@ public class EtcdUtil
     }
 
     /**
-     * put key-value into etcd with an expire time (by etcd lease).
+     * put key-value into etcd with an expiry time (by etcd lease).
      *
      * @param key
      * @param value

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/utils/MetaDBUtil.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/utils/MetaDBUtil.java
@@ -31,7 +31,7 @@ import java.sql.SQLException;
  */
 public class MetaDBUtil
 {
-    private static MetaDBUtil INSTANCE = new MetaDBUtil();
+    private static final MetaDBUtil INSTANCE = new MetaDBUtil();
 
     public static MetaDBUtil Instance()
     {

--- a/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/PixelsCoordinator.java
+++ b/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/PixelsCoordinator.java
@@ -20,8 +20,8 @@
 package io.pixelsdb.pixels.daemon;
 
 /**
- * Created at: 19-7-28
- * Author: hank
+ * @author hank
+ * @create 2019-07-28
  */
 public class PixelsCoordinator
 {

--- a/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/PixelsGuard.java
+++ b/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/PixelsGuard.java
@@ -20,8 +20,8 @@
 package io.pixelsdb.pixels.daemon;
 
 /**
- * Created at: 19-7-28
- * Author: hank
+ * @author hank
+ * @create 2019-07-28
  */
 public class PixelsGuard
 {

--- a/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/cache/CacheManager.java
+++ b/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/cache/CacheManager.java
@@ -252,8 +252,8 @@ public class CacheManager
                                     }
                                 } else if (cacheStatus.get() == CacheNodeStatus.UPDATING.StatusCode)
                                 {
-                                    // The local cache is been updating, ignore the new version.
-                                    logger.warn("The local cache is been updating for version (" + localCacheVersion + "), " +
+                                    // The local cache is updating, ignore the new version.
+                                    logger.warn("The local cache is updating for version (" + localCacheVersion + "), " +
                                             "ignore the new cache version (" + version + ").");
                                 } else
                                 {

--- a/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/turbo/QueryScheduleQueues.java
+++ b/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/turbo/QueryScheduleQueues.java
@@ -26,6 +26,7 @@ import java.util.concurrent.ArrayBlockingQueue;
 
 /**
  * This is only used by pixels-turbo to queue the running queries and choose the query executor.
+ *
  * @author hank
  * @create 2022-10-24
  */

--- a/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/turbo/QueryScheduleServiceImpl.java
+++ b/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/turbo/QueryScheduleServiceImpl.java
@@ -67,7 +67,7 @@ public class QueryScheduleServiceImpl extends QueryScheduleServiceGrpc.QuerySche
                     TimeUnit.MILLISECONDS.sleep(10);
                 } catch (InterruptedException e)
                 {
-                    log.error("interrupted while waiting for enqueue adaptively.");
+                    log.error("interrupted while waiting for enqueue adaptively");
                 }
             }
         }

--- a/proto/pixels.proto
+++ b/proto/pixels.proto
@@ -27,15 +27,15 @@ package pixels.proto;
 option java_package = "io.pixelsdb.pixels.core";
 option java_outer_classname = "PixelsProto";
 
-// Row Group: A logical horizontal partitioning of the data into rows. There is no physical
-//            structure that is guaranteed for a row group. A row group consists of a column
-//            chunk for each column in the dataset.
-// Column Chunk: A chunk of the data for a particular column. These live in a particular row group and is guaranteed to
-//               be contiguous in the file.
-// Pixel: A column chunk is divided into several pixels. A pixel is conceptually an smallest indivisible unit in terms
-//        of indexing. Each pixel contains a fixed num (e.g., 10000) of values inside.
+//     Row Group: The logical and horizontal partition of a table.
+//                Row group has no physical boundaries in the file.
+//                Data in a row group is stored in columns.
+//  Column Chunk: The chunk of data for a column in a row group.
+//                A column chunk is stored sequentially in the file.
+//         Pixel: Each column chunk contains a sequence of 'pixels'.
+//                Each pixel contains a number (e.g., 10000) of values.
 
-// The contents of the file tail that must be serialized.
+// The content of the file tail that must be serialized.
 message FileTail {
     optional Footer footer = 1;
     optional PostScript postscript = 2;
@@ -44,11 +44,11 @@ message FileTail {
 }
 
 // PostScript
-// version: pixels file version
+// version: Pixels file version
 // contentLength: file content length (everything except FileTail)
-// number of rows: number of rows in the file
-// compression: compression kind. currently USELESS
-// compressionBlockSize: compression block size. currently USELESS
+// numberOfRows: number of rows in the file
+// compression: compression kind, currently NOT USED
+// compressionBlockSize: compression block size, currently NOT USED
 // pixelStride: the maximum number of rows in a pixel
 // magic: "PIXELS"
 message PostScript {

--- a/proto/pixels.proto
+++ b/proto/pixels.proto
@@ -27,7 +27,7 @@ package pixels.proto;
 option java_package = "io.pixelsdb.pixels.core";
 option java_outer_classname = "PixelsProto";
 
-//     Row Group: The logical and horizontal partition of a table.
+//     Row Group: A logical and horizontal partition of a table.
 //                Row group has no physical boundaries in the file.
 //                Data in a row group is stored in columns.
 //  Column Chunk: The chunk of data for a column in a row group.


### PR DESCRIPTION
Avoid unknown query status when there are concurrent updates on the queues and results.