### PR TITLE
[Issue #471] pixels reader c++ code refactor

### DIFF
--- a/cpp/include/PixelsReadLocalState.hpp
+++ b/cpp/include/PixelsReadLocalState.hpp
@@ -31,8 +31,6 @@ struct PixelsReadLocalState : public LocalTableFunctionState {
     idx_t next_batch_index;
     std::string next_file_name;
     std::string curr_file_name;
-    // the state when PixelsScanInitLocal calls
-    bool is_first_state;
     // the state when next_file_index is none. In this state we only readBatch the curr_file.
     bool is_last_state;
 };

--- a/cpp/include/PixelsReadLocalState.hpp
+++ b/cpp/include/PixelsReadLocalState.hpp
@@ -31,8 +31,6 @@ struct PixelsReadLocalState : public LocalTableFunctionState {
     idx_t next_batch_index;
     std::string next_file_name;
     std::string curr_file_name;
-    // the state when next_file_index is none. In this state we only readBatch the curr_file.
-    bool is_last_state;
 };
 
 }

--- a/cpp/include/PixelsReadLocalState.hpp
+++ b/cpp/include/PixelsReadLocalState.hpp
@@ -16,6 +16,18 @@
 namespace duckdb {
 
 struct PixelsReadLocalState : public LocalTableFunctionState {
+    PixelsReadLocalState() {
+        curr_file_index = 0;
+        next_file_index = 0;
+        curr_batch_index = 0;
+        next_batch_index = 0;
+        rowOffset = 0;
+        currPixelsRecordReader = nullptr;
+        nextPixelsRecordReader = nullptr;
+        vectorizedRowBatch = nullptr;
+        currReader = nullptr;
+        nextReader = nullptr;
+    }
 	shared_ptr<PixelsRecordReader> currPixelsRecordReader;
     shared_ptr<PixelsRecordReader> nextPixelsRecordReader;
 	// this is used for storing row batch results.

--- a/cpp/include/PixelsScanFunction.hpp
+++ b/cpp/include/PixelsScanFunction.hpp
@@ -82,7 +82,8 @@ public:
 	static unique_ptr<LocalTableFunctionState>
 	PixelsScanInitLocal(ExecutionContext &context, TableFunctionInitInput &input, GlobalTableFunctionState *gstate_p);
 	static bool PixelsParallelStateNext(ClientContext &context, const PixelsReadBindData &bind_data,
-	                                     PixelsReadLocalState &scan_data, PixelsReadGlobalState &parallel_state);
+	                                     PixelsReadLocalState &scan_data, PixelsReadGlobalState &parallel_state,
+                                         bool is_init_state = false);
     static PixelsReaderOption GetPixelsReaderOption(PixelsReadLocalState &local_state, PixelsReadGlobalState &global_state);
 private:
 	static void TransformDuckdbType(const std::shared_ptr<TypeDescription>& type,

--- a/cpp/include/PixelsScanFunction.hpp
+++ b/cpp/include/PixelsScanFunction.hpp
@@ -83,6 +83,7 @@ public:
 	PixelsScanInitLocal(ExecutionContext &context, TableFunctionInitInput &input, GlobalTableFunctionState *gstate_p);
 	static bool PixelsParallelStateNext(ClientContext &context, const PixelsReadBindData &bind_data,
 	                                     PixelsReadLocalState &scan_data, PixelsReadGlobalState &parallel_state);
+    static PixelsReaderOption GetPixelsReaderOption(PixelsReadLocalState &local_state, PixelsReadGlobalState &global_state);
 private:
 	static void TransformDuckdbType(const std::shared_ptr<TypeDescription>& type,
 	                         vector<LogicalType> &return_types);

--- a/cpp/pixels-reader/pixels-core/include/vector/BinaryColumnVector.h
+++ b/cpp/pixels-reader/pixels-core/include/vector/BinaryColumnVector.h
@@ -36,7 +36,7 @@ public:
     * Use this constructor by default. All column vectors
     * should normally be the default size.
     */
-    BinaryColumnVector(int len = VectorizedRowBatch::DEFAULT_SIZE, bool encoding = false);
+    explicit BinaryColumnVector(uint64_t len = VectorizedRowBatch::DEFAULT_SIZE, bool encoding = false);
 
 	~BinaryColumnVector();
     /**
@@ -48,6 +48,7 @@ public:
      * @param length     length of source byte sequence
      */
     void setRef(int elementNum, uint8_t * const & sourceBuf, int start, int length);
+    void * current() override;
     void close() override;
     void print(int rowCount) override;
 };

--- a/cpp/pixels-reader/pixels-core/include/vector/ColumnVector.h
+++ b/cpp/pixels-reader/pixels-core/include/vector/ColumnVector.h
@@ -41,16 +41,19 @@ public:
       * length is the capacity, i.e., maximum number of values, of this column vector
       * <b>DO NOT</b> modify it or used it as the number of values in-used.
       */
-    int length;
-    int writeIndex;
-    long memoryUsage;
+    uint64_t length;
+    uint64_t writeIndex;
+    uint64_t readIndex;
+    uint64_t memoryUsage;
 	bool closed;
 	bool encoding;
-    ColumnVector() = default;
-    explicit ColumnVector(int len, bool encoding);
-
+    explicit ColumnVector(uint64_t len, bool encoding);
+    void increment(uint64_t size);              // increment the readIndex
+    bool isFull();                         // if the readIndex reaches length
+    uint64_t position();                   // return readIndex
     virtual void close();
     virtual void reset();
+    virtual void * current() = 0;              // get the pointer in the current location
     virtual void print(int rowCount);      // this is only used for debug
 };
 

