### PR TITLE
Fix compilation error: move partitioned from footer to postScript

### DIFF
--- a/cpp/pixels-reader/pixels-core/lib/PixelsReaderImpl.cpp
+++ b/cpp/pixels-reader/pixels-core/lib/PixelsReaderImpl.cpp
@@ -65,7 +65,7 @@ int PixelsReaderImpl::getRowGroupNum() {
 }
 
 bool PixelsReaderImpl::isPartitioned() {
-	return footer.has_partitioned() && footer.partitioned();
+	return postScript.has_partitioned() && postScript.partitioned();
 }
 
 ColumnStatisticList PixelsReaderImpl::getColumnStats() {


### PR DESCRIPTION
`partitioned` has moved from `footer` to `postScript`, so we need to do the fix in the pixels c++ correspondingly. 