### PR TITLE
[Issue #512] Fix the out-of-range issue caused by splitting a row

### DIFF
--- a/pixels-cli/src/main/java/io/pixelsdb/pixels/cli/load/PixelsConsumer.java
+++ b/pixels-cli/src/main/java/io/pixelsdb/pixels/cli/load/PixelsConsumer.java
@@ -152,7 +152,8 @@ public class PixelsConsumer extends Consumer
                             try
                             {
                                 int valueIdx = orderMapping[i];
-                                if (colsInLine[valueIdx].isEmpty() ||
+                                if (valueIdx >= colsInLine.length ||
+                                        colsInLine[valueIdx].isEmpty() ||
                                         colsInLine[valueIdx].equalsIgnoreCase("\\N"))
                                 {
                                     columnVectors[i].addNull();


### PR DESCRIPTION
Fix the out-of-range issue caused by splitting a row which has the null value