### PR TITLE
RenameSuggestion

### DIFF
--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/layout/InvertedSplitsIndex.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/layout/InvertedSplitsIndex.java
@@ -55,7 +55,7 @@ public class InvertedSplitsIndex implements SplitsIndex
             BitSet bitMap = new BitSet(this.querySplitPatterns.size());
             for (int i = 0; i < this.querySplitPatterns.size(); ++i)
             {
-                if (this.querySplitPatterns.get(i).contaiansColumn(column))
+                if (this.querySplitPatterns.get(i).containsColumn(column))
                 {
                     bitMap.set(i, true);
                 }

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/layout/SplitPattern.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/layout/SplitPattern.java
@@ -66,7 +66,7 @@ public class SplitPattern
         return splitSize;
     }
 
-    public boolean contaiansColumn(String column)
+    public boolean containsColumn(String column)
     {
         return this.columnSet.contains(column);
     }


### PR DESCRIPTION
### Renaming Suggestion of Method Names to Make Them More Descriptive
---
**Description**
---

We have developed a tool (**NameSpotter**) for identifying non-descriptive method names, and using this tool we find a non-descriptive method name in your repository:

```java
/* Non-descriptive Method Name in pixels-common/src/main/java/io/pixelsdb/pixels/common/layout/SplitPattern.java */
    public boolean contaiansColumn(String column)
    {
        return this.columnSet.contains(column);
    }
```
We consider "contaiansColumn" as non-descriptive because it contains a typo, i.e., "contaians" should be "contains".  We have corrected it (including all the occurrence in other file) and submitted a pull request.

Do you agree with the judgment? 

- If not, could you please leave your valuable opinion?

- If you do agree, the relevant modification has been submitted as a PR, and thanks for your precious time to consider it.