--- a/cpp/pixels-reader/pixels-core/include/vector/DateColumnVector.h
+++ b/cpp/pixels-reader/pixels-core/include/vector/DateColumnVector.h
@@ -21,8 +21,9 @@ public:
     * Use this constructor by default. All column vectors
     * should normally be the default size.
 	 */
-	DateColumnVector(int len = VectorizedRowBatch::DEFAULT_SIZE, bool encoding = false);
+	explicit DateColumnVector(uint64_t len = VectorizedRowBatch::DEFAULT_SIZE, bool encoding = false);
 	~DateColumnVector();
+    void * current() override;
 	void print(int rowCount) override;
 	void close() override;
 	void set(int elementNum, int days);

--- a/cpp/pixels-reader/pixels-core/include/vector/DecimalColumnVector.h
+++ b/cpp/pixels-reader/pixels-core/include/vector/DecimalColumnVector.h
@@ -19,10 +19,11 @@ public:
     * should normally be the default size.
     */
     DecimalColumnVector(int precision, int scale, bool encoding = false);
-    DecimalColumnVector(int len, int precision, int scale, bool encoding = false);
+    DecimalColumnVector(uint64_t len, int precision, int scale, bool encoding = false);
     ~DecimalColumnVector();
     void print(int rowCount) override;
     void close() override;
+    void * current() override;
 	int getPrecision();
 	int getScale();
 };

--- a/cpp/pixels-reader/pixels-core/include/vector/LongColumnVector.h
+++ b/cpp/pixels-reader/pixels-core/include/vector/LongColumnVector.h
@@ -16,9 +16,12 @@ public:
     * Use this constructor by default. All column vectors
     * should normally be the default size.
     */
-    LongColumnVector(int len = VectorizedRowBatch::DEFAULT_SIZE, bool encoding = false, bool isLong = true);
+    explicit LongColumnVector(uint64_t len = VectorizedRowBatch::DEFAULT_SIZE, bool encoding = false, bool isLong = true);
+    void * current() override;
 	~LongColumnVector();
     void print(int rowCount) override;
     void close() override;
+private:
+    bool isLong;
 };
 #endif //PIXELS_LONGCOLUMNVECTOR_H

--- a/cpp/pixels-reader/pixels-core/include/vector/VectorizedRowBatch.h
+++ b/cpp/pixels-reader/pixels-core/include/vector/VectorizedRowBatch.h
@@ -28,17 +28,16 @@ public:
     static int DEFAULT_SIZE;
     int maxSize;                                       // capacity, i.e. the maximum number of rows can be stored in this row batch
 
-    // If this is true, then there is no data in the batch -- we have hit the end of input
-    bool endOfFile;
     explicit VectorizedRowBatch(int nCols, int size = DEFAULT_SIZE);
 	~VectorizedRowBatch();
 	void close();
     int getMaxSize();
+    uint64_t position();
     int count();
     bool isEmpty();
     bool isFull();
     int freeSlots();
-
+    bool isEndOfFile();
 private:
 	bool closed;
 };

