### PR TITLE
[Issue #498] remove the orders array from StringColumnReader in C++.

### DIFF
--- a/cpp/pixels-reader/pixels-core/include/reader/StringColumnReader.h
+++ b/cpp/pixels-reader/pixels-core/include/reader/StringColumnReader.h
@@ -34,7 +34,6 @@ private:
     int startsOffset;
 
 	int * starts;
-	int * orders;
     int startsLength;
     /**
      * In this method, we have reduced most of significant memory copies.


### PR DESCRIPTION
Remove order in buffer read in Pixels C++