### PR TITLE
[Issue #542] rename pixelsFilterMask to PixelsBitMask

### DIFF
--- a/cpp/PixelsScanFunction.cpp
+++ b/cpp/PixelsScanFunction.cpp
@@ -83,7 +83,7 @@ void PixelsScanFunction::PixelsScanImplementation(ClientContext &context,
         assert(remaining > 0);
         auto thisOutputChunkRows = MinValue<idx_t>(STANDARD_VECTOR_SIZE, remaining);
         output.SetCardinality(thisOutputChunkRows);
-        std::shared_ptr<pixelsFilterMask> filterMask =
+        std::shared_ptr<PixelsBitMask> filterMask =
                 std::static_pointer_cast<PixelsRecordReaderImpl>(data.currPixelsRecordReader)->getFilterMask();
 
         TransformDuckdbChunk(data, output, resultSchema, thisOutputChunkRows);
@@ -100,7 +100,6 @@ void PixelsScanFunction::PixelsScanImplementation(ClientContext &context,
             }
             output.Slice(sel, sel_size);
         }
-
         if (output.size() > 0) {
             return;
         } else {

--- a/cpp/pixels-reader/pixels-core/CMakeLists.txt
+++ b/cpp/pixels-reader/pixels-core/CMakeLists.txt
@@ -16,9 +16,31 @@ set(pixels_core_cxx
         lib/vector/VectorizedRowBatch.cpp
         lib/vector/ColumnVector.cpp
         lib/vector/ByteColumnVector.cpp
-        lib/vector/BinaryColumnVector.cpp lib/reader/ColumnReader.cpp lib/reader/ColumnReaderBuilder.cpp lib/reader/IntegerColumnReader.cpp lib/reader/CharColumnReader.cpp lib/reader/VarcharColumnReader.cpp lib/reader/StringColumnReader.cpp lib/encoding/Decoder.cpp lib/encoding/RunLenIntDecoder.cpp lib/encoding/Encoder.cpp lib/encoding/RunLenIntEncoder.cpp lib/utils/EncodingUtils.cpp lib/utils/EncodingUtils.cpp include/vector/DecimalColumnVector.h lib/vector/DecimalColumnVector.cpp include/reader/DecimalColumnReader.h lib/reader/DecimalColumnReader.cpp lib/vector/DateColumnVector.cpp include/vector/DateColumnVector.h include/reader/DateColumnReader.h lib/reader/DateColumnReader.cpp include/PixelsFilter.h lib/PixelsFilter.cpp
-        include/PixelsFilterMask.h
-        lib/PixelsFilterMask.cpp)
+        lib/vector/BinaryColumnVector.cpp
+        lib/reader/ColumnReader.cpp
+        lib/reader/ColumnReaderBuilder.cpp
+        lib/reader/IntegerColumnReader.cpp
+        lib/reader/CharColumnReader.cpp
+        lib/reader/VarcharColumnReader.cpp
+        lib/reader/StringColumnReader.cpp
+        lib/encoding/Decoder.cpp
+        lib/encoding/RunLenIntDecoder.cpp
+        lib/encoding/Encoder.cpp
+        lib/encoding/RunLenIntEncoder.cpp
+        lib/utils/EncodingUtils.cpp
+        lib/utils/EncodingUtils.cpp
+        include/vector/DecimalColumnVector.h
+        lib/vector/DecimalColumnVector.cpp
+        include/reader/DecimalColumnReader.h
+        lib/reader/DecimalColumnReader.cpp
+        lib/vector/DateColumnVector.cpp
+        include/vector/DateColumnVector.h
+        include/reader/DateColumnReader.h
+        lib/reader/DateColumnReader.cpp
+        include/PixelsFilter.h
+        lib/PixelsFilter.cpp
+        include/PixelsBitMask.h
+        lib/PixelsBitMask.cpp)
 
 add_library(pixels-core ${pixels_core_cxx})
 

--- a/cpp/pixels-reader/pixels-core/include/PixelsBitMask.h
+++ b/cpp/pixels-reader/pixels-core/include/PixelsBitMask.h
@@ -2,8 +2,8 @@
 // Created by liyu on 7/6/23.
 //
 
-#ifndef DUCKDB_PIXELSFILTERMASK_H
-#define DUCKDB_PIXELSFILTERMASK_H
+#ifndef DUCKDB_PIXELSBITMASK_H
+#define DUCKDB_PIXELSBITMASK_H
 
 #include <bitset>
 #include "duckdb/planner/table_filter.hpp"
@@ -16,16 +16,16 @@
 #include "vector/ColumnVector.h"
 #include "TypeDescription.h"
 
-class pixelsFilterMask {
+class PixelsBitMask {
 public:
     uint8_t * mask;
     long maskLength;
     long arrayLength;
-    pixelsFilterMask(long length);
-    pixelsFilterMask(pixelsFilterMask & other);
-    ~pixelsFilterMask();
-    void Or(pixelsFilterMask & other);
-    void And(pixelsFilterMask & other);
+    PixelsBitMask(long length);
+    PixelsBitMask(PixelsBitMask & other);
+    ~PixelsBitMask();
+    void Or(PixelsBitMask & other);
+    void And(PixelsBitMask & other);
     void Or(long index, uint8_t value);
     void And(long index, uint8_t value);
     bool isNone();
@@ -35,4 +35,4 @@ public:
     uint8_t get(long index);
 };
 
-#endif //DUCKDB_PIXELSFILTERMASK_H
+#endif //DUCKDB_PIXELSBITMASK_H

--- a/cpp/pixels-reader/pixels-core/include/PixelsFilter.h
+++ b/cpp/pixels-reader/pixels-core/include/PixelsFilter.h
@@ -12,7 +12,7 @@
 #include "duckdb/planner/filter/null_filter.hpp"
 #include "duckdb/planner/filter/conjunction_filter.hpp"
 #include "duckdb/common/operator/comparison_operators.hpp"
-#include "PixelsFilterMask.h"
+#include "PixelsBitMask.h"
 #include "vector/ColumnVector.h"
 #include "TypeDescription.h"
 #include <immintrin.h>
@@ -23,7 +23,7 @@
 class PixelsFilter {
 public:
     static void ApplyFilter(std::shared_ptr<ColumnVector> vector, duckdb::TableFilter &filter,
-                            pixelsFilterMask& filterMask,
+                            PixelsBitMask& filterMask,
                             std::shared_ptr<TypeDescription> type);
 
     template <class T, class OP>
@@ -31,12 +31,12 @@ public:
 
     template <class T, class OP>
     static void TemplatedFilterOperation(std::shared_ptr<ColumnVector> vector,
-                            const duckdb::Value &constant, pixelsFilterMask &filter_mask,
+                            const duckdb::Value &constant, PixelsBitMask &filter_mask,
                             std::shared_ptr<TypeDescription> type);
 
     template <class OP>
     static void FilterOperationSwitch(std::shared_ptr<ColumnVector> vector, duckdb::Value &constant,
-                                      pixelsFilterMask &filter_mask, std::shared_ptr<TypeDescription> type);
+                                      PixelsBitMask &filter_mask, std::shared_ptr<TypeDescription> type);
 
 };
 #endif //DUCKDB_PIXELSFILTER_H

--- a/cpp/pixels-reader/pixels-core/include/reader/ColumnReader.h
+++ b/cpp/pixels-reader/pixels-core/include/reader/ColumnReader.h
@@ -42,7 +42,7 @@ public:
                       int offset, int size, int pixelStride,
                       int vectorIndex, std::shared_ptr<ColumnVector> vector,
                       pixels::proto::ColumnChunkIndex & chunkIndex,
-                      std::shared_ptr<pixelsFilterMask> filterMask) = 0;
+                      std::shared_ptr<PixelsBitMask> filterMask) = 0;
 private:
 	bool hasNull;
 protected:

