### PR TITLE
[Issue #531] support configurable endianness

### DIFF
--- a/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsPhysicalReader.java
+++ b/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsPhysicalReader.java
@@ -25,6 +25,7 @@ import io.pixelsdb.pixels.common.physical.Storage;
 import io.pixelsdb.pixels.core.PixelsProto;
 
 import java.io.IOException;
+import java.nio.ByteOrder;
 
 /**
  * @author guodong
@@ -48,7 +49,7 @@ public class PixelsPhysicalReader
             {
                 long fileLen = physicalReader.getFileLength();
                 physicalReader.seek(fileLen - Long.BYTES);
-                long fileTailOffset = physicalReader.readLong();
+                long fileTailOffset = physicalReader.readLong(ByteOrder.BIG_ENDIAN);
                 int fileTailLength = (int) (fileLen - fileTailOffset - Long.BYTES);
                 physicalReader.seek(fileTailOffset);
                 byte[] fileTailBuffer = new byte[fileTailLength];

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/PhysicalReader.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/PhysicalReader.java
@@ -22,6 +22,7 @@ package io.pixelsdb.pixels.common.physical;
 import java.io.Closeable;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -33,8 +34,21 @@ public interface PhysicalReader extends Closeable
 {
     long getFileLength() throws IOException;
 
+    /**
+     * Set the current offset to the desired value.
+     * @param desired the desired offset
+     * @throws IOException
+     */
     void seek(long desired) throws IOException;
 
+    /**
+     * Read a byte buffer of the given length from the current offset. The byte order
+     * of the byte buffer is default byte order of {@link ByteBuffer}. Please check and
+     * reset it if necessary.
+     * @param length the number of bytes to read
+     * @return the byte buffer been read
+     * @throws IOException
+     */
     ByteBuffer readFully(int length) throws IOException;
 
     void readFully(byte[] buffer) throws IOException;
@@ -61,9 +75,21 @@ public interface PhysicalReader extends Closeable
         throw new UnsupportedOperationException("asynchronous read is not supported for " + getStorageScheme().name());
     }
 
-    long readLong() throws IOException;
+    /**
+     * Read an eight-byte signed integer from the current offset using the specified byte order.
+     * @param byteOrder the byte order
+     * @return the integer been read
+     * @throws IOException
+     */
+    long readLong(ByteOrder byteOrder) throws IOException;
 
-    int readInt() throws IOException;
+    /**
+     * Read a four-byte signed integer from the current offset using the specified byte order.
+     * @param byteOrder the byte order
+     * @return the integer been read
+     * @throws IOException
+     */
+    int readInt(ByteOrder byteOrder) throws IOException;
 
     void close() throws IOException;
 
@@ -78,7 +104,7 @@ public interface PhysicalReader extends Closeable
     /**
      * For a file or object in the storage, it may have one or more
      * blocks. Each block has its unique id. This method returns the
-     * block id of the current block that is been reading.
+     * block id of the current block that is being reading.
      *
      * For local fs, each file has only one block id, which is also
      * the file id.

--- a/pixels-common/src/main/resources/pixels.properties
+++ b/pixels-common/src/main/resources/pixels.properties
@@ -54,21 +54,29 @@ cache.read.direct=false
 
 ###### storage engine settings ######
 
-### pixels reader and writer settings ###
-# properties for pixels writer
+### pixels reader, writer, and compactor settings ###
+# the pixels stride (number of values in a pixel) for pixels writer
 pixel.stride=10000
+# the row group size in bytes for pixels writer
 row.group.size=268435456
-# The alignment is for SIMD and its unit is byte
+# the chunk alignment for pixels writer, it is for SIMD and its unit is byte
 column.chunk.alignment=32
+# whether column chunks are encoded in pixels writer
 column.chunk.encoding=true
+# the endianness used in pixels writer, LE = little-endian, BE = big-endian
+column.chunk.endiannes=LE
+# the block size for block-wise storage systems such as HDFS
 block.size=2147483648
+# the number of replications of each block for block-wise storage systems such as HDFS
 block.replication=1
+# for block-wise storage systems, whether padding the leftover space in current block
 block.padding=true
-compression.block.size=1
+# the number of bytes to be compressed as a block using heavy compression algorithms
+compression.block.size=1048576
+# for pixels compactor how many row groups are compacted into one file
+compact.factor=32
 # row batch size for pixels record reader, default value is 10000
 row.batch.size=10000
-# how many row groups are compacted into one file
-compact.factor=32
 
 ### file storage and I/O ###
 # the scheme of the storage systems that are enabled, e.g., hdfs,file,s3,gcs,minio,redis

--- a/pixels-common/src/main/resources/pixels.properties
+++ b/pixels-common/src/main/resources/pixels.properties
@@ -63,8 +63,8 @@ row.group.size=268435456
 column.chunk.alignment=32
 # whether column chunks are encoded in pixels writer
 column.chunk.encoding=true
-# the endianness used in pixels writer, LE = little-endian, BE = big-endian
-column.chunk.endiannes=LE
+# the little-endian is used on the column chunks in pixels writer
+column.chunk.little.endian=true
 # the block size for block-wise storage systems such as HDFS
 block.size=2147483648
 # the number of replications of each block for block-wise storage systems such as HDFS

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/PixelsReaderImpl.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/PixelsReaderImpl.java
@@ -38,6 +38,7 @@ import org.apache.logging.log4j.Logger;
 import javax.annotation.concurrent.NotThreadSafe;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Random;
@@ -171,7 +172,7 @@ public class PixelsReaderImpl implements PixelsReader
                 // get FileTail
                 long fileLen = fsReader.getFileLength();
                 fsReader.seek(fileLen - Long.BYTES);
-                long fileTailOffset = fsReader.readLong();
+                long fileTailOffset = fsReader.readLong(ByteOrder.BIG_ENDIAN);
                 int fileTailLength = (int) (fileLen - fileTailOffset - Long.BYTES);
                 fsReader.seek(fileTailOffset);
                 ByteBuffer fileTailBuffer = fsReader.readFully(fileTailLength);

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/PixelsWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/PixelsWriter.java
@@ -29,8 +29,7 @@ import java.io.IOException;
  *
  * @author guodong
  */
-public interface PixelsWriter
-        extends Closeable
+public interface PixelsWriter extends Closeable
 {
     /**
      * Add row batch into the file that is not hash partitioned.

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/PixelsWriterImpl.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/PixelsWriterImpl.java
@@ -69,6 +69,22 @@ public class PixelsWriterImpl implements PixelsWriter
 {
     private static final Logger LOGGER = LogManager.getLogger(PixelsWriterImpl.class);
 
+    static final ByteOrder WRITER_ENDIAN;
+
+    static
+    {
+        boolean littleEndian = Boolean.parseBoolean(
+                ConfigFactory.Instance().getProperty("column.chunk.little.endian"));
+        if (littleEndian)
+        {
+            WRITER_ENDIAN = ByteOrder.LITTLE_ENDIAN;
+        }
+        else
+        {
+            WRITER_ENDIAN = ByteOrder.BIG_ENDIAN;
+        }
+    }
+
     private final TypeDescription schema;
     private final int pixelStride;
     private final int rowGroupSize;
@@ -144,7 +160,7 @@ public class PixelsWriterImpl implements PixelsWriter
         fileColStatRecorders = new StatsRecorder[children.size()];
         for (int i = 0; i < children.size(); ++i)
         {
-            columnWriters[i] = newColumnWriter(children.get(i), pixelStride, encoding);
+            columnWriters[i] = newColumnWriter(children.get(i), pixelStride, encoding, WRITER_ENDIAN);
             fileColStatRecorders[i] = StatsRecorder.create(children.get(i));
         }
 
@@ -611,7 +627,7 @@ public class PixelsWriterImpl implements PixelsWriter
              * We temporarily fix this problem by creating a new column writer for each row group.
              */
             // writer.reset();
-            columnWriters[i] = newColumnWriter(children.get(i), pixelStride, encoding);
+            columnWriters[i] = newColumnWriter(children.get(i), pixelStride, encoding, WRITER_ENDIAN);
         }
 
         // put curRowGroupIndex into rowGroupFooter

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/PixelsWriterImpl.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/PixelsWriterImpl.java
@@ -38,6 +38,7 @@ import org.apache.logging.log4j.Logger;
 import javax.annotation.concurrent.NotThreadSafe;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/compactor/PixelsCompactor.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/compactor/PixelsCompactor.java
@@ -34,6 +34,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.TimeZone;
@@ -250,7 +251,7 @@ public class PixelsCompactor
                 // get FileTail
                 long fileLen = fsReader.getFileLength();
                 fsReader.seek(fileLen - Long.BYTES);
-                long fileTailOffset = fsReader.readLong();
+                long fileTailOffset = fsReader.readLong(ByteOrder.BIG_ENDIAN);
                 int fileTailLength = (int) (fileLen - fileTailOffset - Long.BYTES);
                 fsReader.seek(fileTailOffset);
                 byte[] fileTailBuffer = new byte[fileTailLength];

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/encoding/Dictionary.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/encoding/Dictionary.java
@@ -67,7 +67,8 @@ public interface Dictionary
      * This method prepares a {@link VisitorContext} instance for each item (key) in this dictionary,
      * and calls {@link Visitor#visit(VisitorContext)} to visit the item.
      * <p>
-     * The items <b>MUST</b> be visited in the ascending order of the item's key position, i.e., the encoded id of the item in this dictionary.
+     * The items <b>MUST</b> be visited in the ascending order of the item's key position, i.e.,
+     * the encoded id of the item in this dictionary.
      * The visitor can write (serialize) the dictionary item to an output stream.
      * </p>
      * @param visitor the visitor that is going to serialize the dictionary to an output stream.

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/encoding/Encoder.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/encoding/Encoder.java
@@ -49,38 +49,32 @@ public abstract class Encoder implements AutoCloseable
         throw new PixelsEncodingException("Encoding char values is not supported");
     }
 
-    public byte[] encode(byte[] values)
-            throws IOException
+    public byte[] encode(byte[] values) throws IOException
     {
         throw new PixelsEncodingException("Encoding byte values is not supported");
     }
 
-    public byte[] encode(byte[] values, int offset, int length)
-            throws IOException
+    public byte[] encode(byte[] values, int offset, int length) throws IOException
     {
         throw new PixelsEncodingException("Encoding byte values is not supported");
     }
 
-    public byte[] encode(long[] values)
-            throws IOException
+    public byte[] encode(long[] values) throws IOException
     {
         throw new PixelsEncodingException("Encoding long values is not supported");
     }
 
-    public byte[] encode(long[] values, int offset, int length)
-            throws IOException
+    public byte[] encode(long[] values, int offset, int length) throws IOException
     {
         throw new PixelsEncodingException("Encoding long values is not supported");
     }
 
-    public byte[] encode(int[] values)
-            throws IOException
+    public byte[] encode(int[] values) throws IOException
     {
         throw new PixelsEncodingException("Encoding int values is not supported");
     }
 
-    public byte[] encode(int[] values, int offset, int length)
-            throws IOException
+    public byte[] encode(int[] values, int offset, int length) throws IOException
     {
         throw new PixelsEncodingException("Encoding int values is not supported");
     }
@@ -100,6 +94,5 @@ public abstract class Encoder implements AutoCloseable
         throw new PixelsEncodingException("Encoding double values is not supported");
     }
 
-    abstract public void close()
-            throws IOException;
+    abstract public void close() throws IOException;
 }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/encoding/IntDecoder.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/encoding/IntDecoder.java
@@ -26,6 +26,5 @@ import java.io.IOException;
  */
 public abstract class IntDecoder extends Decoder
 {
-    public abstract long next()
-            throws IOException;
+    public abstract long next() throws IOException;
 }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/encoding/RedBlackTree.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/encoding/RedBlackTree.java
@@ -169,8 +169,7 @@ abstract class RedBlackTree
      * @param greatGrandparent Grandparent's parent
      * @return Does parent also need to be checked and/or fixed?
      */