--- a/cpp/pixels-reader/pixels-core/lib/reader/PixelsRecordReaderImpl.cpp
+++ b/cpp/pixels-reader/pixels-core/lib/reader/PixelsRecordReaderImpl.cpp
@@ -162,7 +162,7 @@ std::shared_ptr<VectorizedRowBatch> PixelsRecordReaderImpl::readBatch(bool reuse
     if(resultRowBatch == nullptr) {
         resultRowBatch = resultSchema->createRowBatch(curBatchSize, resultColumnsEncoded);
     }
-    resultRowBatch->rowCount = 0;
+
     auto columnVectors = resultRowBatch->cols;
     if(filterMask != nullptr) {
         filterMask->set();
@@ -217,7 +217,6 @@ std::shared_ptr<VectorizedRowBatch> PixelsRecordReaderImpl::readBatch(bool reuse
         } else {
             // if end of file, set result vectorized row batch endOfFile
             // TODO: set checkValid to false!
-            resultRowBatch->endOfFile = true;
             endOfFile = true;
         }
         curRowInRG = 0;
@@ -406,8 +405,7 @@ std::shared_ptr<VectorizedRowBatch> PixelsRecordReaderImpl::createEmptyEOFRowBat
 	auto emptySchema = TypeDescription::createSchema(
 	    std::vector<std::shared_ptr<pixels::proto::Type>>());
 	auto emptyRowBatch = emptySchema->createRowBatch(0);
-	emptyRowBatch->rowCount = size;
-	emptyRowBatch->endOfFile = true;
+	emptyRowBatch->rowCount = 0;
 	return emptyRowBatch;
 }
 bool PixelsRecordReaderImpl::isEndOfFile() {
@@ -420,6 +418,7 @@ void PixelsRecordReaderImpl::close() {
 	for(const auto& reader: readers) {
 		reader->close();
 	}
+    resultRowBatch->close();
 	readers.clear();
 	rowGroupFooters.clear();
 	includedColumnTypes.clear();

--- a/cpp/pixels-reader/pixels-core/lib/vector/BinaryColumnVector.cpp
+++ b/cpp/pixels-reader/pixels-core/lib/vector/BinaryColumnVector.cpp
@@ -4,7 +4,7 @@
 
 #include "vector/BinaryColumnVector.h"
 
-BinaryColumnVector::BinaryColumnVector(int len, bool encoding): ColumnVector(len, encoding) {
+BinaryColumnVector::BinaryColumnVector(uint64_t len, bool encoding): ColumnVector(len, encoding) {
     posix_memalign(reinterpret_cast<void **>(&vector), 32,
                    len * sizeof(duckdb::string_t));
     memoryUsage += (long) sizeof(uint8_t) * len;
@@ -38,4 +38,12 @@ BinaryColumnVector::~BinaryColumnVector() {
 	if(!closed) {
 		BinaryColumnVector::close();
 	}
+}
+
+void * BinaryColumnVector::current() {
+    if(vector == nullptr) {
+        return nullptr;
+    } else {
+        return vector + readIndex;
+    }
 }

--- a/cpp/pixels-reader/pixels-core/lib/vector/ColumnVector.cpp
+++ b/cpp/pixels-reader/pixels-core/lib/vector/ColumnVector.cpp
@@ -4,8 +4,9 @@
 
 #include "vector/ColumnVector.h"
 
-ColumnVector::ColumnVector(int len, bool encoding) {
+ColumnVector::ColumnVector(uint64_t len, bool encoding) {
     writeIndex = 0;
+    readIndex = 0;
     length = len;
 	this->encoding = encoding;
     memoryUsage = len + sizeof(int) * 3 + 4;
@@ -22,11 +23,24 @@ void ColumnVector::close() {
 
 void ColumnVector::reset() {
     writeIndex = 0;
+    readIndex = 0;
     // TODO: reset other variables
 }
 
 void ColumnVector::print(int rowCount) {
     throw InvalidArgumentException("This columnVector doesn't implement this function.");
+}
+
+void ColumnVector::increment(uint64_t size) {
+    readIndex += size;
+}
+
+bool ColumnVector::isFull() {
+    return readIndex >= length;
+}
+
+uint64_t ColumnVector::position() {
+    return readIndex;
 }
 
 

--- a/cpp/pixels-reader/pixels-core/lib/vector/DateColumnVector.cpp
+++ b/cpp/pixels-reader/pixels-core/lib/vector/DateColumnVector.cpp
@@ -4,7 +4,7 @@
 
 #include "vector/DateColumnVector.h"
 
-DateColumnVector::DateColumnVector(int len, bool encoding): ColumnVector(len, encoding) {
+DateColumnVector::DateColumnVector(uint64_t len, bool encoding): ColumnVector(len, encoding) {
 	if(encoding) {
         posix_memalign(reinterpret_cast<void **>(&dates), 32,
                        len * sizeof(int32_t));
@@ -49,4 +49,12 @@ void DateColumnVector::set(int elementNum, int days) {
 	}
 	dates[elementNum] = days;
 	// TODO: isNull
+}
+
+void * DateColumnVector::current() {
+    if(dates == nullptr) {
+        return nullptr;
+    } else {
+        return dates + readIndex;
+    }
 }

--- a/cpp/pixels-reader/pixels-core/lib/vector/DecimalColumnVector.cpp
+++ b/cpp/pixels-reader/pixels-core/lib/vector/DecimalColumnVector.cpp
@@ -18,16 +18,16 @@
  * Author: hank
  */
 
-DecimalColumnVector::DecimalColumnVector(int precision, int scale, bool encoding) {
+DecimalColumnVector::DecimalColumnVector(int precision, int scale, bool encoding): ColumnVector(VectorizedRowBatch::DEFAULT_SIZE, encoding) {
     DecimalColumnVector(VectorizedRowBatch::DEFAULT_SIZE, precision, scale, encoding);
 }
 
-DecimalColumnVector::DecimalColumnVector(int len, int precision, int scale, bool encoding): ColumnVector(len, encoding) {
+DecimalColumnVector::DecimalColumnVector(uint64_t len, int precision, int scale, bool encoding): ColumnVector(len, encoding) {
 	// decimal column vector has no encoding so we don't allocate memory to this->vector
 	this->vector = nullptr;
     this->precision = precision;
     this->scale = scale;
-    memoryUsage += (long) sizeof(long) * len;
+    memoryUsage += (uint64_t) sizeof(uint64_t) * len;
 }
 
 void DecimalColumnVector::close() {
@@ -50,6 +50,13 @@ DecimalColumnVector::~DecimalColumnVector() {
     }
 }
 
+void * DecimalColumnVector::current() {
+    if(vector == nullptr) {
+        return nullptr;
+    } else {
+        return vector + readIndex;
+    }
+}
 
 int DecimalColumnVector::getPrecision() {
 	return precision;

--- a/cpp/pixels-reader/pixels-core/lib/vector/LongColumnVector.cpp
+++ b/cpp/pixels-reader/pixels-core/lib/vector/LongColumnVector.cpp
@@ -4,7 +4,7 @@
 
 #include "vector/LongColumnVector.h"
 
-LongColumnVector::LongColumnVector(int len, bool encoding, bool isLong): ColumnVector(len, encoding) {
+LongColumnVector::LongColumnVector(uint64_t len, bool encoding, bool isLong): ColumnVector(len, encoding) {
 	if(encoding) {
 		if(isLong) {
             posix_memalign(reinterpret_cast<void **>(&longVector), 32,
@@ -20,6 +20,7 @@ LongColumnVector::LongColumnVector(int len, bool encoding, bool isLong): ColumnV
 		intVector = nullptr;
 	}
 
+    this->isLong = isLong;
     memoryUsage += (long) sizeof(long) * len;
 }
 
@@ -49,4 +50,20 @@ LongColumnVector::~LongColumnVector() {
 	if(!closed) {
 		LongColumnVector::close();
 	}
+}
+
+void * LongColumnVector::current() {
+    if(isLong) {
+        if(longVector == nullptr) {
+            return nullptr;
+        } else {
+            return longVector + readIndex;
+        }
+    } else {
+        if(intVector == nullptr) {
+            return nullptr;
+        } else {
+            return intVector + readIndex;
+        }
+    }
 }

--- a/cpp/pixels-reader/pixels-core/lib/vector/VectorizedRowBatch.cpp
+++ b/cpp/pixels-reader/pixels-core/lib/vector/VectorizedRowBatch.cpp
@@ -76,7 +76,6 @@ int VectorizedRowBatch::freeSlots() {
 void VectorizedRowBatch::close() {
 	if(!closed) {
 		maxSize = 0;
-		endOfFile = false;
 		for(const auto& col : cols) {
 			col->close();
 		}
@@ -84,3 +83,20 @@ void VectorizedRowBatch::close() {
 		closed = true;
 	}
 }
+
+bool VectorizedRowBatch::isEndOfFile() {
+    bool isEndOfFile = closed;
+    if(!cols.empty()) {
+        isEndOfFile = cols.at(0)->isFull();
+    }
+    return isEndOfFile;
+}
+
+uint64_t VectorizedRowBatch::position() {
+    uint64_t position = 0;
+    if(!cols.empty()) {
+        position = cols.at(0)->position();
+    }
+    return position;
+}
+


### PR DESCRIPTION
PixelsScanFunction is messy. Refactor the code to make it clearer. The fixes are:
1. Add `readIndex` for column vector
2. Move all change state logic to PixelsParallelStateNext
I have already verify its correctness and it doesn't affect the performance.