--- a/cpp/pixels-reader/pixels-core/include/reader/DateColumnReader.h
+++ b/cpp/pixels-reader/pixels-core/include/reader/DateColumnReader.h
@@ -17,7 +17,7 @@ public:
 	          int offset, int size, int pixelStride,
 	          int vectorIndex, std::shared_ptr<ColumnVector> vector,
 	          pixels::proto::ColumnChunkIndex & chunkIndex,
-			  std::shared_ptr<pixelsFilterMask> filterMask) override;
+			  std::shared_ptr<PixelsBitMask> filterMask) override;
 private:
 	/**
      * True if the data type of the values is long (int64), otherwise the data type is int32.

--- a/cpp/pixels-reader/pixels-core/include/reader/DecimalColumnReader.h
+++ b/cpp/pixels-reader/pixels-core/include/reader/DecimalColumnReader.h
@@ -16,7 +16,7 @@ public:
               int offset, int size, int pixelStride,
               int vectorIndex, std::shared_ptr<ColumnVector> vector,
               pixels::proto::ColumnChunkIndex & chunkIndex,
-              std::shared_ptr<pixelsFilterMask> filterMask) override;
+              std::shared_ptr<PixelsBitMask> filterMask) override;
 private:
     /**
      * True if the data type of the values is long (int64), otherwise the data type is int32.

--- a/cpp/pixels-reader/pixels-core/include/reader/IntegerColumnReader.h
+++ b/cpp/pixels-reader/pixels-core/include/reader/IntegerColumnReader.h
@@ -17,7 +17,7 @@ public:
               int offset, int size, int pixelStride,
               int vectorIndex, std::shared_ptr<ColumnVector> vector,
               pixels::proto::ColumnChunkIndex & chunkIndex,
-              std::shared_ptr<pixelsFilterMask> filterMask) override;
+              std::shared_ptr<PixelsBitMask> filterMask) override;
 private:
     /**
      * True if the data type of the values is long (int64), otherwise the data type is int32.

--- a/cpp/pixels-reader/pixels-core/include/reader/PixelsRecordReaderImpl.h
+++ b/cpp/pixels-reader/pixels-core/include/reader/PixelsRecordReaderImpl.h
@@ -49,7 +49,7 @@ public:
     std::shared_ptr<VectorizedRowBatch> readBatch(bool reuse) override;
 	std::shared_ptr<TypeDescription> getResultSchema() override;
     bool read();
-	std::shared_ptr<pixelsFilterMask> getFilterMask();
+	std::shared_ptr<PixelsBitMask> getFilterMask();
 	bool isEndOfFile() override;
     ~PixelsRecordReaderImpl();
 	void close() override;
@@ -79,7 +79,7 @@ private:
 	bool endOfFile;
 	int curRGRowCount;
     bool enabledFilterPushDown;
-    std::shared_ptr<pixelsFilterMask> filterMask;
+    std::shared_ptr<PixelsBitMask> filterMask;
 	std::shared_ptr<pixels::proto::RowGroupFooter> curRGFooter;
 	std::vector<std::shared_ptr<pixels::proto::ColumnEncoding>> curEncoding;
 	std::vector<int> curChunkBufferIndex;

--- a/cpp/pixels-reader/pixels-core/include/reader/StringColumnReader.h
+++ b/cpp/pixels-reader/pixels-core/include/reader/StringColumnReader.h
@@ -18,7 +18,7 @@ public:
               int offset, int size, int pixelStride,
               int vectorIndex, std::shared_ptr<ColumnVector> vector,
               pixels::proto::ColumnChunkIndex & chunkIndex,
-			  std::shared_ptr<pixelsFilterMask> filterMask) override;
+			  std::shared_ptr<PixelsBitMask> filterMask) override;
 
 private:
     /**

--- a/cpp/pixels-reader/pixels-core/lib/PixelsBitMask.cpp
+++ b/cpp/pixels-reader/pixels-core/lib/PixelsBitMask.cpp
@@ -2,29 +2,29 @@
 // Created by liyu on 7/6/23.
 //
 
-#include "PixelsFilterMask.h"
+#include "PixelsBitMask.h"
 #include <math.h>
 
-pixelsFilterMask::pixelsFilterMask(long length) {
+PixelsBitMask::PixelsBitMask(long length) {
     this->maskLength = length;
     this->arrayLength = std::ceil(1.0 * length / 8);
     posix_memalign(reinterpret_cast<void **>(&mask), 4096, arrayLength);
     memset(mask, 255, arrayLength);
 }
 
-pixelsFilterMask::pixelsFilterMask(pixelsFilterMask &other) {
+PixelsBitMask::PixelsBitMask(PixelsBitMask &other) {
     maskLength = other.maskLength;
     arrayLength = other.arrayLength;
     posix_memalign(reinterpret_cast<void **>(&mask), 4096, arrayLength);
     memcpy(mask, other.mask, arrayLength);
 }
 
-pixelsFilterMask::~pixelsFilterMask() {
+PixelsBitMask::~PixelsBitMask() {
     free(mask);
     mask = nullptr;
 }
 
-bool pixelsFilterMask::isNone() {
+bool PixelsBitMask::isNone() {
     for(int i = 0; i < arrayLength - 1; i++) {
         if(mask[i] != 0) {
             return false;
@@ -35,7 +35,7 @@ bool pixelsFilterMask::isNone() {
     return !(lastByte & lastMask);
 }
 
-void pixelsFilterMask::Or(pixelsFilterMask &other) {
+void PixelsBitMask::Or(PixelsBitMask &other) {
     // if their maskLength are the same, the arrayLength must be the same
     assert(other.maskLength == maskLength);
     for(int i = 0; i < arrayLength; i++) {
@@ -43,7 +43,7 @@ void pixelsFilterMask::Or(pixelsFilterMask &other) {
     }
 }
 
-void pixelsFilterMask::And(pixelsFilterMask &other) {
+void PixelsBitMask::And(PixelsBitMask &other) {
 // if their maskLength are the same, the arrayLength must be the same
     assert(other.maskLength == maskLength);
     for(int i = 0; i < arrayLength; i++) {
@@ -51,11 +51,11 @@ void pixelsFilterMask::And(pixelsFilterMask &other) {
     }
 }
 
-void pixelsFilterMask::set() {
+void PixelsBitMask::set() {
     memset(mask, 255, arrayLength);
 }
 
-void pixelsFilterMask::set(long index, uint8_t value) {
+void PixelsBitMask::set(long index, uint8_t value) {
     assert(index < maskLength);
     uint8_t & byteMask = mask[index / 8];
     uint8_t shiftMask = 1 << (index % 8);
@@ -68,13 +68,13 @@ void pixelsFilterMask::set(long index, uint8_t value) {
 
 
 
-uint8_t pixelsFilterMask::get(long index) {
+uint8_t PixelsBitMask::get(long index) {
     uint8_t & byteMask = mask[index / 8];
     uint8_t shiftMask = 1 << (index % 8);
     return bool(byteMask & shiftMask);
 }
 
-void pixelsFilterMask::Or(long index, uint8_t value) {
+void PixelsBitMask::Or(long index, uint8_t value) {
     if(value == 1) {
         assert(index < maskLength);
         uint8_t & byteMask = mask[index / 8];
@@ -83,7 +83,7 @@ void pixelsFilterMask::Or(long index, uint8_t value) {
     }
 }
 
-void pixelsFilterMask::And(long index, uint8_t value) {
+void PixelsBitMask::And(long index, uint8_t value) {
     if(value == 0) {
         assert(index < maskLength);
         uint8_t & byteMask = mask[index / 8];
@@ -92,7 +92,7 @@ void pixelsFilterMask::And(long index, uint8_t value) {
     }
 }
 
-void pixelsFilterMask::setByteAligned(long index, uint8_t value) {
+void PixelsBitMask::setByteAligned(long index, uint8_t value) {
     mask[index / 8] = value;
 }
 

--- a/cpp/pixels-reader/pixels-core/lib/reader/DateColumnReader.cpp
+++ b/cpp/pixels-reader/pixels-core/lib/reader/DateColumnReader.cpp
@@ -15,7 +15,7 @@ void DateColumnReader::close() {
 
 void DateColumnReader::read(std::shared_ptr<ByteBuffer> input, pixels::proto::ColumnEncoding & encoding, int offset,
                                int size, int pixelStride, int vectorIndex, std::shared_ptr<ColumnVector> vector,
-                               pixels::proto::ColumnChunkIndex & chunkIndex, std::shared_ptr<pixelsFilterMask> filterMask) {
+                               pixels::proto::ColumnChunkIndex & chunkIndex, std::shared_ptr<PixelsBitMask> filterMask) {
 	std::shared_ptr<DateColumnVector> columnVector =
 	    std::static_pointer_cast<DateColumnVector>(vector);
 	if(offset == 0) {

--- a/cpp/pixels-reader/pixels-core/lib/reader/DecimalColumnReader.cpp
+++ b/cpp/pixels-reader/pixels-core/lib/reader/DecimalColumnReader.cpp
@@ -19,7 +19,7 @@ void DecimalColumnReader::close() {
 
 void DecimalColumnReader::read(std::shared_ptr<ByteBuffer> input, pixels::proto::ColumnEncoding & encoding, int offset,
                                int size, int pixelStride, int vectorIndex, std::shared_ptr<ColumnVector> vector,
-                               pixels::proto::ColumnChunkIndex & chunkIndex, std::shared_ptr<pixelsFilterMask> filterMask) {
+                               pixels::proto::ColumnChunkIndex & chunkIndex, std::shared_ptr<PixelsBitMask> filterMask) {
     std::shared_ptr<DecimalColumnVector> columnVector =
             std::static_pointer_cast<DecimalColumnVector>(vector);
 	if(type->getPrecision() != columnVector->getPrecision() || type->getScale() != columnVector->getScale()) {

--- a/cpp/pixels-reader/pixels-core/lib/reader/IntegerColumnReader.cpp
+++ b/cpp/pixels-reader/pixels-core/lib/reader/IntegerColumnReader.cpp
@@ -15,7 +15,7 @@ void IntegerColumnReader::close() {
 
 void IntegerColumnReader::read(std::shared_ptr<ByteBuffer> input, pixels::proto::ColumnEncoding & encoding, int offset,
                                int size, int pixelStride, int vectorIndex, std::shared_ptr<ColumnVector> vector,
-                               pixels::proto::ColumnChunkIndex & chunkIndex, std::shared_ptr<pixelsFilterMask> filterMask) {
+                               pixels::proto::ColumnChunkIndex & chunkIndex, std::shared_ptr<PixelsBitMask> filterMask) {
     std::shared_ptr<LongColumnVector> columnVector =
             std::static_pointer_cast<LongColumnVector>(vector);
     // if read from start, init the stream and decoder

--- a/cpp/pixels-reader/pixels-core/lib/reader/PixelsRecordReaderImpl.cpp
+++ b/cpp/pixels-reader/pixels-core/lib/reader/PixelsRecordReaderImpl.cpp
@@ -120,7 +120,7 @@ void PixelsRecordReaderImpl::UpdateRowGroupInfo() {
 
     if(enabledFilterPushDown) {
         int length = std::min(batchSize, curRGRowCount);
-        filterMask = std::make_shared<pixelsFilterMask>(length);
+        filterMask = std::make_shared<PixelsBitMask>(length);
     }
 
 	curRGFooter = rowGroupFooters.at(curRGIdx);
@@ -330,7 +330,7 @@ void PixelsRecordReaderImpl::asyncReadComplete(int requestSize) {
 }
 
 
-std::shared_ptr<pixelsFilterMask> PixelsRecordReaderImpl::getFilterMask() {
+std::shared_ptr<PixelsBitMask> PixelsRecordReaderImpl::getFilterMask() {
     return filterMask;
 }
 

--- a/cpp/pixels-reader/pixels-core/lib/reader/StringColumnReader.cpp
+++ b/cpp/pixels-reader/pixels-core/lib/reader/StringColumnReader.cpp
@@ -16,7 +16,7 @@ void StringColumnReader::close() {
 
 void StringColumnReader::read(std::shared_ptr<ByteBuffer> input, pixels::proto::ColumnEncoding & encoding, int offset,
                               int size, int pixelStride, int vectorIndex, std::shared_ptr<ColumnVector> vector,
-                              pixels::proto::ColumnChunkIndex & chunkIndex, std::shared_ptr<pixelsFilterMask> filterMask) {
+                              pixels::proto::ColumnChunkIndex & chunkIndex, std::shared_ptr<PixelsBitMask> filterMask) {
     if(offset == 0) {
         elementIndex = 0;
         bufferOffset = 0;

--- a/cpp/pixels-reader/tests/unit_tests.cpp
+++ b/cpp/pixels-reader/tests/unit_tests.cpp
@@ -5,7 +5,7 @@
 #include <iostream>
 #include <thread>
 #include <string>
-#include "PixelsFilterMask.h"
+#include "PixelsBitMask.h"
 using namespace std;
 //
 //
@@ -583,7 +583,7 @@ using namespace std;
 //	}
 //}
 TEST(reader, filterMaskTest) {
-	pixelsFilterMask filterMask(1025);
+    PixelsBitMask filterMask(1025);
 	filterMask.set(0, 1);
 	filterMask.set(66, 1);
 	filterMask.set(1023, 1);


### PR DESCRIPTION
We rename `pixelsFilterMask` to `PixelsBitMask`. The reason is that both filter mask and null mask use this class, so we rename it to a more general name. 