-    private boolean add(int node, boolean fromLeft, int parent,
-                        int grandparent, int greatGrandparent)
+    private boolean add(int node, boolean fromLeft, int parent, int grandparent, int greatGrandparent)
     {
         if (node == NULL)
         {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/encoding/RunLenByteDecoder.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/encoding/RunLenByteDecoder.java
@@ -28,8 +28,7 @@ import java.io.IOException;
 public class RunLenByteDecoder extends Decoder
 {
     @Override
-    public boolean hasNext()
-            throws IOException
+    public boolean hasNext() throws IOException
     {
         return false;
     }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/encoding/RunLenIntDecoder.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/encoding/RunLenIntDecoder.java
@@ -60,8 +60,7 @@ public class RunLenIntDecoder extends IntDecoder
     }
 
     @Override
-    public long next()
-            throws IOException
+    public long next() throws IOException
     {
         long result;
         if (used == numLiterals)
@@ -75,8 +74,7 @@ public class RunLenIntDecoder extends IntDecoder
     }
 
     @Override
-    public boolean hasNext()
-            throws IOException
+    public boolean hasNext() throws IOException
     {
         return used != numLiterals || inputStream.available() > 0;
     }
@@ -90,8 +88,7 @@ public class RunLenIntDecoder extends IntDecoder
         }
     }
 
-    private void readValues()
-            throws IOException
+    private void readValues() throws IOException
     {
         // read the first 2 bits and determine the encoding type
         isRepeating = false;
@@ -122,8 +119,7 @@ public class RunLenIntDecoder extends IntDecoder
         }
     }
 
-    private void readShortRepeatValues(int firstByte)
-            throws IOException
+    private void readShortRepeatValues(int firstByte) throws IOException
     {
         // read the number of bytes occupied by the value
         int size = (firstByte >>> 3) & 0x07;
@@ -161,8 +157,7 @@ public class RunLenIntDecoder extends IntDecoder
         numLiterals = len;
     }
 
-    private void readDirectValues(int firstByte)
-            throws IOException
+    private void readDirectValues(int firstByte) throws IOException
     {
         // extract the number of fixed bits
         int fbo = (firstByte >>> 1) & 0x1f;
@@ -310,8 +305,7 @@ public class RunLenIntDecoder extends IntDecoder
         }
     }
 
