### PR TITLE
Make the batch size of pixels c++ reader configurable

### DIFF
--- a/cpp/PixelsScanFunction.cpp
+++ b/cpp/PixelsScanFunction.cpp
@@ -3,7 +3,7 @@
 //
 
 #include "PixelsScanFunction.hpp"
-#include "profiler/TimeProfiler.h"
+#include "profiler/CountProfiler.h"
 namespace duckdb {
 
 bool PixelsScanFunction::enable_filter_pushdown = false;

--- a/cpp/PixelsScanFunction.cpp
+++ b/cpp/PixelsScanFunction.cpp
@@ -59,7 +59,7 @@ void PixelsScanFunction::PixelsScanImplementation(ClientContext &context,
     auto &bind_data = (PixelsReadBindData &)*data_p.bind_data;
 
     do {
-        if(data.currPixelsRecordReader == nullptr ||
+        if (data.currPixelsRecordReader == nullptr ||
            (data.currPixelsRecordReader->isEndOfFile() && data.vectorizedRowBatch->isEndOfFile())) {
             if(data.currPixelsRecordReader != nullptr) {
                 data.currPixelsRecordReader.reset();
@@ -71,10 +71,10 @@ void PixelsScanFunction::PixelsScanImplementation(ClientContext &context,
         auto currPixelsRecordReader = std::static_pointer_cast<PixelsRecordReaderImpl>(data.currPixelsRecordReader);
         auto nextPixelsRecordReader = std::static_pointer_cast<PixelsRecordReaderImpl>(data.nextPixelsRecordReader);
 
-        if(data.vectorizedRowBatch != nullptr && data.vectorizedRowBatch->isEndOfFile()) {
+        if (data.vectorizedRowBatch != nullptr && data.vectorizedRowBatch->isEndOfFile()) {
             data.vectorizedRowBatch = nullptr;
         }
-        if(data.vectorizedRowBatch == nullptr) {
+        if (data.vectorizedRowBatch == nullptr) {
             data.vectorizedRowBatch = currPixelsRecordReader->readBatch(false);
         }
         uint64_t currentLoc = data.vectorizedRowBatch->position();
@@ -89,7 +89,7 @@ void PixelsScanFunction::PixelsScanImplementation(ClientContext &context,
         TransformDuckdbChunk(data, output, resultSchema, thisOutputChunkRows);
 
         // apply the filter operation
-        if(enable_filter_pushdown) {
+        if (enable_filter_pushdown) {
             idx_t sel_size = 0;
             SelectionVector sel;
             sel.Initialize(thisOutputChunkRows);
@@ -101,7 +101,7 @@ void PixelsScanFunction::PixelsScanImplementation(ClientContext &context,
             output.Slice(sel, sel_size);
         }
 
-        if(output.size() > 0) {
+        if (output.size() > 0) {
             return;
         } else {
             output.Reset();
@@ -237,11 +237,11 @@ void PixelsScanFunction::TransformDuckdbType(const std::shared_ptr<TypeDescripti
 		}
 	}
 }
+
 void PixelsScanFunction::TransformDuckdbChunk(PixelsReadLocalState & data,
                                               DataChunk & output,
                                               const std::shared_ptr<TypeDescription> & schema,
                                               uint64_t thisOutputChunkRows) {
-
 	int row_batch_id = 0;
 	auto column_ids = data.column_ids;
 	auto vectorizedRowBatch = data.vectorizedRowBatch;
@@ -422,8 +422,6 @@ bool PixelsScanFunction::PixelsParallelStateNext(ClientContext &context, const P
         scan_data.nextReader = nullptr;
         scan_data.nextPixelsRecordReader = nullptr;
     }
-
-
     return true;
 }
 
@@ -438,8 +436,8 @@ PixelsReaderOption PixelsScanFunction::GetPixelsReaderOption(PixelsReadLocalStat
     option.setIncludeCols(local_state.column_names);
     option.setRGRange(0, local_state.nextReader->getRowGroupNum());
     option.setQueryId(1);
+    int stride = std::stoi(ConfigFactory::Instance().getProperty("pixel.stride"));
+    option.setBatchSize(stride);
     return option;
 }
-
-
 }

--- a/cpp/pixels-reader/pixels-core/include/PixelsFilter.h
+++ b/cpp/pixels-reader/pixels-core/include/PixelsFilter.h
@@ -18,6 +18,8 @@
 #include <immintrin.h>
 #include <avxintrin.h>
 
+#define ENABLE_SIMD_FILTER
+
 class PixelsFilter {
 public:
     static void ApplyFilter(std::shared_ptr<ColumnVector> vector, duckdb::TableFilter &filter,

--- a/cpp/pixels-reader/pixels-core/include/reader/PixelsReaderOption.h
+++ b/cpp/pixels-reader/pixels-core/include/reader/PixelsReaderOption.h
@@ -27,7 +27,7 @@ public:
     duckdb::TableFilterSet * getFilter();
     int getRGStart();
     int getRGLen();
-    int getBatchSize();
+    int getBatchSize() const;
     void setTolerantSchemaEvolution(bool t);
     bool isTolerantSchemaEvolution();
     void setEnableEncodedColumnVector(bool enabled);

--- a/cpp/pixels-reader/pixels-core/include/reader/PixelsRecordReaderImpl.h
+++ b/cpp/pixels-reader/pixels-core/include/reader/PixelsRecordReaderImpl.h
@@ -73,6 +73,7 @@ private:
     int targetRGNum;
     int curRGIdx;
     int curRowInRG;
+    int batchSize;
 	int curRowInStride;
     std::string fileName;
 	bool endOfFile;

--- a/cpp/pixels-reader/pixels-core/include/vector/ColumnVector.h
+++ b/cpp/pixels-reader/pixels-core/include/vector/ColumnVector.h
@@ -51,6 +51,7 @@ public:
     void increment(uint64_t size);              // increment the readIndex
     bool isFull();                         // if the readIndex reaches length
     uint64_t position();                   // return readIndex
+    void resize(int size);                 // resize the column vector to a smaller one
     virtual void close();
     virtual void reset();
     virtual void * current() = 0;              // get the pointer in the current location

--- a/cpp/pixels-reader/pixels-core/include/vector/VectorizedRowBatch.h
+++ b/cpp/pixels-reader/pixels-core/include/vector/VectorizedRowBatch.h
@@ -32,6 +32,8 @@ public:
 	~VectorizedRowBatch();
 	void close();
     int getMaxSize();
+    void reset();
+    void resize(int size);
     uint64_t position();
     int count();
     bool isEmpty();

--- a/cpp/pixels-reader/pixels-core/lib/PixelsFilter.cpp
+++ b/cpp/pixels-reader/pixels-core/lib/PixelsFilter.cpp
@@ -81,10 +81,12 @@ void PixelsFilter::TemplatedFilterOperation(std::shared_ptr<ColumnVector> vector
         case TypeDescription::INT: {
             auto longColumnVector = std::static_pointer_cast<LongColumnVector>(vector);
             int i = 0;
+#ifdef  ENABLE_SIMD_FILTER
             for (; i < vector->length - vector->length % 8; i += 8) {
                 uint8_t mask = CompareAvx2<T, OP>(longColumnVector->intVector + i, constant_value);
                 filter_mask.setByteAligned(i, mask);
             }
+#endif
             for (; i < vector->length; i++) {
                 filter_mask.set(i, OP::Operation((T)longColumnVector->intVector[i],
                                                                  constant_value));
@@ -94,10 +96,12 @@ void PixelsFilter::TemplatedFilterOperation(std::shared_ptr<ColumnVector> vector
         case TypeDescription::LONG: {
             auto longColumnVector = std::static_pointer_cast<LongColumnVector>(vector);
             int i = 0;
+#ifdef ENABLE_SIMD_FILTER
             for (; i < vector->length - vector->length % 8; i += 8) {
                 uint8_t mask = CompareAvx2<T, OP>(longColumnVector->longVector + i, constant_value);
                 filter_mask.setByteAligned(i, mask);
             }
+#endif
             for(; i < vector->length; i++) {
                 filter_mask.set(i, OP::Operation((T)longColumnVector->longVector[i],
                                                  constant_value));
@@ -107,10 +111,12 @@ void PixelsFilter::TemplatedFilterOperation(std::shared_ptr<ColumnVector> vector
         case TypeDescription::DATE: {
             auto dateColumnVector = std::static_pointer_cast<DateColumnVector>(vector);
             int i = 0;
+#ifdef ENABLE_SIMD_FILTER
             for (; i < vector->length - vector->length % 8; i += 8) {
                 uint8_t mask = CompareAvx2<T, OP>(dateColumnVector->dates + i, constant_value);
                 filter_mask.setByteAligned(i, mask);
             }
+#endif
             for (; i < vector->length; i++) {
                 filter_mask.set(i, OP::Operation((T)dateColumnVector->dates[i],
                                                                  constant_value));
@@ -120,10 +126,12 @@ void PixelsFilter::TemplatedFilterOperation(std::shared_ptr<ColumnVector> vector
         case TypeDescription::DECIMAL: {
             auto decimalColumnVector = std::static_pointer_cast<DecimalColumnVector>(vector);
             int i = 0;
+#ifdef ENABLE_SIMD_FILTER
             for (; i < vector->length - vector->length % 8; i += 8) {
                 uint8_t mask = CompareAvx2<T, OP>(decimalColumnVector->vector + i, constant_value);
                 filter_mask.setByteAligned(i, mask);
             }
+#endif
             for (; i < vector->length; i++) {
                 filter_mask.set(i, OP::Operation((T)decimalColumnVector->vector[i],
                                                                  constant_value));

--- a/cpp/pixels-reader/pixels-core/lib/reader/PixelsReaderOption.cpp
+++ b/cpp/pixels-reader/pixels-core/lib/reader/PixelsReaderOption.cpp
@@ -11,6 +11,7 @@ PixelsReaderOption::PixelsReaderOption() {
     enableEncodedColumnVector = true;
     enableFilterPushDown = false;
     queryId = -1L;
+    batchSize = 0;
     rgStart = 0;
     rgLen = -1;  // -1 means reading to the end of the file
 }
@@ -82,6 +83,14 @@ void PixelsReaderOption::setFilter(duckdb::TableFilterSet * filter) {
 
 duckdb::TableFilterSet * PixelsReaderOption::getFilter() {
     return this->filter;
+}
+
+void PixelsReaderOption::setBatchSize(int batchSize) {
+    this->batchSize = batchSize;
+}
+
+int PixelsReaderOption::getBatchSize() const {
+    return batchSize;
 }
 
 

--- a/cpp/pixels-reader/pixels-core/lib/vector/ColumnVector.cpp
+++ b/cpp/pixels-reader/pixels-core/lib/vector/ColumnVector.cpp
@@ -43,6 +43,14 @@ uint64_t ColumnVector::position() {
     return readIndex;
 }
 
+void ColumnVector::resize(int size) {
+    if(this->length < size) {
+        throw InvalidArgumentException("column vector can only be resized to a smaller vector. ");
+    } else {
+        this->length = size;
+    }
+}
+
 
 
 

--- a/cpp/pixels-reader/pixels-core/lib/vector/VectorizedRowBatch.cpp
+++ b/cpp/pixels-reader/pixels-core/lib/vector/VectorizedRowBatch.cpp
@@ -100,3 +100,17 @@ uint64_t VectorizedRowBatch::position() {
     return position;
 }
 
+void VectorizedRowBatch::reset() {
+    for(auto col: cols) {
+        col->reset();
+    }
+    rowCount = 0;
+}
+
+void VectorizedRowBatch::resize(int size) {
+    for(auto col: cols) {
+        col->resize(size);
+    }
+    maxSize = size;
+}
+


### PR DESCRIPTION
We have verify that the following changes doesn't affect the performance of pixels c++ reader
1. In this pr, we can config the batch size of pixels reader c++. The default value is `pixelStride`
2. Set the length of filter mask as `batchSize` instead of `curRGRowCount`. 
3. Reuse the column vector. We allocate a new column vector only when switching to another pxl file
4. Set a macro to control if we enable SIMD for pixels filter or not