-    private void readDeltaValues(int firstByte)
-            throws IOException
+    private void readDeltaValues(int firstByte) throws IOException
     {
         // extract the number of fixed bits
         int fb = (firstByte >>> 1) & 0x1f;
@@ -394,8 +388,7 @@ public class RunLenIntDecoder extends IntDecoder
      * Read bitpacked integers from input stream
      */
     private void readInts(long[] buffer, int offset, int len, int bitSize,
-                          InputStream input)
-            throws IOException
+                          InputStream input) throws IOException
     {
         int bitsLeft = 0;
         int current = 0;
@@ -470,8 +463,7 @@ public class RunLenIntDecoder extends IntDecoder
      * @return the long value.
      * @throws IOException if an I/O error occurs.
      */
-    private long bytesToLongBE(InputStream input, int n)
-            throws IOException
+    private long bytesToLongBE(InputStream input, int n) throws IOException
     {
         long out = 0;
         long val = 0;
@@ -499,8 +491,7 @@ public class RunLenIntDecoder extends IntDecoder
      * @return the long value.
      * @throws IOException if an I/O error occurs.
      */
-    private long readVulong(InputStream in)
-            throws IOException
+    private long readVulong(InputStream in) throws IOException
     {
         long result = 0;
         long b;
@@ -524,8 +515,7 @@ public class RunLenIntDecoder extends IntDecoder
      * @return the long value.
      * @throws IOException if an I/O error occurs.
      */
-    private long readVslong(InputStream in)
-            throws IOException
+    private long readVslong(InputStream in) throws IOException
     {
         long result = readVulong(in);
         return (result >>> 1) ^ -(result & 1);

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/encoding/RunLenIntEncoder.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/encoding/RunLenIntEncoder.java
@@ -88,8 +88,7 @@ public class RunLenIntEncoder extends Encoder
     }
 
     @Override
-    public byte[] encode(long[] values, int offset, int length)
-            throws IOException
+    public byte[] encode(long[] values, int offset, int length) throws IOException
     {
         for (int i = 0; i < length; i++)
         {
@@ -102,8 +101,7 @@ public class RunLenIntEncoder extends Encoder
     }
 
     @Override
-    public byte[] encode(int[] values, int offset, int length)
-            throws IOException
+    public byte[] encode(int[] values, int offset, int length) throws IOException
     {
         for (int i = 0; i < length; i++)
         {
@@ -116,22 +114,19 @@ public class RunLenIntEncoder extends Encoder
     }
 
     @Override
-    public byte[] encode(long[] values)
-            throws IOException
+    public byte[] encode(long[] values) throws IOException
     {
         return encode(values, 0, values.length);
     }
 
     @Override
-    public byte[] encode(int[] values)
-            throws IOException
+    public byte[] encode(int[] values) throws IOException
     {
         return encode(values, 0, values.length);
     }
 
     @Override
-    public void close()
-            throws IOException
+    public void close() throws IOException
     {
         gapVsPatchList = null;
         outputStream.close();
@@ -184,7 +179,7 @@ public class RunLenIntEncoder extends Encoder
             }
         }
 
-        // its faster to exit under delta overflow condition without checking for
+        // it is faster to exit under delta overflow condition without checking for
         // PATCHED_BASE condition as encoding using DIRECT is faster and has less
         // overhead than PATCHED_BASE
         if (!isSafeSubtract(max, min))
@@ -264,7 +259,7 @@ public class RunLenIntEncoder extends Encoder
             // after base reducing the values, if the difference in bits between
             // 95th percentile and 100th percentile value is zero then there
             // is no point in patching the values, in which case we will
-            // fallback to DIRECT encoding.
+            // fall back to DIRECT encoding.
             // The decision to use patched base was based on zigzag values, but the
             // actual patching is done on base reduced literals.
             if ((brBits100p - brBits95p) != 0)
@@ -400,8 +395,7 @@ public class RunLenIntEncoder extends Encoder
         }
     }
 
-    private void writeValues()
-            throws IOException
+    private void writeValues() throws IOException
     {
         if (numLiterals != 0)
         {
@@ -427,8 +421,7 @@ public class RunLenIntEncoder extends Encoder
         }
     }
 
-    private void write(long value)
-            throws IOException
+    private void write(long value) throws IOException
     {
         if (numLiterals == 0)
         {
@@ -548,8 +541,7 @@ public class RunLenIntEncoder extends Encoder
         }
     }
 
-    private void flush()
-            throws IOException
+    private void flush() throws IOException
     {
         if (numLiterals != 0)
         {
@@ -622,8 +614,7 @@ public class RunLenIntEncoder extends Encoder
         fixedRunLength = 0;
     }
 
-    private void writeDirectValues()
-            throws IOException
+    private void writeDirectValues() throws IOException
     {
         // write the number of fixed bits required in next 5 bits
         int fb = zzBits100p;
@@ -658,8 +649,7 @@ public class RunLenIntEncoder extends Encoder
         variableRunLength = 0;
     }
 
-    private void writePatchedBaseValues()
-            throws IOException
+    private void writePatchedBaseValues() throws IOException
     {
         // NOTE: Aligned bit packing cannot be applied for PATCHED_BASE encoding
         // because patch is applied to MSB bits. For example: If fixed bit width of
@@ -733,8 +723,7 @@ public class RunLenIntEncoder extends Encoder
         variableRunLength = 0;
     }
 
-    private void writeDeltaValues()
-            throws IOException
+    private void writeDeltaValues() throws IOException
     {
         int len;
         int fb = bitsDeltaMax;
@@ -814,7 +803,7 @@ public class RunLenIntEncoder extends Encoder
             // store the first value as delta value using zigzag encoding
             writeVslong(outputStream, adjDeltas[0]);
 
-            // adjacent delta values are bit packed. The length of adjDeltas array is
+            // adjacent delta values are bit-packed. The length of adjDeltas array is
             // always one less than the number of literals (delta difference for n
             // elements is n-1). We have already written one element, write the
             // remaining numLiterals - 2 elements here
@@ -823,10 +812,9 @@ public class RunLenIntEncoder extends Encoder
     }
 
     /**
-     * Bitpack and write the input values to underlying output stream
+     * Bit-pack and write the input values to underlying output stream
      */
-    private void writeInts(long[] input, int offset, int len, int bitSize)
-            throws IOException
+    private void writeInts(long[] input, int offset, int len, int bitSize) throws IOException
     {
         if (input == null || input.length < 1 || offset < 0 || len < 1 || bitSize < 1)
         {
@@ -1064,9 +1052,7 @@ public class RunLenIntEncoder extends Encoder
         return (left ^ right) >= 0 | (left ^ (left - right)) >= 0;
     }
 
-    private void writeVulong(OutputStream output,
-                             long value)
-            throws IOException
+    private void writeVulong(OutputStream output, long value) throws IOException
     {
         while (true)
         {
@@ -1083,8 +1069,7 @@ public class RunLenIntEncoder extends Encoder
         }
     }
 
-    private void writeVslong(OutputStream output,
-                             long value)
+    private void writeVslong(OutputStream output, long value)
             throws IOException
     {
         writeVulong(output, (value << 1) ^ (value >> 63));

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/encoding/StringRedBlackTree.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/encoding/StringRedBlackTree.java
@@ -147,8 +147,7 @@ public class StringRedBlackTree extends RedBlackTree implements Dictionary
      * @throws IOException
      */
     @Override
-    public void visit(Visitor visitor)
-            throws IOException
+    public void visit(Visitor visitor) throws IOException
     {
         /*
          * Issue #498:

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/BinaryColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/BinaryColumnReader.java
@@ -30,8 +30,7 @@ import java.nio.ByteBuffer;
  * TODO: unimplemented.
  * @author guodong
  */
-public class BinaryColumnReader
-        extends ColumnReader
+public class BinaryColumnReader extends ColumnReader
 {
     BinaryColumnReader(TypeDescription type)
     {
@@ -54,7 +53,6 @@ public class BinaryColumnReader
     @Override
     public void close() throws IOException
     {
-
     }
 
     /**

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/BooleanColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/BooleanColumnReader.java
@@ -31,8 +31,7 @@ import java.nio.ByteBuffer;
 /**
  * @author guodong
  */
-public class BooleanColumnReader
-        extends ColumnReader
+public class BooleanColumnReader extends ColumnReader
 {
     private ByteBuffer inputBuffer;
     private byte[] bits;

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/ByteColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/ByteColumnReader.java
@@ -29,8 +29,7 @@ import java.nio.ByteBuffer;
 /**
  * @author guodong
  */
-public class ByteColumnReader
-        extends ColumnReader
+public class ByteColumnReader extends ColumnReader
 {
     ByteColumnReader(TypeDescription type)
     {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/CharColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/CharColumnReader.java
@@ -27,8 +27,7 @@ import io.pixelsdb.pixels.core.TypeDescription;
  * @author guodong
  * @author hank
  */
-public class CharColumnReader
-        extends StringColumnReader
+public class CharColumnReader extends StringColumnReader
 {
     // This class is implemented in Issue #100.
 

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/ColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/ColumnReader.java
@@ -87,7 +87,7 @@ public abstract class ColumnReader implements Closeable
 
     /**
      * Read values from input buffer.
-     * Values after specified offset are gonna be put into the specified vector.
+     * Values after specified offset are going to be put into the specified vector.
      *
      * @param input    input buffer
      * @param encoding encoding type

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/ColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/ColumnReader.java
@@ -101,8 +101,7 @@ public abstract class ColumnReader implements Closeable
      */
     public abstract void read(ByteBuffer input, PixelsProto.ColumnEncoding encoding,
                               int offset, int size, int pixelStride, final int vectorIndex,
-                              ColumnVector vector, PixelsProto.ColumnChunkIndex chunkIndex)
-            throws IOException;
+                              ColumnVector vector, PixelsProto.ColumnChunkIndex chunkIndex) throws IOException;
 
     public ColumnReader(TypeDescription type)
     {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/DateColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/DateColumnReader.java
@@ -97,7 +97,8 @@ public class DateColumnReader extends ColumnReader
                 inputStream.close();
             }
             this.inputBuffer = input;
-            this.inputBuffer.order(chunkIndex.getLittleEndian() ? ByteOrder.LITTLE_ENDIAN : ByteOrder.BIG_ENDIAN);
+            boolean littleEndian = chunkIndex.hasLittleEndian() && chunkIndex.getLittleEndian();
+            this.inputBuffer.order(littleEndian ? ByteOrder.LITTLE_ENDIAN : ByteOrder.BIG_ENDIAN);
             inputStream = new ByteBufferInputStream(inputBuffer, inputBuffer.position(), inputBuffer.limit());
             decoder = new RunLenIntDecoder(inputStream, true);
             isNullOffset = inputBuffer.position() + (int) chunkIndex.getIsNullOffset();

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/DateColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/DateColumnReader.java
@@ -30,6 +30,7 @@ import io.pixelsdb.pixels.core.vector.DateColumnVector;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 
 /**
  * pixels date column reader
@@ -98,6 +99,7 @@ public class DateColumnReader
                 inputStream.close();
             }
             this.inputBuffer = input;
+            this.inputBuffer.order(ByteOrder.LITTLE_ENDIAN);
             inputStream = new ByteBufferInputStream(inputBuffer, inputBuffer.position(), inputBuffer.limit());
             decoder = new RunLenIntDecoder(inputStream, true);
             isNullOffset = inputBuffer.position() + (int) chunkIndex.getIsNullOffset();

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/DateColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/DateColumnReader.java
@@ -38,8 +38,7 @@ import java.nio.ByteOrder;
  *
  * @author hank
  */
-public class DateColumnReader
-        extends ColumnReader
+public class DateColumnReader extends ColumnReader
 {
     private ByteBuffer inputBuffer = null;
     private InputStream inputStream = null;
@@ -88,8 +87,7 @@ public class DateColumnReader
     @Override
     public void read(ByteBuffer input, PixelsProto.ColumnEncoding encoding,
                      int offset, int size, int pixelStride, final int vectorIndex,
-                     ColumnVector vector, PixelsProto.ColumnChunkIndex chunkIndex)
-            throws IOException
+                     ColumnVector vector, PixelsProto.ColumnChunkIndex chunkIndex) throws IOException
     {
         DateColumnVector columnVector = (DateColumnVector) vector;
         if (offset == 0)
@@ -99,7 +97,7 @@ public class DateColumnReader
                 inputStream.close();
             }
             this.inputBuffer = input;
-            this.inputBuffer.order(ByteOrder.LITTLE_ENDIAN);
+            this.inputBuffer.order(chunkIndex.getLittleEndian() ? ByteOrder.LITTLE_ENDIAN : ByteOrder.BIG_ENDIAN);
             inputStream = new ByteBufferInputStream(inputBuffer, inputBuffer.position(), inputBuffer.limit());
             decoder = new RunLenIntDecoder(inputStream, true);
             isNullOffset = inputBuffer.position() + (int) chunkIndex.getIsNullOffset();

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/DecimalColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/DecimalColumnReader.java
@@ -34,8 +34,7 @@ import java.nio.ByteOrder;
  * <p><b>Note: it only supports short decimals with max precision and scale 18.</b></p>
  * @author hank
  */
-public class DecimalColumnReader
-        extends ColumnReader
+public class DecimalColumnReader extends ColumnReader
 {
     // private final EncodingUtils encodingUtils;
     private ByteBuffer inputBuffer;

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/DoubleColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/DoubleColumnReader.java
@@ -32,8 +32,7 @@ import java.nio.ByteOrder;
 /**
  * @author guodong
  */
-public class DoubleColumnReader
-        extends ColumnReader
+public class DoubleColumnReader extends ColumnReader
 {
     // private final EncodingUtils encodingUtils;
     private ByteBuffer inputBuffer;

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/FloatColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/FloatColumnReader.java
@@ -32,8 +32,7 @@ import java.nio.ByteOrder;
 /**
  * @author guodong
  */
-public class FloatColumnReader
-        extends ColumnReader
+public class FloatColumnReader extends ColumnReader
 {
     // private final EncodingUtils encodingUtils;
     private ByteBuffer inputBuffer;

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/IntegerColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/IntegerColumnReader.java
@@ -106,7 +106,8 @@ public class IntegerColumnReader extends ColumnReader
                 inputStream.close();
             }
             this.inputBuffer = input;
-            this.inputBuffer.order(chunkIndex.getLittleEndian() ? ByteOrder.LITTLE_ENDIAN : ByteOrder.BIG_ENDIAN);
+            boolean littleEndian = chunkIndex.hasLittleEndian() && chunkIndex.getLittleEndian();
+            this.inputBuffer.order(littleEndian ? ByteOrder.LITTLE_ENDIAN : ByteOrder.BIG_ENDIAN);
             inputStream = new ByteBufferInputStream(inputBuffer, inputBuffer.position(), inputBuffer.limit());
             decoder = new RunLenIntDecoder(inputStream, true);
             // isNull

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/IntegerColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/IntegerColumnReader.java
@@ -35,8 +35,7 @@ import java.nio.ByteOrder;
 /**
  * @author guodong
  */
-public class IntegerColumnReader
-        extends ColumnReader
+public class IntegerColumnReader extends ColumnReader
 {
     private RunLenIntDecoder decoder;
     private ByteBuffer inputBuffer;
@@ -96,8 +95,7 @@ public class IntegerColumnReader
     @Override
     public void read(ByteBuffer input, PixelsProto.ColumnEncoding encoding,
                      int offset, int size, int pixelStride, final int vectorIndex,
-                     ColumnVector vector, PixelsProto.ColumnChunkIndex chunkIndex)
-            throws IOException
+                     ColumnVector vector, PixelsProto.ColumnChunkIndex chunkIndex) throws IOException
     {
         LongColumnVector columnVector = (LongColumnVector) vector;
         // if read from start, init the stream and decoder
@@ -108,7 +106,7 @@ public class IntegerColumnReader
                 inputStream.close();
             }
             this.inputBuffer = input;
-            this.inputBuffer.order(ByteOrder.LITTLE_ENDIAN);
+            this.inputBuffer.order(chunkIndex.getLittleEndian() ? ByteOrder.LITTLE_ENDIAN : ByteOrder.BIG_ENDIAN);
             inputStream = new ByteBufferInputStream(inputBuffer, inputBuffer.position(), inputBuffer.limit());
             decoder = new RunLenIntDecoder(inputStream, true);
             // isNull

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/IntegerColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/IntegerColumnReader.java
@@ -30,6 +30,7 @@ import io.pixelsdb.pixels.core.vector.LongColumnVector;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 
 /**
  * @author guodong
@@ -107,6 +108,7 @@ public class IntegerColumnReader
                 inputStream.close();
             }
             this.inputBuffer = input;
+            this.inputBuffer.order(ByteOrder.LITTLE_ENDIAN);
             inputStream = new ByteBufferInputStream(inputBuffer, inputBuffer.position(), inputBuffer.limit());
             decoder = new RunLenIntDecoder(inputStream, true);
             // isNull
@@ -122,7 +124,7 @@ public class IntegerColumnReader
                  * The position should not be pushed, because the first byte will be read
                  * again for the first pixel (stride).
                  */
-                isLong = inputBuffer.getLong(0) == 1;
+                isLong = type.getCategory() == TypeDescription.Category.LONG;
             }
         }
         // if run length encoded
@@ -176,8 +178,6 @@ public class IntegerColumnReader
                     {
                         int pixelId = elementIndex / pixelStride;
                         hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
-                        // Read the first byte of the pixels (stride).
-                        isLong = inputBuffer.getLong() == 1;
                         if (hasNull && isNullBitIndex > 0)
                         {
                             BitUtils.bitWiseDeCompact(isNull, inputBuffer, isNullOffset++, 1);
@@ -214,8 +214,6 @@ public class IntegerColumnReader
                     {
                         int pixelId = elementIndex / pixelStride;
                         hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
-                        // Read the first byte of the pixels (stride).
-                        isLong = inputBuffer.getLong() == 1;
                         if (hasNull && isNullBitIndex > 0)
                         {
                             BitUtils.bitWiseDeCompact(isNull, inputBuffer, isNullOffset++, 1);

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/LongDecimalColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/LongDecimalColumnReader.java
@@ -35,8 +35,7 @@ import java.nio.ByteOrder;
  * @date 2022-07-03
  * @author hank
  */
-public class LongDecimalColumnReader
-        extends ColumnReader
+public class LongDecimalColumnReader extends ColumnReader
 {
     // private final EncodingUtils encodingUtils;
     private ByteBuffer inputBuffer;

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/StringColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/StringColumnReader.java
@@ -156,7 +156,7 @@ public class StringColumnReader extends ColumnReader
             // no memory copy
             inputBuffer = Unpooled.wrappedBuffer(input);
             boolean littleEndian = chunkIndex.hasLittleEndian() && chunkIndex.getLittleEndian();
-            inputBuffer.order(littleEndian ? ByteOrder.LITTLE_ENDIAN : ByteOrder.BIG_ENDIAN);
+            inputBuffer = inputBuffer.order(littleEndian ? ByteOrder.LITTLE_ENDIAN : ByteOrder.BIG_ENDIAN);
             readContent(input.remaining(), encoding);
             isNullOffset = (int) chunkIndex.getIsNullOffset();
             bufferOffset = 0;

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/StringColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/StringColumnReader.java
@@ -154,9 +154,9 @@ public class StringColumnReader extends ColumnReader
                 inputBuffer.release();
             }
             // no memory copy
-            inputBuffer = Unpooled.wrappedBuffer(input);
             boolean littleEndian = chunkIndex.hasLittleEndian() && chunkIndex.getLittleEndian();
-            inputBuffer = inputBuffer.order(littleEndian ? ByteOrder.LITTLE_ENDIAN : ByteOrder.BIG_ENDIAN);
+            inputBuffer = Unpooled.wrappedBuffer(input)
+                    .order(littleEndian ? ByteOrder.LITTLE_ENDIAN : ByteOrder.BIG_ENDIAN);
             readContent(input.remaining(), encoding);
             isNullOffset = (int) chunkIndex.getIsNullOffset();
             bufferOffset = 0;

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/StringColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/StringColumnReader.java
@@ -40,8 +40,7 @@ import static com.google.common.base.Preconditions.checkArgument;
  * @author guodong
  * @author hank
  */
-public class StringColumnReader
-        extends ColumnReader
+public class StringColumnReader extends ColumnReader
 {
     private int originsOffset;
 
@@ -301,8 +300,7 @@ public class StringColumnReader
     /**
      * In this method, we have reduced most of significant memory copies.
      */
-    private void readContent(int inputLength, PixelsProto.ColumnEncoding encoding)
-            throws IOException
+    private void readContent(int inputLength, PixelsProto.ColumnEncoding encoding) throws IOException
     {
         if (encoding.getKind().equals(PixelsProto.ColumnEncoding.Kind.DICTIONARY))
         {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/StringColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/StringColumnReader.java
@@ -33,6 +33,7 @@ import io.pixelsdb.pixels.core.vector.DictionaryColumnVector;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
@@ -154,6 +155,8 @@ public class StringColumnReader extends ColumnReader
             }
             // no memory copy
             inputBuffer = Unpooled.wrappedBuffer(input);
+            boolean littleEndian = chunkIndex.hasLittleEndian() && chunkIndex.getLittleEndian();
+            inputBuffer.order(littleEndian ? ByteOrder.LITTLE_ENDIAN : ByteOrder.BIG_ENDIAN);
             readContent(input.remaining(), encoding);
             isNullOffset = (int) chunkIndex.getIsNullOffset();
             bufferOffset = 0;

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/TimeColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/TimeColumnReader.java
@@ -37,8 +37,7 @@ import java.nio.ByteBuffer;
  *
  * @author hank
  */
-public class TimeColumnReader
-        extends ColumnReader
+public class TimeColumnReader extends ColumnReader
 {
     private ByteBuffer inputBuffer = null;
     private InputStream inputStream = null;
@@ -68,7 +67,6 @@ public class TimeColumnReader
     @Override
     public void close() throws IOException
     {
-
     }
 
     /**
@@ -87,8 +85,7 @@ public class TimeColumnReader
     @Override
     public void read(ByteBuffer input, PixelsProto.ColumnEncoding encoding,
                      int offset, int size, int pixelStride, final int vectorIndex,
-                     ColumnVector vector, PixelsProto.ColumnChunkIndex chunkIndex)
-            throws IOException
+                     ColumnVector vector, PixelsProto.ColumnChunkIndex chunkIndex) throws IOException
     {
         TimeColumnVector columnVector = (TimeColumnVector) vector;
         if (offset == 0)

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/TimeColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/TimeColumnReader.java
@@ -30,6 +30,7 @@ import io.pixelsdb.pixels.core.vector.TimeColumnVector;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 
 /**
  * pixels time column reader
@@ -95,6 +96,8 @@ public class TimeColumnReader extends ColumnReader
                 inputStream.close();
             }
             this.inputBuffer = input;
+            boolean littleEndian = chunkIndex.hasLittleEndian() && chunkIndex.getLittleEndian();
+            this.inputBuffer.order(littleEndian ? ByteOrder.LITTLE_ENDIAN : ByteOrder.BIG_ENDIAN);
             inputStream = new ByteBufferInputStream(inputBuffer, inputBuffer.position(), inputBuffer.limit());
             decoder = new RunLenIntDecoder(inputStream, true);
             isNullOffset = inputBuffer.position() + (int) chunkIndex.getIsNullOffset();

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/TimestampColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/TimestampColumnReader.java
@@ -30,6 +30,7 @@ import io.pixelsdb.pixels.core.vector.TimestampColumnVector;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.sql.Timestamp;
 
 /**
@@ -97,6 +98,8 @@ public class TimestampColumnReader extends ColumnReader
                 inputStream.close();
             }
             this.inputBuffer = input;
+            boolean littleEndian = chunkIndex.hasLittleEndian() && chunkIndex.getLittleEndian();
+            this.inputBuffer.order(littleEndian ? ByteOrder.LITTLE_ENDIAN : ByteOrder.BIG_ENDIAN);
             inputStream = new ByteBufferInputStream(inputBuffer, inputBuffer.position(), inputBuffer.limit());
             decoder = new RunLenIntDecoder(inputStream, true);
             isNullOffset = inputBuffer.position() + (int) chunkIndex.getIsNullOffset();

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/TimestampColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/TimestampColumnReader.java
@@ -39,8 +39,7 @@ import java.sql.Timestamp;
  * @author guodong
  * @author hank
  */
-public class TimestampColumnReader
-        extends ColumnReader
+public class TimestampColumnReader extends ColumnReader
 {
     private ByteBuffer inputBuffer = null;
     private InputStream inputStream = null;
@@ -70,7 +69,6 @@ public class TimestampColumnReader
     @Override
     public void close() throws IOException
     {
-
     }
 
     /**
@@ -89,8 +87,7 @@ public class TimestampColumnReader
     @Override
     public void read(ByteBuffer input, PixelsProto.ColumnEncoding encoding,
                      int offset, int size, int pixelStride, final int vectorIndex,
-                     ColumnVector vector, PixelsProto.ColumnChunkIndex chunkIndex)
-            throws IOException
+                     ColumnVector vector, PixelsProto.ColumnChunkIndex chunkIndex) throws IOException
     {
         TimestampColumnVector columnVector = (TimestampColumnVector) vector;
         if (offset == 0)

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/VarbinaryColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/VarbinaryColumnReader.java
@@ -22,11 +22,10 @@ package io.pixelsdb.pixels.core.reader;
 import io.pixelsdb.pixels.core.TypeDescription;
 
 /**
- * Created at: 04/03/2022
+ * Created at: 2022-03-04
  * Author: hank
  */
-public class VarbinaryColumnReader
-        extends BinaryColumnReader
+public class VarbinaryColumnReader extends BinaryColumnReader
 {
     VarbinaryColumnReader(TypeDescription type)
     {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/VarcharColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/VarcharColumnReader.java
@@ -26,8 +26,7 @@ import io.pixelsdb.pixels.core.TypeDescription;
  * @author guodong
  * @author hank
  */
-public class VarcharColumnReader
-        extends StringColumnReader
+public class VarcharColumnReader extends StringColumnReader
 {
     // This class is implemented in Issue #100.
 

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/utils/EncodingUtils.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/utils/EncodingUtils.java
@@ -25,11 +25,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
-import java.nio.charset.CharacterCodingException;
-import java.nio.charset.Charset;
-import java.nio.charset.CharsetDecoder;
-import java.nio.charset.CharsetEncoder;
-import java.nio.charset.CodingErrorAction;
+import java.nio.charset.*;
 
 /**
  * pixels
@@ -58,8 +54,7 @@ public class EncodingUtils
     }
 
     public void unrolledBitPack1(long[] input, int offset, int len,
-                                 OutputStream output)
-            throws IOException
+                                 OutputStream output) throws IOException
     {
         final int numHops = 8;
         final int remainder = len % numHops;
@@ -93,8 +88,7 @@ public class EncodingUtils
     }
 
     public void unrolledBitPack2(long[] input, int offset, int len,
-                                 OutputStream output)
-            throws IOException
+                                 OutputStream output) throws IOException
     {
         final int numHops = 4;
         final int remainder = len % numHops;
@@ -124,8 +118,7 @@ public class EncodingUtils
     }
 
     public void unrolledBitPack4(long[] input, int offset, int len,
-                                 OutputStream output)
-            throws IOException
+                                 OutputStream output) throws IOException
     {
         final int numHops = 2;
         final int remainder = len % numHops;
@@ -152,57 +145,49 @@ public class EncodingUtils
     }
 
     public void unrolledBitPack8(long[] input, int offset, int len,
-                                 OutputStream output)
-            throws IOException
+                                 OutputStream output) throws IOException
     {
         unrolledBitPackBytes(input, offset, len, output, 1);
     }
 
     public void unrolledBitPack16(long[] input, int offset, int len,
-                                  OutputStream output)
-            throws IOException
+                                  OutputStream output) throws IOException
     {
         unrolledBitPackBytes(input, offset, len, output, 2);
     }
 
     public void unrolledBitPack24(long[] input, int offset, int len,
-                                  OutputStream output)
-            throws IOException
+                                  OutputStream output) throws IOException
     {
         unrolledBitPackBytes(input, offset, len, output, 3);
     }
 
     public void unrolledBitPack32(long[] input, int offset, int len,
-                                  OutputStream output)
-            throws IOException
+                                  OutputStream output) throws IOException
     {
         unrolledBitPackBytes(input, offset, len, output, 4);
     }
 
     public void unrolledBitPack40(long[] input, int offset, int len,
-                                  OutputStream output)
-            throws IOException
+                                  OutputStream output) throws IOException
     {
         unrolledBitPackBytes(input, offset, len, output, 5);
     }
 
     public void unrolledBitPack48(long[] input, int offset, int len,
-                                  OutputStream output)
-            throws IOException
+                                  OutputStream output) throws IOException
     {
         unrolledBitPackBytes(input, offset, len, output, 6);
     }
 
     public void unrolledBitPack56(long[] input, int offset, int len,
-                                  OutputStream output)
-            throws IOException
+                                  OutputStream output) throws IOException
     {
         unrolledBitPackBytes(input, offset, len, output, 7);
     }
 
     public void unrolledBitPack64(long[] input, int offset, int len,
-                                  OutputStream output)
-            throws IOException
+                                  OutputStream output) throws IOException
     {
         unrolledBitPackBytes(input, offset, len, output, 8);
     }
@@ -234,8 +219,7 @@ public class EncodingUtils
      * @param value the long value
      * @throws IOException
      */
-    public void writeLongLE(OutputStream output, long value)
-            throws IOException
+    public void writeLongLE(OutputStream output, long value) throws IOException
     {
         writeBuffer[0] = (byte) ((value) & 0xff);
         writeBuffer[1] = (byte) ((value >> 8) & 0xff);
@@ -268,8 +252,7 @@ public class EncodingUtils
      * @param value the long value
      * @throws IOException
      */
-    public void writeIntLE(OutputStream output, int value)
-            throws IOException
+    public void writeIntLE(OutputStream output, int value) throws IOException
     {
         writeBuffer[0] = (byte) ((value) & 0xff);
         writeBuffer[1] = (byte) ((value >> 8) & 0xff);
@@ -481,8 +464,7 @@ public class EncodingUtils
     }
 
     private void writeRemainingLongs(OutputStream output, int offset, long[] input, int remainder,
-                                     int numBytes)
-            throws IOException
+                                     int numBytes) throws IOException
     {
         final int numHops = remainder;
 
@@ -562,8 +544,7 @@ public class EncodingUtils
     }
 
     public void unrolledUnPack1(long[] buffer, int offset, int len,
-                                InputStream input)
-            throws IOException
+                                InputStream input) throws IOException
     {
         final int numHops = 8;
         final int remainder = len % numHops;
@@ -596,8 +577,7 @@ public class EncodingUtils
     }
 
     public void unrolledUnPack2(long[] buffer, int offset, int len,
-                                InputStream input)
-            throws IOException
+                                InputStream input) throws IOException
     {
         final int numHops = 4;
         final int remainder = len % numHops;
@@ -626,8 +606,7 @@ public class EncodingUtils
     }
 
     public void unrolledUnPack4(long[] buffer, int offset, int len,
-                                InputStream input)
-            throws IOException
+                                InputStream input) throws IOException
     {
         final int numHops = 2;
         final int remainder = len % numHops;
@@ -654,57 +633,49 @@ public class EncodingUtils
     }
 
     public void unrolledUnPack8(long[] buffer, int offset, int len,
-                                InputStream input)
-            throws IOException
+                                InputStream input) throws IOException
     {
         unrolledUnPackBytes(buffer, offset, len, input, 1);
     }
 
     public void unrolledUnPack16(long[] buffer, int offset, int len,
-                                 InputStream input)
-            throws IOException
+                                 InputStream input) throws IOException
     {
         unrolledUnPackBytes(buffer, offset, len, input, 2);
     }
 
     public void unrolledUnPack24(long[] buffer, int offset, int len,
-                                 InputStream input)
-            throws IOException
+                                 InputStream input) throws IOException
     {
         unrolledUnPackBytes(buffer, offset, len, input, 3);
     }
 
     public void unrolledUnPack32(long[] buffer, int offset, int len,
-                                 InputStream input)
-            throws IOException
+                                 InputStream input) throws IOException
     {
         unrolledUnPackBytes(buffer, offset, len, input, 4);
     }
 
     public void unrolledUnPack40(long[] buffer, int offset, int len,
-                                 InputStream input)
-            throws IOException
+                                 InputStream input) throws IOException
     {
         unrolledUnPackBytes(buffer, offset, len, input, 5);
     }
 
     public void unrolledUnPack48(long[] buffer, int offset, int len,
-                                 InputStream input)
-            throws IOException
+                                 InputStream input) throws IOException
     {
         unrolledUnPackBytes(buffer, offset, len, input, 6);
     }
 
     public void unrolledUnPack56(long[] buffer, int offset, int len,
-                                 InputStream input)
-            throws IOException
+                                 InputStream input) throws IOException
     {
         unrolledUnPackBytes(buffer, offset, len, input, 7);
     }
 
     public void unrolledUnPack64(long[] buffer, int offset, int len,
-                                 InputStream input)
-            throws IOException
+                                 InputStream input) throws IOException
     {
         unrolledUnPackBytes(buffer, offset, len, input, 8);
     }
@@ -729,8 +700,7 @@ public class EncodingUtils
     }
 
     private void readRemainingLongs(long[] buffer, int offset, InputStream input, int remainder,
-                                    int numBytes)
-            throws IOException
+                                    int numBytes) throws IOException
     {
         final int toRead = remainder * numBytes;
         // bulk read to buffer
@@ -1102,14 +1072,14 @@ public class EncodingUtils
     }
 
     /** Derived from org.apache.hadoop.io.Text.ENCODER_FACTORY */
-    private static ThreadLocal<CharsetEncoder> ENCODER_FACTORY =
-            ThreadLocal.withInitial(() -> Charset.forName("UTF-8").newEncoder().
+    private static final ThreadLocal<CharsetEncoder> ENCODER_FACTORY =
+            ThreadLocal.withInitial(() -> StandardCharsets.UTF_8.newEncoder().
                     onMalformedInput(CodingErrorAction.REPORT).
                     onUnmappableCharacter(CodingErrorAction.REPORT));
 
     /** Derived from org.apache.hadoop.io.Text.DECODER_FACTORY */
-    private static ThreadLocal<CharsetDecoder> DECODER_FACTORY =
-            ThreadLocal.withInitial(() -> Charset.forName("UTF-8").newDecoder().
+    private static final ThreadLocal<CharsetDecoder> DECODER_FACTORY =
+            ThreadLocal.withInitial(() -> StandardCharsets.UTF_8.newDecoder().
                     onMalformedInput(CodingErrorAction.REPORT).
                     onUnmappableCharacter(CodingErrorAction.REPORT));
 

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/BaseColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/BaseColumnWriter.java
@@ -72,7 +72,8 @@ public abstract class BaseColumnWriter implements ColumnWriter
         this.isNull = new boolean[pixelStride];
 
         this.columnChunkIndex =
-                PixelsProto.ColumnChunkIndex.newBuilder();
+                PixelsProto.ColumnChunkIndex.newBuilder()
+                        .setLittleEndian(byteOrder.equals(ByteOrder.LITTLE_ENDIAN));
         this.columnChunkStat =
                 PixelsProto.ColumnStatistic.newBuilder();
         this.pixelStatRecorder = StatsRecorder.create(type);
@@ -95,8 +96,7 @@ public abstract class BaseColumnWriter implements ColumnWriter
      * @return size in bytes of the current column chunk
      */
     @Override
-    public abstract int write(ColumnVector vector, int size)
-            throws IOException;
+    public abstract int write(ColumnVector vector, int size) throws IOException;
 
     /**
      * Get byte array of column chunk content
@@ -137,8 +137,7 @@ public abstract class BaseColumnWriter implements ColumnWriter
     }
 
     @Override
-    public void flush()
-            throws IOException
+    public void flush() throws IOException
     {
         if (curPixelEleIndex > 0)
         {
@@ -150,8 +149,7 @@ public abstract class BaseColumnWriter implements ColumnWriter
         isNullStream.writeTo(outputStream);
     }
 
-    void newPixel()
-            throws IOException
+    void newPixel() throws IOException
     {
         // isNull
         if (hasNull)

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/BaseColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/BaseColumnWriter.java
@@ -28,6 +28,7 @@ import io.pixelsdb.pixels.core.vector.ColumnVector;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.ByteOrder;
 
 import static java.util.Objects.requireNonNull;
 
@@ -40,6 +41,7 @@ public abstract class BaseColumnWriter implements ColumnWriter
 {
     final int pixelStride;                     // indicate num of elements in a pixel
     final boolean isEncoding;                  // indicate if encoding enabled during writing
+    final ByteOrder byteOrder;                 // indicate the endianness used during writing
     final boolean[] isNull;
     private final PixelsProto.ColumnChunkIndex.Builder columnChunkIndex;
     private final PixelsProto.ColumnStatistic.Builder columnChunkStat;
@@ -61,11 +63,12 @@ public abstract class BaseColumnWriter implements ColumnWriter
     final ByteArrayOutputStream outputStream;  // column chunk content
     private final ByteArrayOutputStream isNullStream;  // column chunk isNull
 
-    public BaseColumnWriter(TypeDescription type, int pixelStride, boolean isEncoding)
+    public BaseColumnWriter(TypeDescription type, int pixelStride, boolean isEncoding, ByteOrder byteOrder)
     {
         this.type = requireNonNull(type, "type is null");
         this.pixelStride = pixelStride;
         this.isEncoding = isEncoding;
+        this.byteOrder = requireNonNull(byteOrder, "byteOrder is null");
         this.isNull = new boolean[pixelStride];
 
         this.columnChunkIndex =

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/BinaryColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/BinaryColumnWriter.java
@@ -49,8 +49,7 @@ public class BinaryColumnWriter extends BaseColumnWriter
     }
 
     @Override
-    public int write(ColumnVector vector, int size)
-            throws IOException
+    public int write(ColumnVector vector, int size) throws IOException
     {
         BinaryColumnVector columnVector = (BinaryColumnVector) vector;
         byte[][] values = columnVector.vector;
@@ -73,8 +72,8 @@ public class BinaryColumnWriter extends BaseColumnWriter
         return outputStream.size();
     }
 
-    private void writeCurPartBinary(BinaryColumnVector columnVector, byte[][] values, int curPartLength, int curPartOffset)
-            throws IOException
+    private void writeCurPartBinary(BinaryColumnVector columnVector, byte[][] values,
+                                    int curPartLength, int curPartOffset) throws IOException
     {
         for (int i = 0; i < curPartLength; i++)
         {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/BinaryColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/BinaryColumnWriter.java
@@ -24,6 +24,7 @@ import io.pixelsdb.pixels.core.vector.BinaryColumnVector;
 import io.pixelsdb.pixels.core.vector.ColumnVector;
 
 import java.io.IOException;
+import java.nio.ByteOrder;
 
 /**
  * pixels binary column writer.
@@ -40,9 +41,9 @@ public class BinaryColumnWriter extends BaseColumnWriter
     private final int maxLength;
     private int numTruncated;
 
-    public BinaryColumnWriter(TypeDescription type, int pixelStride, boolean isEncoding)
+    public BinaryColumnWriter(TypeDescription type, int pixelStride, boolean isEncoding, ByteOrder byteOrder)
     {
-        super(type, pixelStride, isEncoding);
+        super(type, pixelStride, isEncoding, byteOrder);
         this.maxLength = type.getMaxLength();
         this.numTruncated = 0;
     }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/BooleanColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/BooleanColumnWriter.java
@@ -25,6 +25,7 @@ import io.pixelsdb.pixels.core.vector.ByteColumnVector;
 import io.pixelsdb.pixels.core.vector.ColumnVector;
 
 import java.io.IOException;
+import java.nio.ByteOrder;
 
 /**
  * Boolean column writer.
@@ -36,9 +37,9 @@ public class BooleanColumnWriter extends BaseColumnWriter
 {
     private final byte[] curPixelVector = new byte[pixelStride];
 
-    public BooleanColumnWriter(TypeDescription type, int pixelStride, boolean isEncoding)
+    public BooleanColumnWriter(TypeDescription type, int pixelStride, boolean isEncoding, ByteOrder byteOrder)
     {
-        super(type, pixelStride, isEncoding);
+        super(type, pixelStride, isEncoding, byteOrder);
     }
 
     @Override

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/BooleanColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/BooleanColumnWriter.java
@@ -43,8 +43,7 @@ public class BooleanColumnWriter extends BaseColumnWriter
     }
 
     @Override
-    public int write(ColumnVector vector, int size)
-            throws IOException
+    public int write(ColumnVector vector, int size) throws IOException
     {
         ByteColumnVector columnVector = (ByteColumnVector) vector;
         byte[] values = columnVector.vector;
@@ -87,8 +86,7 @@ public class BooleanColumnWriter extends BaseColumnWriter
     }
 
     @Override
-    public void newPixel()
-            throws IOException
+    public void newPixel() throws IOException
     {
         for (int i = 0; i < curPixelVectorIndex; i++)
         {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/ByteColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/ByteColumnWriter.java
@@ -44,8 +44,7 @@ public class ByteColumnWriter extends BaseColumnWriter
     }
 
     @Override
-    public int write(ColumnVector vector, int size)
-            throws IOException
+    public int write(ColumnVector vector, int size) throws IOException
     {
         LongColumnVector columnVector = (LongColumnVector) vector;
         long[] values = columnVector.vector;
@@ -93,8 +92,7 @@ public class ByteColumnWriter extends BaseColumnWriter
     }
 
     @Override
-    public void newPixel()
-            throws IOException
+    public void newPixel() throws IOException
     {
         for (int i = 0; i < curPixelVectorIndex; i++)
         {
@@ -126,8 +124,7 @@ public class ByteColumnWriter extends BaseColumnWriter
     }
 
     @Override
-    public void close()
-            throws IOException
+    public void close() throws IOException
     {
         encoder.close();
         super.close();

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/ByteColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/ByteColumnWriter.java
@@ -26,6 +26,7 @@ import io.pixelsdb.pixels.core.vector.ColumnVector;
 import io.pixelsdb.pixels.core.vector.LongColumnVector;
 
 import java.io.IOException;
+import java.nio.ByteOrder;
 
 /**
  * pixels byte column writer
@@ -36,9 +37,9 @@ public class ByteColumnWriter extends BaseColumnWriter
 {
     private final byte[] curPixelVector = new byte[pixelStride];
 
-    public ByteColumnWriter(TypeDescription type, int pixelStride, boolean isEncoding)
+    public ByteColumnWriter(TypeDescription type, int pixelStride, boolean isEncoding, ByteOrder byteOrder)
     {
-        super(type, pixelStride, isEncoding);
+        super(type, pixelStride, isEncoding, byteOrder);
         encoder = new RunLenByteEncoder();
     }
 

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/CharColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/CharColumnWriter.java
@@ -21,6 +21,8 @@ package io.pixelsdb.pixels.core.writer;
 
 import io.pixelsdb.pixels.core.TypeDescription;
 
+import java.nio.ByteOrder;
+
 /**
  * pixels column writer for <code>Char</code>
  * It is the same as VarcharColumnWriter, which means it never pads zero
@@ -30,8 +32,8 @@ import io.pixelsdb.pixels.core.TypeDescription;
  */
 public class CharColumnWriter extends VarcharColumnWriter
 {
-    public CharColumnWriter(TypeDescription type, int pixelStride, boolean isEncoding)
+    public CharColumnWriter(TypeDescription type, int pixelStride, boolean isEncoding, ByteOrder byteOrder)
     {
-        super(type, pixelStride, isEncoding);
+        super(type, pixelStride, isEncoding, byteOrder);
     }
 }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/ColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/ColumnWriter.java
@@ -25,6 +25,7 @@ import io.pixelsdb.pixels.core.stats.StatsRecorder;
 import io.pixelsdb.pixels.core.vector.ColumnVector;
 
 import java.io.IOException;
+import java.nio.ByteOrder;
 
 import static io.pixelsdb.pixels.core.TypeDescription.SHORT_DECIMAL_MAX_PRECISION;
 
@@ -42,51 +43,51 @@ public interface ColumnWriter
      * @param isEncoding set true if enable data encoding.
      * @return
      */
-    public static ColumnWriter newColumnWriter(TypeDescription type, int pixelStride, boolean isEncoding)
+    static ColumnWriter newColumnWriter(TypeDescription type, int pixelStride,
+                                        boolean isEncoding, ByteOrder byteOrder)
     {
         switch (type.getCategory())
         {
             case BOOLEAN:
-                return new BooleanColumnWriter(type, pixelStride, isEncoding);
+                return new BooleanColumnWriter(type, pixelStride, isEncoding, byteOrder);
             case BYTE:
-                return new ByteColumnWriter(type, pixelStride, isEncoding);
+                return new ByteColumnWriter(type, pixelStride, isEncoding, byteOrder);
             case SHORT:
             case INT:
             case LONG:
-                return new IntegerColumnWriter(type, pixelStride, isEncoding);
+                return new IntegerColumnWriter(type, pixelStride, isEncoding, byteOrder);
             case FLOAT:
-                return new FloatColumnWriter(type, pixelStride, isEncoding);
+                return new FloatColumnWriter(type, pixelStride, isEncoding, byteOrder);
             case DOUBLE:
-                return new DoubleColumnWriter(type, pixelStride, isEncoding);
+                return new DoubleColumnWriter(type, pixelStride, isEncoding, byteOrder);
             case DECIMAL: // Issue #196: precision and scale are passed through type.
                 if (type.getPrecision() <= SHORT_DECIMAL_MAX_PRECISION)
-                    return new DecimalColumnWriter(type, pixelStride, isEncoding);
+                    return new DecimalColumnWriter(type, pixelStride, isEncoding, byteOrder);
                 else
-                    return new LongDecimalColumnWriter(type, pixelStride, isEncoding);
+                    return new LongDecimalColumnWriter(type, pixelStride, isEncoding, byteOrder);
             case STRING:
-                return new StringColumnWriter(type, pixelStride, isEncoding);
+                return new StringColumnWriter(type, pixelStride, isEncoding, byteOrder);
             // Issue #196: max length of char, varchar, binary, and varbinary, are passed through type.
             case CHAR:
-                return new CharColumnWriter(type, pixelStride, isEncoding);
+                return new CharColumnWriter(type, pixelStride, isEncoding, byteOrder);
             case VARCHAR:
-                return new VarcharColumnWriter(type, pixelStride, isEncoding);
+                return new VarcharColumnWriter(type, pixelStride, isEncoding, byteOrder);
             case BINARY:
-                return new BinaryColumnWriter(type, pixelStride, isEncoding);
+                return new BinaryColumnWriter(type, pixelStride, isEncoding, byteOrder);
             case VARBINARY:
-                return new VarbinaryColumnWriter(type, pixelStride, isEncoding);
+                return new VarbinaryColumnWriter(type, pixelStride, isEncoding, byteOrder);
             case DATE:
-                return new DateColumnWriter(type, pixelStride, isEncoding);
+                return new DateColumnWriter(type, pixelStride, isEncoding, byteOrder);
             case TIME:
-                return new TimeColumnWriter(type, pixelStride, isEncoding);
+                return new TimeColumnWriter(type, pixelStride, isEncoding, byteOrder);
             case TIMESTAMP:
-                return new TimestampColumnWriter(type, pixelStride, isEncoding);
+                return new TimestampColumnWriter(type, pixelStride, isEncoding, byteOrder);
             default:
                 throw new IllegalArgumentException("Bad schema type: " + type.getCategory());
         }
     }
 
-    int write(ColumnVector vector, int length)
-            throws IOException;
+    int write(ColumnVector vector, int length) throws IOException;
 
     byte[] getColumnChunkContent();
 
@@ -102,9 +103,7 @@ public interface ColumnWriter
 
     void reset();
 
-    void flush()
-            throws IOException;
+    void flush() throws IOException;
 
-    void close()
-            throws IOException;
+    void close() throws IOException;
 }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/DateColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/DateColumnWriter.java
@@ -49,8 +49,7 @@ public class DateColumnWriter extends BaseColumnWriter
     }
 
     @Override
-    public int write(ColumnVector vector, int size)
-            throws IOException
+    public int write(ColumnVector vector, int size) throws IOException
     {
         DateColumnVector columnVector = (DateColumnVector) vector;
         int[] dates = columnVector.dates;
@@ -93,8 +92,7 @@ public class DateColumnWriter extends BaseColumnWriter
     }
 
     @Override
-    public void newPixel()
-            throws IOException
+    public void newPixel() throws IOException
     {
         for (int i = 0; i < curPixelVectorIndex; i++)
         {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/DateColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/DateColumnWriter.java
@@ -41,9 +41,9 @@ public class DateColumnWriter extends BaseColumnWriter
 {
     private final int[] curPixelVector = new int[pixelStride];
 
-    public DateColumnWriter(TypeDescription type, int pixelStride, boolean isEncoding)
+    public DateColumnWriter(TypeDescription type, int pixelStride, boolean isEncoding, ByteOrder byteOrder)
     {
-        super(type, pixelStride, isEncoding);
+        super(type, pixelStride, isEncoding, byteOrder);
         // Issue #94: Date.getTime() can be negative if the date is before 1970-1-1.
         encoder = new RunLenIntEncoder(true, true);
     }
@@ -111,7 +111,7 @@ public class DateColumnWriter extends BaseColumnWriter
         {
             ByteBuffer curVecPartitionBuffer =
                     ByteBuffer.allocate(curPixelVectorIndex * Integer.BYTES);
-            curVecPartitionBuffer.order(ByteOrder.LITTLE_ENDIAN);
+            curVecPartitionBuffer.order(byteOrder);
             for (int i = 0; i < curPixelVectorIndex; i++)
             {
                 curVecPartitionBuffer.putInt(curPixelVector[i]);

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/DateColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/DateColumnWriter.java
@@ -27,6 +27,7 @@ import io.pixelsdb.pixels.core.vector.DateColumnVector;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 
 /**
  * Date column writer.
@@ -110,6 +111,7 @@ public class DateColumnWriter extends BaseColumnWriter
         {
             ByteBuffer curVecPartitionBuffer =
                     ByteBuffer.allocate(curPixelVectorIndex * Integer.BYTES);
+            curVecPartitionBuffer.order(ByteOrder.LITTLE_ENDIAN);
             for (int i = 0; i < curPixelVectorIndex; i++)
             {
                 curVecPartitionBuffer.putInt(curPixelVector[i]);

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/DecimalColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/DecimalColumnWriter.java
@@ -25,6 +25,7 @@ import io.pixelsdb.pixels.core.vector.ColumnVector;
 import io.pixelsdb.pixels.core.vector.DecimalColumnVector;
 
 import java.io.IOException;
+import java.nio.ByteOrder;
 
 /**
  * The column writer of decimals.
@@ -36,9 +37,9 @@ public class DecimalColumnWriter extends BaseColumnWriter
 {
     private final EncodingUtils encodingUtils;
 
-    public DecimalColumnWriter(TypeDescription type, int pixelStride, boolean isEncoding)
+    public DecimalColumnWriter(TypeDescription type, int pixelStride, boolean isEncoding, ByteOrder byteOrder)
     {
-        super(type, pixelStride, isEncoding);
+        super(type, pixelStride, isEncoding, byteOrder);
         encodingUtils = new EncodingUtils();
     }
 

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/DecimalColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/DecimalColumnWriter.java
@@ -44,8 +44,7 @@ public class DecimalColumnWriter extends BaseColumnWriter
     }
 
     @Override
-    public int write(ColumnVector vector, int length)
-            throws IOException
+    public int write(ColumnVector vector, int length) throws IOException
     {
         DecimalColumnVector columnVector = (DecimalColumnVector) vector;
         long[] values = columnVector.vector;

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/DoubleColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/DoubleColumnWriter.java
@@ -43,8 +43,7 @@ public class DoubleColumnWriter extends BaseColumnWriter
     }
 
     @Override
-    public int write(ColumnVector vector, int length)
-            throws IOException
+    public int write(ColumnVector vector, int length) throws IOException
     {
         DoubleColumnVector columnVector = (DoubleColumnVector) vector;
         long[] values = columnVector.vector;

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/DoubleColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/DoubleColumnWriter.java
@@ -25,6 +25,7 @@ import io.pixelsdb.pixels.core.vector.ColumnVector;
 import io.pixelsdb.pixels.core.vector.DoubleColumnVector;
 
 import java.io.IOException;
+import java.nio.ByteOrder;
 
 /**
  * pixels
@@ -35,9 +36,9 @@ public class DoubleColumnWriter extends BaseColumnWriter
 {
     private final EncodingUtils encodingUtils;
 
-    public DoubleColumnWriter(TypeDescription type, int pixelStride, boolean isEncoding)
+    public DoubleColumnWriter(TypeDescription type, int pixelStride, boolean isEncoding, ByteOrder byteOrder)
     {
-        super(type, pixelStride, isEncoding);
+        super(type, pixelStride, isEncoding, byteOrder);
         encodingUtils = new EncodingUtils();
     }
 

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/FloatColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/FloatColumnWriter.java
@@ -43,8 +43,7 @@ public class FloatColumnWriter extends BaseColumnWriter
     }
 
     @Override
-    public int write(ColumnVector vector, int length)
-            throws IOException
+    public int write(ColumnVector vector, int length) throws IOException
     {
         DoubleColumnVector columnVector = (DoubleColumnVector) vector;
         long[] values = columnVector.vector;

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/FloatColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/FloatColumnWriter.java
@@ -25,6 +25,7 @@ import io.pixelsdb.pixels.core.vector.ColumnVector;
 import io.pixelsdb.pixels.core.vector.DoubleColumnVector;
 
 import java.io.IOException;
+import java.nio.ByteOrder;
 
 /**
  * pixels
@@ -35,9 +36,9 @@ public class FloatColumnWriter extends BaseColumnWriter
 {
     private final EncodingUtils encodingUtils;
 
-    public FloatColumnWriter(TypeDescription type, int pixelStride, boolean isEncoding)
+    public FloatColumnWriter(TypeDescription type, int pixelStride, boolean isEncoding, ByteOrder byteOrder)
     {
-        super(type, pixelStride, isEncoding);
+        super(type, pixelStride, isEncoding, byteOrder);
         encodingUtils = new EncodingUtils();
     }
 

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/IntegerColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/IntegerColumnWriter.java
@@ -27,6 +27,7 @@ import io.pixelsdb.pixels.core.vector.LongColumnVector;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 
 /**
  * Integer column writer.
@@ -38,8 +39,7 @@ import java.nio.ByteBuffer;
 public class IntegerColumnWriter extends BaseColumnWriter
 {
     private final long[] curPixelVector = new long[pixelStride];        // current pixel value vector haven't written out yet
-    private final boolean isLong;                                       // current column type is long or int
-
+    private final boolean isLong;                                       // current column type is long or int     // if the current pixel is the first pixel
     public IntegerColumnWriter(TypeDescription type, int pixelStride, boolean isEncoding)
     {
         super(type, pixelStride, isEncoding);
@@ -113,8 +113,8 @@ public class IntegerColumnWriter extends BaseColumnWriter
             ByteBuffer curVecPartitionBuffer;
             if (isLong)
             {
-                curVecPartitionBuffer = ByteBuffer.allocate((curPixelVectorIndex + 1) * Long.BYTES);
-                curVecPartitionBuffer.putLong(1);
+                curVecPartitionBuffer = ByteBuffer.allocate(curPixelVectorIndex * Long.BYTES);
+                curVecPartitionBuffer.order(ByteOrder.LITTLE_ENDIAN);
                 for (int i = 0; i < curPixelVectorIndex; i++)
                 {
                     curVecPartitionBuffer.putLong(curPixelVector[i]);
@@ -122,8 +122,8 @@ public class IntegerColumnWriter extends BaseColumnWriter
             }
             else
             {
-                curVecPartitionBuffer = ByteBuffer.allocate(curPixelVectorIndex * Integer.BYTES + Long.BYTES);
-                curVecPartitionBuffer.putLong(0);
+                curVecPartitionBuffer = ByteBuffer.allocate(curPixelVectorIndex * Integer.BYTES);
+                curVecPartitionBuffer.order(ByteOrder.LITTLE_ENDIAN);
                 for (int i = 0; i < curPixelVectorIndex; i++)
                 {
                     curVecPartitionBuffer.putInt((int) curPixelVector[i]);

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/IntegerColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/IntegerColumnWriter.java
@@ -39,10 +39,11 @@ import java.nio.ByteOrder;
 public class IntegerColumnWriter extends BaseColumnWriter
 {
     private final long[] curPixelVector = new long[pixelStride];        // current pixel value vector haven't written out yet
-    private final boolean isLong;                                       // current column type is long or int     // if the current pixel is the first pixel
-    public IntegerColumnWriter(TypeDescription type, int pixelStride, boolean isEncoding)
+    private final boolean isLong;                                       // current column type is long or int, used for the first pixel
+
+    public IntegerColumnWriter(TypeDescription type, int pixelStride, boolean isEncoding, ByteOrder byteOrder)
     {
-        super(type, pixelStride, isEncoding);
+        super(type, pixelStride, isEncoding, byteOrder);
         encoder = new RunLenIntEncoder();
         this.isLong = type.getCategory() == TypeDescription.Category.LONG;
     }
@@ -114,7 +115,7 @@ public class IntegerColumnWriter extends BaseColumnWriter
             if (isLong)
             {
                 curVecPartitionBuffer = ByteBuffer.allocate(curPixelVectorIndex * Long.BYTES);
-                curVecPartitionBuffer.order(ByteOrder.LITTLE_ENDIAN);
+                curVecPartitionBuffer.order(byteOrder);
                 for (int i = 0; i < curPixelVectorIndex; i++)
                 {
                     curVecPartitionBuffer.putLong(curPixelVector[i]);
@@ -123,7 +124,7 @@ public class IntegerColumnWriter extends BaseColumnWriter
             else
             {
                 curVecPartitionBuffer = ByteBuffer.allocate(curPixelVectorIndex * Integer.BYTES);
-                curVecPartitionBuffer.order(ByteOrder.LITTLE_ENDIAN);
+                curVecPartitionBuffer.order(byteOrder);
                 for (int i = 0; i < curPixelVectorIndex; i++)
                 {
                     curVecPartitionBuffer.putInt((int) curPixelVector[i]);

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/IntegerColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/IntegerColumnWriter.java
@@ -49,8 +49,7 @@ public class IntegerColumnWriter extends BaseColumnWriter
     }
 
     @Override
-    public int write(ColumnVector vector, int size)
-            throws IOException
+    public int write(ColumnVector vector, int size) throws IOException
     {
         LongColumnVector columnVector = (LongColumnVector) vector;
         long[] values = columnVector.vector;
@@ -95,8 +94,7 @@ public class IntegerColumnWriter extends BaseColumnWriter
     }
 
     @Override
-    void newPixel()
-            throws IOException
+    void newPixel() throws IOException
     {
         // update stats
         for (int i = 0; i < curPixelVectorIndex; i++)

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/LongDecimalColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/LongDecimalColumnWriter.java
@@ -25,6 +25,7 @@ import io.pixelsdb.pixels.core.vector.ColumnVector;
 import io.pixelsdb.pixels.core.vector.LongDecimalColumnVector;
 
 import java.io.IOException;
+import java.nio.ByteOrder;
 
 /**
  * The column writer of long decimals.
@@ -37,9 +38,9 @@ public class LongDecimalColumnWriter extends BaseColumnWriter
 {
     private final EncodingUtils encodingUtils;
 
-    public LongDecimalColumnWriter(TypeDescription type, int pixelStride, boolean isEncoding)
+    public LongDecimalColumnWriter(TypeDescription type, int pixelStride, boolean isEncoding, ByteOrder byteOrder)
     {
-        super(type, pixelStride, isEncoding);
+        super(type, pixelStride, isEncoding, byteOrder);
         encodingUtils = new EncodingUtils();
     }
 

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/LongDecimalColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/LongDecimalColumnWriter.java
@@ -45,8 +45,7 @@ public class LongDecimalColumnWriter extends BaseColumnWriter
     }
 
     @Override
-    public int write(ColumnVector vector, int length)
-            throws IOException
+    public int write(ColumnVector vector, int length) throws IOException
     {
         LongDecimalColumnVector columnVector = (LongDecimalColumnVector) vector;
         long[] values = columnVector.vector;

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/StringColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/StringColumnWriter.java
@@ -62,9 +62,9 @@ public class StringColumnWriter extends BaseColumnWriter
     private boolean currentUseDictionaryEncoding;
     private boolean doneDictionaryEncodingCheck = false;
 
-    public StringColumnWriter(TypeDescription type, int pixelStride, boolean isEncoding)
+    public StringColumnWriter(TypeDescription type, int pixelStride, boolean isEncoding, ByteOrder byteOrder)
     {
-        super(type, pixelStride, isEncoding);
+        super(type, pixelStride, isEncoding, byteOrder);
         this.futureUseDictionaryEncoding = isEncoding;
         this.currentUseDictionaryEncoding = isEncoding;
         encoder = new RunLenIntEncoder(false, true);
@@ -233,7 +233,7 @@ public class StringColumnWriter extends BaseColumnWriter
         outputStream.write(encoder.encode(tmpLens));
 
         ByteBuffer offsetBuf = ByteBuffer.allocate(Integer.BYTES);
-        offsetBuf.order(ByteOrder.LITTLE_ENDIAN);
+        offsetBuf.order(byteOrder);
         offsetBuf.putInt(lensFieldOffset);
         outputStream.write(offsetBuf.array());
     }
@@ -276,7 +276,7 @@ public class StringColumnWriter extends BaseColumnWriter
          */
 
         ByteBuffer offsetsBuf = ByteBuffer.allocate(2 * Integer.BYTES);
-        offsetsBuf.order(ByteOrder.LITTLE_ENDIAN);
+        offsetsBuf.order(byteOrder);
         offsetsBuf.putInt(originsFieldOffset);
         offsetsBuf.putInt(startsFieldOffset);
         outputStream.write(offsetsBuf.array());

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/StringColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/StringColumnWriter.java
@@ -71,8 +71,7 @@ public class StringColumnWriter extends BaseColumnWriter
     }
 
     @Override
-    public int write(ColumnVector vector, int size)
-            throws IOException
+    public int write(ColumnVector vector, int size) throws IOException
     {
         currentUseDictionaryEncoding = futureUseDictionaryEncoding;
         BinaryColumnVector columnVector = (BinaryColumnVector) vector;
@@ -162,8 +161,7 @@ public class StringColumnWriter extends BaseColumnWriter
     }
 
     @Override
-    public void newPixel()
-            throws IOException
+    public void newPixel() throws IOException
     {
         if (currentUseDictionaryEncoding)
         {
@@ -176,8 +174,7 @@ public class StringColumnWriter extends BaseColumnWriter
     }
 
     @Override
-    public void flush()
-            throws IOException
+    public void flush() throws IOException
     {
         // flush out pixels field
         super.flush();
@@ -211,8 +208,7 @@ public class StringColumnWriter extends BaseColumnWriter
     }
 
     @Override
-    public void close()
-            throws IOException
+    public void close() throws IOException
     {
         lensArray.clear();
         dictionary.clear();
@@ -220,8 +216,7 @@ public class StringColumnWriter extends BaseColumnWriter
         super.close();
     }
 
-    private void flushLens()
-            throws IOException
+    private void flushLens() throws IOException
     {
         int lensFieldOffset = outputStream.size();
         long[] tmpLens = new long[lensArray.size()];
@@ -238,8 +233,7 @@ public class StringColumnWriter extends BaseColumnWriter
         outputStream.write(offsetBuf.array());
     }
 
-    private void flushDictionary()
-            throws IOException
+    private void flushDictionary() throws IOException
     {
         int originsFieldOffset;
         int startsFieldOffset;

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/StringColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/StringColumnWriter.java
@@ -31,6 +31,7 @@ import io.pixelsdb.pixels.core.vector.ColumnVector;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 
 /**
  * String column writer.
@@ -232,6 +233,7 @@ public class StringColumnWriter extends BaseColumnWriter
         outputStream.write(encoder.encode(tmpLens));
 
         ByteBuffer offsetBuf = ByteBuffer.allocate(Integer.BYTES);
+        offsetBuf.order(ByteOrder.LITTLE_ENDIAN);
         offsetBuf.putInt(lensFieldOffset);
         outputStream.write(offsetBuf.array());
     }
@@ -274,6 +276,7 @@ public class StringColumnWriter extends BaseColumnWriter
          */
 
         ByteBuffer offsetsBuf = ByteBuffer.allocate(2 * Integer.BYTES);
+        offsetsBuf.order(ByteOrder.LITTLE_ENDIAN);
         offsetsBuf.putInt(originsFieldOffset);
         offsetsBuf.putInt(startsFieldOffset);
         outputStream.write(offsetsBuf.array());

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/TimeColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/TimeColumnWriter.java
@@ -27,6 +27,7 @@ import io.pixelsdb.pixels.core.vector.TimeColumnVector;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 
 /**
  * Time column writer.
@@ -39,9 +40,9 @@ public class TimeColumnWriter extends BaseColumnWriter
 {
     private final int[] curPixelVector = new int[pixelStride];
 
-    public TimeColumnWriter(TypeDescription type, int pixelStride, boolean isEncoding)
+    public TimeColumnWriter(TypeDescription type, int pixelStride, boolean isEncoding, ByteOrder byteOrder)
     {
-        super(type, pixelStride, isEncoding);
+        super(type, pixelStride, isEncoding, byteOrder);
         // time is likely to be negative according to different time zone.
         encoder = new RunLenIntEncoder(true, true);
     }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/TimeColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/TimeColumnWriter.java
@@ -108,6 +108,7 @@ public class TimeColumnWriter extends BaseColumnWriter
         {
             ByteBuffer curVecPartitionBuffer =
                     ByteBuffer.allocate(curPixelVectorIndex * Integer.BYTES);
+            curVecPartitionBuffer.order(byteOrder);
             for (int i = 0; i < curPixelVectorIndex; i++)
             {
                 curVecPartitionBuffer.putInt(curPixelVector[i]);

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/TimeColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/TimeColumnWriter.java
@@ -48,8 +48,7 @@ public class TimeColumnWriter extends BaseColumnWriter
     }
 
     @Override
-    public int write(ColumnVector vector, int size)
-            throws IOException
+    public int write(ColumnVector vector, int size) throws IOException
     {
         TimeColumnVector columnVector = (TimeColumnVector) vector;
         int[] times = columnVector.times;
@@ -92,8 +91,7 @@ public class TimeColumnWriter extends BaseColumnWriter
     }
 
     @Override
-    public void newPixel()
-            throws IOException
+    public void newPixel() throws IOException
     {
         for (int i = 0; i < curPixelVectorIndex; i++)
         {
@@ -133,8 +131,7 @@ public class TimeColumnWriter extends BaseColumnWriter
     }
 
     @Override
-    public void close()
-            throws IOException
+    public void close() throws IOException
     {
         encoder.close();
         super.close();

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/TimestampColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/TimestampColumnWriter.java
@@ -47,8 +47,7 @@ public class TimestampColumnWriter extends BaseColumnWriter
     }
 
     @Override
-    public int write(ColumnVector vector, int size)
-            throws IOException
+    public int write(ColumnVector vector, int size) throws IOException
     {
         TimestampColumnVector columnVector = (TimestampColumnVector) vector;
         long[] times = columnVector.times;
@@ -91,8 +90,7 @@ public class TimestampColumnWriter extends BaseColumnWriter
     }
 
     @Override
-    public void newPixel()
-            throws IOException
+    public void newPixel() throws IOException
     {
         for (int i = 0; i < curPixelVectorIndex; i++)
         {
@@ -132,8 +130,7 @@ public class TimestampColumnWriter extends BaseColumnWriter
     }
 
     @Override
-    public void close()
-            throws IOException
+    public void close() throws IOException
     {
         encoder.close();
         super.close();

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/TimestampColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/TimestampColumnWriter.java
@@ -107,6 +107,7 @@ public class TimestampColumnWriter extends BaseColumnWriter
         {
             ByteBuffer curVecPartitionBuffer =
                     ByteBuffer.allocate(curPixelVectorIndex * Long.BYTES);
+            curVecPartitionBuffer.order(byteOrder);
             for (int i = 0; i < curPixelVectorIndex; i++)
             {
                 curVecPartitionBuffer.putLong(curPixelVector[i]);

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/TimestampColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/TimestampColumnWriter.java
@@ -27,6 +27,7 @@ import io.pixelsdb.pixels.core.vector.TimestampColumnVector;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 
 /**
  * Timestamp column writer.
@@ -38,9 +39,9 @@ public class TimestampColumnWriter extends BaseColumnWriter
 {
     private final long[] curPixelVector = new long[pixelStride];
 
-    public TimestampColumnWriter(TypeDescription type, int pixelStride, boolean isEncoding)
+    public TimestampColumnWriter(TypeDescription type, int pixelStride, boolean isEncoding, ByteOrder byteOrder)
     {
-        super(type, pixelStride, isEncoding);
+        super(type, pixelStride, isEncoding, byteOrder);
         // Issue #94: time can be negative if it is before 1970-1-1 0:0:0.
         encoder = new RunLenIntEncoder(true, true);
     }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/VarbinaryColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/VarbinaryColumnWriter.java
@@ -21,14 +21,16 @@ package io.pixelsdb.pixels.core.writer;
 
 import io.pixelsdb.pixels.core.TypeDescription;
 
+import java.nio.ByteOrder;
+
 /**
  * Created at: 04/03/2022
  * Author: hank
  */
 public class VarbinaryColumnWriter extends BinaryColumnWriter
 {
-    public VarbinaryColumnWriter(TypeDescription type, int pixelStride, boolean isEncoding)
+    public VarbinaryColumnWriter(TypeDescription type, int pixelStride, boolean isEncoding, ByteOrder byteOrder)
     {
-        super(type, pixelStride, isEncoding);
+        super(type, pixelStride, isEncoding, byteOrder);
     }
 }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/VarcharColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/VarcharColumnWriter.java
@@ -24,6 +24,7 @@ import io.pixelsdb.pixels.core.vector.BinaryColumnVector;
 import io.pixelsdb.pixels.core.vector.ColumnVector;
 
 import java.io.IOException;
+import java.nio.ByteOrder;
 
 /**
  * pixels column writer for <code>Varchar</code>
@@ -41,9 +42,9 @@ public class VarcharColumnWriter extends StringColumnWriter
     private final int maxLength;
     private int numTruncated;
 
-    public VarcharColumnWriter(TypeDescription type, int pixelStride, boolean isEncoding)
+    public VarcharColumnWriter(TypeDescription type, int pixelStride, boolean isEncoding, ByteOrder byteOrder)
     {
-        super(type, pixelStride, isEncoding);
+        super(type, pixelStride, isEncoding, byteOrder);
         this.maxLength = type.getMaxLength();
         this.numTruncated = 0;
     }

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/writer/TestStringColumnWriter.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/writer/TestStringColumnWriter.java
@@ -24,6 +24,7 @@ import io.pixelsdb.pixels.core.vector.BinaryColumnVector;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.nio.ByteOrder;
 import java.util.UUID;
 
 /**
@@ -43,7 +44,7 @@ public class TestStringColumnWriter
             stringColumnVector.add(UUID.randomUUID().toString());
         }
         StringColumnWriter stringColumnWriter = new StringColumnWriter(
-                TypeDescription.createString(), 10000, true);
+                TypeDescription.createString(), 10000, true, ByteOrder.BIG_ENDIAN);
         long startTime = System.currentTimeMillis();
         for (int i = 0; i < 1000; ++i)
         {

--- a/pixels-example/src/main/java/io/pixelsdb/pixels/example/core/MockPixelsReader.java
+++ b/pixels-example/src/main/java/io/pixelsdb/pixels/example/core/MockPixelsReader.java
@@ -17,9 +17,11 @@
  * License along with Pixels.  If not, see
  * <https://www.gnu.org/licenses/>.
  */
-package io.pixelsdb.pixels.core;
+package io.pixelsdb.pixels.example.core;
 
 import io.pixelsdb.pixels.common.physical.Storage;
+import io.pixelsdb.pixels.core.PixelsReader;
+import io.pixelsdb.pixels.core.PixelsReaderImpl;
 import io.pixelsdb.pixels.core.reader.PixelsReaderOption;
 import io.pixelsdb.pixels.core.reader.PixelsRecordReader;
 import io.pixelsdb.pixels.core.vector.VectorizedRowBatch;
@@ -27,13 +29,10 @@ import io.pixelsdb.pixels.core.vector.VectorizedRowBatch;
 import java.io.IOException;
 
 /**
- * pixels
- *
  * @author guodong
  * @author hank
  */
-public class MockPixelsReader
-        implements Runnable
+public class MockPixelsReader implements Runnable
 {
     private final Storage storage;
     private final String filePath;

--- a/pixels-storage/pixels-storage-gcs/src/main/java/io/pixelsdb/pixels/storage/gcs/PhysicalGCSReader.java
+++ b/pixels-storage/pixels-storage-gcs/src/main/java/io/pixelsdb/pixels/storage/gcs/PhysicalGCSReader.java
@@ -30,9 +30,12 @@ import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * The physical readers of Google Cloud Storage.
@@ -214,16 +217,16 @@ public class PhysicalGCSReader implements PhysicalReader
     }
 
     @Override
-    public long readLong() throws IOException
+    public long readLong(ByteOrder byteOrder) throws IOException
     {
-        ByteBuffer buffer = readFully(Long.BYTES);
+        ByteBuffer buffer = readFully(Long.BYTES).order(requireNonNull(byteOrder));
         return buffer.getLong();
     }
 
     @Override
-    public int readInt() throws IOException
+    public int readInt(ByteOrder byteOrder) throws IOException
     {
-        ByteBuffer buffer = readFully(Integer.BYTES);
+        ByteBuffer buffer = readFully(Integer.BYTES).order(requireNonNull(byteOrder));
         return buffer.getInt();
     }
 

--- a/pixels-storage/pixels-storage-hdfs/src/main/java/io/pixelsdb/pixels/storage/hdfs/PhysicalHDFSReader.java
+++ b/pixels-storage/pixels-storage-hdfs/src/main/java/io/pixelsdb/pixels/storage/hdfs/PhysicalHDFSReader.java
@@ -29,11 +29,14 @@ import org.apache.hadoop.hdfs.protocol.LocatedBlock;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * @author guodong
@@ -164,17 +167,31 @@ public class PhysicalHDFSReader implements PhysicalReader
     }
 
     @Override
-    public long readLong() throws IOException
+    public long readLong(ByteOrder byteOrder) throws IOException
     {
         numRequests.incrementAndGet();
-        return rawReader.readLong();
+        if (requireNonNull(byteOrder).equals(ByteOrder.BIG_ENDIAN))
+        {
+            return rawReader.readLong();
+        }
+        else
+        {
+            return Long.reverseBytes(rawReader.readLong());
+        }
     }
 
     @Override
-    public int readInt() throws IOException
+    public int readInt(ByteOrder byteOrder) throws IOException
     {
         numRequests.incrementAndGet();
-        return rawReader.readInt();
+        if (requireNonNull(byteOrder).equals(ByteOrder.BIG_ENDIAN))
+        {
+            return rawReader.readInt();
+        }
+        else
+        {
+            return Integer.reverseBytes(rawReader.readInt());
+        }
     }
 
     @Override

--- a/pixels-storage/pixels-storage-localfs/src/main/java/io/pixelsdb/pixels/storage/localfs/PhysicalLocalReader.java
+++ b/pixels-storage/pixels-storage-localfs/src/main/java/io/pixelsdb/pixels/storage/localfs/PhysicalLocalReader.java
@@ -26,9 +26,12 @@ import io.pixelsdb.pixels.common.utils.ConfigFactory;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * @author hank
@@ -141,15 +144,29 @@ public class PhysicalLocalReader implements PhysicalReader
     }
 
     @Override
-    public long readLong() throws IOException
+    public long readLong(ByteOrder byteOrder) throws IOException
     {
-        return raf.readLong();
+        if (requireNonNull(byteOrder).equals(ByteOrder.BIG_ENDIAN))
+        {
+            return raf.readLong();
+        }
+        else
+        {
+            return Long.reverseBytes(raf.readLong());
+        }
     }
 
     @Override
-    public int readInt() throws IOException
+    public int readInt(ByteOrder byteOrder) throws IOException
     {
-        return raf.readInt();
+        if (requireNonNull(byteOrder).equals(ByteOrder.BIG_ENDIAN))
+        {
+            return raf.readInt();
+        }
+        else
+        {
+            return Integer.reverseBytes(raf.readInt());
+        }
     }
 
     @Override

--- a/pixels-storage/pixels-storage-mock/src/main/java/io/pixelsdb/pixels/storage/mock/PhysicalMockReader.java
+++ b/pixels-storage/pixels-storage-mock/src/main/java/io/pixelsdb/pixels/storage/mock/PhysicalMockReader.java
@@ -26,6 +26,7 @@ import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 
@@ -136,13 +137,13 @@ public class PhysicalMockReader implements PhysicalReader
     }
 
     @Override
-    public long readLong() throws IOException
+    public long readLong(ByteOrder byteOrder) throws IOException
     {
         return 0;
     }
 
     @Override
-    public int readInt() throws IOException
+    public int readInt(ByteOrder byteOrder) throws IOException
     {
         return 0;
     }

--- a/pixels-storage/pixels-storage-redis/src/main/java/io/pixelsdb/pixels/storage/redis/PhysicalRedisReader.java
+++ b/pixels-storage/pixels-storage-redis/src/main/java/io/pixelsdb/pixels/storage/redis/PhysicalRedisReader.java
@@ -25,9 +25,12 @@ import redis.clients.jedis.JedisPooled;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * The physical reader for Redis.
@@ -122,16 +125,16 @@ public class PhysicalRedisReader implements PhysicalReader
     }
 
     @Override
-    public long readLong() throws IOException
+    public long readLong(ByteOrder byteOrder) throws IOException
     {
-        ByteBuffer buffer = readFully(Long.BYTES);
+        ByteBuffer buffer = readFully(Long.BYTES).order(requireNonNull(byteOrder));
         return buffer.getLong();
     }
 
     @Override
-    public int readInt() throws IOException
+    public int readInt(ByteOrder byteOrder) throws IOException
     {
-        ByteBuffer buffer = readFully(Integer.BYTES);
+        ByteBuffer buffer = readFully(Integer.BYTES).order(requireNonNull(byteOrder));
         return buffer.getInt();
     }
 

--- a/pixels-storage/pixels-storage-s3/src/main/java/io/pixelsdb/pixels/storage/s3/AbstractS3Reader.java
+++ b/pixels-storage/pixels-storage-s3/src/main/java/io/pixelsdb/pixels/storage/s3/AbstractS3Reader.java
@@ -31,9 +31,12 @@ import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * The abstract class for the physical readers of AWS S3 compatible storage systems.
@@ -189,16 +192,16 @@ public abstract class AbstractS3Reader implements PhysicalReader
     abstract public CompletableFuture<ByteBuffer> readAsync(long offset, int len) throws IOException;
 
     @Override
-    public long readLong() throws IOException
+    public long readLong(ByteOrder byteOrder) throws IOException
     {
-        ByteBuffer buffer = readFully(Long.BYTES);
+        ByteBuffer buffer = readFully(Long.BYTES).order(requireNonNull(byteOrder));
         return buffer.getLong();
     }
 
     @Override
-    public int readInt() throws IOException
+    public int readInt(ByteOrder byteOrder) throws IOException
     {
-        ByteBuffer buffer = readFully(Integer.BYTES);
+        ByteBuffer buffer = readFully(Integer.BYTES).order(requireNonNull(byteOrder));
         return buffer.getInt();
     }
 

--- a/pixels-turbo/pixels-worker-vhive/README.md
+++ b/pixels-turbo/pixels-worker-vhive/README.md
@@ -1,8 +1,8 @@
-# Pixels-Worker-Vhive
+# Pixels-Worker-vHive
 
 This module is for creating the Docker image for vHive cloud functions.
 
-\* Currently, you need to modify [pixels-trino/connector/pom.xml](https://github.com/pixelsdb/pixels-trino/blob/master/connector/pom.xml): replace the `pixels-invoker-lambda` with `pixels-invoker-vhive`.
+Currently, you need to modify [pixels-trino/connector/pom.xml](https://github.com/pixelsdb/pixels-trino/blob/master/connector/pom.xml): replace the `pixels-invoker-lambda` with `pixels-invoker-vhive`.
 
 After [building Pixels](https://github.com/pixelsdb/pixels#build-pixels), we have the executable JAR file `target/pixels-worker-vhive-jar-with-dependencies.jar`.
 Also modify the following items in `pixels.properties`:
@@ -29,7 +29,7 @@ docker build -f ./Dockerfile -t <your-docker-username>/<your-docker-image-name>:
 ## Docker Run
 
 First of all, test the Docker image locally.
-Please pass the required environement variables by the `--env` option to correctly start the gRPC server in docker.
+Please pass the required environment variables by the `--env` option to correctly start the gRPC server in docker.
 
 ```bash
 docker run -p 50051:50051 --rm --network=bridge \
@@ -55,7 +55,7 @@ Note that Docker uses the docker hub by default, unless otherwise specified.
 docker push <your-docker-username>/<your-docker-image-name>:<your-image-tag>
 ```
 
-## FTP Service for Debuging and Profiling
+## FTP Service for Debugging and Profiling
 
 As you can see, we have FTP related environment variables in the configuration.
 This is because the function image will generate the logging file and profiling file during the execution, but the Firecracker microVM
@@ -66,4 +66,3 @@ Now our module use FTP service as a solution.
 You can follow [this tutorial](https://ubuntu.com/server/docs/service-ftp)
 and [this one](https://www.digitalocean.com/community/tutorials/how-to-set-up-vsftpd-for-a-user-s-directory-on-ubuntu-20-04)
 to set up an FTP server easily.
-

--- a/proto/pixels.proto
+++ b/proto/pixels.proto
@@ -36,7 +36,7 @@ option java_outer_classname = "PixelsProto";
 // the RowGroupInformation, column chunk level configurations are in the ColumnChunkIndex.
 
 // The content of the file tail that must be serialized and stored at the end of each file,
-// followed by 8 bytes indicating the start offset of the file tail.
+// followed by an eight-byte integer in big endian indicating the start offset of the file tail.
 message FileTail {
     optional Footer footer = 1;
     optional PostScript postscript = 2;

--- a/proto/pixels.proto
+++ b/proto/pixels.proto
@@ -235,7 +235,7 @@ message ColumnChunkIndex {
     repeated PixelStatistic pixelStatistics = 5;
     // whether this column chunk is stored in little endian
     optional bool littleEndian = 6;
-    // whether the null positions are padded with arbitrary values, only used for non-encoded column chunks
+    // whether the null positions are padded with arbitrary value, only valid non-encoded column chunks
     optional bool nullsPadded = 7;
 }
 


### PR DESCRIPTION
The endianness of Pixels writer is configured by `column.chunk.little.endian`=true/false.
The endianness is then saved in the ColumnChunkIndex of each column chunk.
The Pixels column readers will check the ColumnChunkIndex to use the right endianness.
This is currently implemented in the Java codebase, and the C++ codebase should at least check and report errors for unsupported endianness.