### PR TITLE
[Issue #539] replace lengths with starts for non-encoded string columns.

### DIFF
--- a/cpp/README.md
+++ b/cpp/README.md
@@ -23,7 +23,7 @@ make pull
 
 Then set the `PIXELS_HOME` environment variable (Ignore it if you have already set it when installing Pixels).
 
-Finally compile the code:
+Finally, compile the code:
 
 ```
 make -j
@@ -31,7 +31,7 @@ make -j
 
 ### Example
 
-Here is an pixels reader example in the directory `duckdb/examples/pixels-example`. This example validates the correctness of compilation and gives you an idea how to load the pixels data. 
+Here is a pixels reader example in the directory `duckdb/examples/pixels-example`. This example validates the correctness of compilation and gives you an idea how to load the pixels data. 
 
 To run this binary:
 
@@ -47,8 +47,6 @@ set `CMake options` as:
 ```shell
 -DDUCKDB_OOT_EXTENSION_NAMES="pixels" -DDUCKDB_OOT_EXTENSION_PIXELS_PATH=${PIXELS_HOME}/cpp -DDUCKDB_OOT_EXTENSION_PIXELS_SHOULD_LINK="TRUE" -DDUCKDB_OOT_EXTENSION_PIXELS_INCLUDE_PATH=${PIXELS_HOME}/cpp/include
 ```
-
-
 
 ### Benchmark
 
@@ -70,7 +68,7 @@ cd duckdb
 python scripts/run_benchmark.py --help
 ```
 
-Run TPCH 1 benchmarks:
+Run TPC-H 1 benchmarks:
 
 ```
 python scripts/run_benchmark.py --pixels "benchmark/tpch/pixels/tpch_1/" --parquet "benchmark/tpch/parquet/tpch_1/" -v --repeat-time-disk 1
@@ -117,7 +115,7 @@ Here are two important parameters in `pixels.properties`:
 
 * `localfs.enable.async.io`: use async IO or sync IO
 
-Currently the following configuration has the best performance in pixels C++ reader:
+Currently, the following configuration has the best performance in pixels C++ reader:
 
 ```
 localfs.enable.direct.io=true
@@ -131,7 +129,7 @@ localfs.enable.async.io=true
 
 `pixels reader` and `duckdb` will be updated frequently in the next few months, so please keep the two submodules updated. 
 
-To fetch the lastest pixels reader and duckdb:
+To fetch the latest pixels reader and duckdb:
 
 ```
 make update
@@ -145,7 +143,7 @@ Please make sure you don't use the official `duckdb` repository. The official `d
 
 ### 3. I can't load the pixels data via pixels C++ reader
 
-Currently the pixels Java writer and reader uses big endian to write/read pixels data. We find that small endian is more efficient for pixels c++ reader. Therefore, in order to generate the pixels data with small endian, please use Pixels in [little-endian branch](https://github.com/pixelsdb/pixels/tree/little-endian). We will merge the small endian to pixels java reader in the future. 
+Currently, the pixels Java writer and reader uses big endian to write/read pixels data. We find that small endian is more efficient for pixels c++ reader. Therefore, in order to generate the pixels data with small endian, please use Pixels in [little-endian branch](https://github.com/pixelsdb/pixels/tree/little-endian). We will merge the small endian to pixels java reader in the future. 
 
 
 ### 4. I fail to run the pixels and parquet benchmark

--- a/cpp/pixels-reader/pixels-core/lib/reader/StringColumnReader.cpp
+++ b/cpp/pixels-reader/pixels-core/lib/reader/StringColumnReader.cpp
@@ -123,7 +123,7 @@ void StringColumnReader::readContent(std::shared_ptr<ByteBuffer> input,
 			}
 			starts[i] = bufferStart + startsOffset - originsOffset;
 		} else {
-            throw InvalidArgumentException("StringColumnReader::readContent: dictionary size must  be defined. ");
+            throw InvalidArgumentException("StringColumnReader::readContent: dictionary size must be defined.");
 		}
 		contentDecoder = std::make_shared<RunLenIntDecoder>(contentBuf, false);
     } else {

--- a/pixels-common/src/main/resources/pixels.properties
+++ b/pixels-common/src/main/resources/pixels.properties
@@ -57,7 +57,7 @@ cache.read.direct=false
 ### pixels reader, writer, and compactor settings ###
 # the pixels stride (number of values in a pixel) for pixels writer
 pixel.stride=10000
-# the row group size in bytes for pixels writer
+# the row group size in bytes for pixels writer, should not exceed 2GB
 row.group.size=268435456
 # the chunk alignment for pixels writer, it is for SIMD and its unit is byte
 column.chunk.alignment=32

--- a/pixels-core/pom.xml
+++ b/pixels-core/pom.xml
@@ -66,6 +66,12 @@
         </dependency>
 
         <dependency>
+            <groupId>net.java.dev.jna</groupId>
+            <artifactId>jna</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
             <groupId>io.etcd</groupId>
             <artifactId>jetcd-core</artifactId>
             <optional>true</optional>

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/StringColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/StringColumnReader.java
@@ -242,6 +242,8 @@ public class StringColumnReader extends ColumnReader
                     }
                     if (hasNull && isNull[isNullBitIndex] == 1)
                     {
+                        // skip the repeated starts for null values
+                        startsBuf.skipBytes(Integer.BYTES);
                         columnVector.isNull[i + vectorIndex] = true;
                         columnVector.noNulls = false;
                     } else
@@ -408,6 +410,7 @@ public class StringColumnReader extends ColumnReader
             else
             {
                 contentBuf = inputBuffer.slice(0, startsOffset);
+                bufferOffset = contentBuf.arrayOffset();
             }
             /*
              * Issue #539:
@@ -416,6 +419,7 @@ public class StringColumnReader extends ColumnReader
              * However, for safety, we still explicitly set the byte order for startsBuf.
              */
             startsBuf = inputBuffer.slice(startsOffset, inputLength - Integer.BYTES - startsOffset).order(byteOrder);
+            nextStart = startsBuf.readInt(); // read out the first start offset, which is 0
         }
     }
 }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/StringColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/StringColumnReader.java
@@ -43,33 +43,44 @@ import static com.google.common.base.Preconditions.checkArgument;
  */
 public class StringColumnReader extends ColumnReader
 {
-    private int originsOffset;
+    private int dictContentOffset;
 
-    private int startsOffset;
+    private int dictStartsOffset;
 
     private ByteBuf inputBuffer = null;
     /**
-     * The origin string content in dictionary.
-     * It is copied into heap from inputBuffer and has a backing array.
+     * The string content in dictionary. It is backed by an on-heap array.
+     * If inputBuffer is direct (has no backing array), bytes are copied from
+     * inputBuffer into dictContentBuf.
      */
-    private ByteBuf originsBuf = null;
+    private ByteBuf dictContentBuf = null;
     /**
-     * elements' ABSOLUTE start offsets in originsBuf.
+     * elements' ABSOLUTE start offsets in dictContentBuf.
      */
-    private int[] starts = null;
+    private int[] dictStarts = null;
 
     private byte[] isNull = new byte[8];
     /**
      * The encoded dictionary id (if dictionary encoded) or
      * the origin string content (if not dictionary encoded).
-     * In case of not dictionary encoded, it is copied into heap from inputBuffer
-     * and has a backing array.
+     * In case of not dictionary encoded, we ensure it is backed by an on-heap array.
+     * If inputBuffer is direct (has no backing array), bytes are copied from
+     * inputBuffer into dictContentBuf.
      */
     private ByteBuf contentBuf = null;
     /**
-     * RLE decoder of string content element length if no dictionary encoded.
+     * The start offsets of the elements in the content if not dictionary encoded.
+     * The first start offset is 0, and the last start offset of the length of the content.
      */
-    private RunLenIntDecoder lensDecoder = null;
+    private ByteBuf startsBuf = null;
+    /**
+     * The start offset of the current element in the content if not dictionary encoded.
+     */
+    private int currentStart = 0;
+    /**
+     * The next element in the content if not dictionary encoded.
+     */
+    private int nextStart = 0;
     /**
      * RLE decoder of dictionary encoded ids if dictionary encoded.
      */
@@ -111,20 +122,18 @@ public class StringColumnReader extends ColumnReader
     @Override
     public void close() throws IOException
     {
-        this.contentBuf = null;
         this.inputBuffer = null;
-        this.originsBuf = null;
-        this.starts = null;
+        this.contentBuf = null;
+        this.startsBuf = null;
+        this.currentStart = 0;
+        this.nextStart = 0;
+        this.dictContentBuf = null;
+        this.dictStarts = null;
         this.isNull = null;
         if (this.contentDecoder != null)
         {
             this.contentDecoder.close();
             this.contentDecoder = null;
-        }
-        if (this.lensDecoder != null)
-        {
-            this.lensDecoder.close();
-            this.lensDecoder = null;
         }
     }
 
@@ -155,9 +164,9 @@ public class StringColumnReader extends ColumnReader
             }
             // no memory copy
             boolean littleEndian = chunkIndex.hasLittleEndian() && chunkIndex.getLittleEndian();
-            inputBuffer = Unpooled.wrappedBuffer(input)
-                    .order(littleEndian ? ByteOrder.LITTLE_ENDIAN : ByteOrder.BIG_ENDIAN);
-            readContent(input.remaining(), encoding);
+            ByteOrder byteOrder = littleEndian ? ByteOrder.LITTLE_ENDIAN : ByteOrder.BIG_ENDIAN;
+            inputBuffer = Unpooled.wrappedBuffer(input).order(byteOrder);
+            readContent(input.remaining(), encoding, byteOrder);
             isNullOffset = (int) chunkIndex.getIsNullOffset();
             bufferOffset = 0;
             hasNull = true;
@@ -172,7 +181,7 @@ public class StringColumnReader extends ColumnReader
             {
                 // read original bytes
                 // we get bytes here to reduce memory copies and avoid creating many small byte arrays.
-                byte[] buffer = originsBuf.array();
+                byte[] buffer = dictContentBuf.array();
                 for (int i = 0; i < size; i++)
                 {
                     if (elementIndex % pixelStride == 0)
@@ -197,9 +206,9 @@ public class StringColumnReader extends ColumnReader
                     } else
                     {
                         int originId = (int) contentDecoder.next();
-                        int tmpLen = starts[originId + 1] - starts[originId];
+                        int tmpLen = dictStarts[originId + 1] - dictStarts[originId];
                         // use setRef instead of setVal to reduce memory copy.
-                        columnVector.setRef(i + vectorIndex, buffer, starts[originId], tmpLen);
+                        columnVector.setRef(i + vectorIndex, buffer, dictStarts[originId], tmpLen);
                     }
                     if (hasNull)
                     {
@@ -237,7 +246,9 @@ public class StringColumnReader extends ColumnReader
                         columnVector.noNulls = false;
                     } else
                     {
-                        int len = (int) lensDecoder.next();
+                        currentStart = nextStart;
+                        nextStart = startsBuf.readInt();
+                        int len = nextStart - currentStart;
                         // use setRef instead of setVal to reduce memory copy.
                         columnVector.setRef(i + vectorIndex, buffer, bufferOffset, len);
                         bufferOffset += len;
@@ -252,13 +263,15 @@ public class StringColumnReader extends ColumnReader
         }
         else if (vector instanceof DictionaryColumnVector)
         {
+            checkArgument(encoding.getKind().equals(PixelsProto.ColumnEncoding.Kind.DICTIONARY),
+                    "dictionary column vector can only be used on dictionary encoded column chunks");
             DictionaryColumnVector columnVector = (DictionaryColumnVector) vector;
             if (columnVector.dictArray == null)
             {
-                columnVector.dictArray = originsBuf.array();
-                columnVector.dictOffsets = starts;
+                columnVector.dictArray = dictContentBuf.array();
+                columnVector.dictOffsets = dictStarts;
             }
-            checkArgument(columnVector.dictArray == originsBuf.array(),
+            checkArgument(columnVector.dictArray == dictContentBuf.array(),
                     "dictionaries from the column vector and the origins buffer are not consistent");
 
             for (int i = 0; i < size; i++)
@@ -303,21 +316,21 @@ public class StringColumnReader extends ColumnReader
     /**
      * In this method, we have reduced most of significant memory copies.
      */
-    private void readContent(int inputLength, PixelsProto.ColumnEncoding encoding) throws IOException
+    private void readContent(int inputLength, PixelsProto.ColumnEncoding encoding, ByteOrder byteOrder) throws IOException
     {
         if (encoding.getKind().equals(PixelsProto.ColumnEncoding.Kind.DICTIONARY))
         {
             // read offsets
             inputBuffer.markReaderIndex();
             inputBuffer.skipBytes(inputLength - 2 * Integer.BYTES);
-            originsOffset = inputBuffer.readInt();
-            startsOffset = inputBuffer.readInt();
+            dictContentOffset = inputBuffer.readInt();
+            dictStartsOffset = inputBuffer.readInt();
             inputBuffer.resetReaderIndex();
             // read buffers
-            contentBuf = inputBuffer.slice(0, originsOffset);
+            contentBuf = inputBuffer.slice(0, dictContentOffset);
             if (this.inputBuffer.hasArray())
             {
-                originsBuf = inputBuffer.slice(originsOffset, startsOffset - originsOffset);
+                dictContentBuf = inputBuffer.slice(dictContentOffset, dictStartsOffset - dictContentOffset);
             }
             else
             {
@@ -331,18 +344,18 @@ public class StringColumnReader extends ColumnReader
                  * int the direct inputBuffer into a byte array.
                  * TODO: support ByteBuffer for string types.
                  */
-                byte[] bytes = new byte[startsOffset - originsOffset];
-                inputBuffer.getBytes(originsOffset, bytes, 0, startsOffset - originsOffset);
-                originsBuf = Unpooled.wrappedBuffer(bytes);
+                byte[] bytes = new byte[dictStartsOffset - dictContentOffset];
+                inputBuffer.getBytes(dictContentOffset, bytes, 0, dictStartsOffset - dictContentOffset);
+                dictContentBuf = Unpooled.wrappedBuffer(bytes);
             }
             // read starts, the last two integers (8 bytes) are the origin offset and starts offset
-            ByteBuf startsBuf = inputBuffer.slice(startsOffset, inputLength - startsOffset - 2 * Integer.BYTES);
+            ByteBuf startsBuf = inputBuffer.slice(dictStartsOffset, inputLength - dictStartsOffset - 2 * Integer.BYTES);
 
             // DO NOT use originsOffset as bufferStart, as multiple input buffers read
             // from disk (not from pixels cache) may share the same backing array, each starting
             // from different offsets. originsOffset equals to originsBuf.arrayOffset() only when the
             // input buffer starts from the first byte of backing array.
-            int bufferStart = originsBuf.arrayOffset();
+            int bufferStart = dictContentBuf.arrayOffset();
             RunLenIntDecoder startsDecoder = new RunLenIntDecoder(new ByteBufInputStream(startsBuf), false);
             /**
              * Issue #124:
@@ -350,13 +363,13 @@ public class StringColumnReader extends ColumnReader
              */
             if (encoding.hasDictionarySize())
             {
-                starts = new int[encoding.getDictionarySize() + 1];
+                dictStarts = new int[encoding.getDictionarySize() + 1];
                 int i = 0;
                 while (startsDecoder.hasNext())
                 {
-                    starts[i++] = bufferStart + (int) startsDecoder.next();
+                    dictStarts[i++] = bufferStart + (int) startsDecoder.next();
                 }
-                starts[i] = bufferStart + startsOffset - originsOffset;
+                dictStarts[i] = bufferStart + dictStartsOffset - dictContentOffset;
             }
             else
             {
@@ -366,8 +379,8 @@ public class StringColumnReader extends ColumnReader
                 {
                     startsArray.add(bufferStart + (int) startsDecoder.next());
                 }
-                startsArray.add(bufferStart + startsOffset - originsOffset);
-                starts = startsArray.toArray();
+                startsArray.add(bufferStart + dictStartsOffset - dictContentOffset);
+                dictStarts = startsArray.toArray();
             }
 
             /*
@@ -383,22 +396,26 @@ public class StringColumnReader extends ColumnReader
             // read lens field offset
             inputBuffer.markReaderIndex();
             inputBuffer.skipBytes(inputLength - Integer.BYTES);
-            int lensOffset = inputBuffer.readInt();
+            int startsOffset = inputBuffer.readInt();
             inputBuffer.resetReaderIndex();
             // read strings
             if (this.inputBuffer.isDirect())
             {
-                byte[] bytes = new byte[lensOffset];
-                inputBuffer.getBytes(0, bytes, 0, lensOffset);
+                byte[] bytes = new byte[startsOffset];
+                inputBuffer.getBytes(0, bytes, 0, startsOffset);
                 contentBuf = Unpooled.wrappedBuffer(bytes);
             }
             else
             {
-                contentBuf = inputBuffer.slice(0, lensOffset);
+                contentBuf = inputBuffer.slice(0, startsOffset);
             }
-            // read lens field
-            ByteBuf lensBuf = inputBuffer.slice(lensOffset, inputLength - Integer.BYTES - lensOffset);
-            lensDecoder = new RunLenIntDecoder(new ByteBufInputStream(lensBuf), false);
+            /*
+             * Issue #539:
+             * Read the starts field.
+             * In the current version (4.1.77-Final) of netty, ByteBuf.slice() extends the byte order from inputBuffer.
+             * However, for safety, we still explicitly set the byte order for startsBuf.
+             */
+            startsBuf = inputBuffer.slice(startsOffset, inputLength - Integer.BYTES - startsOffset).order(byteOrder);
         }
     }
 }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/utils/DynamicIntArray.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/utils/DynamicIntArray.java
@@ -83,8 +83,7 @@ public final class DynamicIntArray
         if (index >= length)
         {
             throw new IndexOutOfBoundsException("Index " + index +
-                    " is outside of 0.." +
-                    (length - 1));
+                    " is outside of 0.." + (length - 1));
         }
         int i = index / chunkSize;
         int j = index % chunkSize;

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/utils/EncodingUtils.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/utils/EncodingUtils.java
@@ -213,7 +213,6 @@ public class EncodingUtils
 
     /**
      * Write a long value into the output in little endian.
-     * TODO: the value is not encoded.
      *
      * @param output the output
      * @param value the long value
@@ -245,8 +244,39 @@ public class EncodingUtils
     }
 
     /**
-     * Write a int value into the output in little endian.
-     * TODO: the value is not encoded.
+     * Write a long value into the output in big endian.
+     *
+     * @param output the output
+     * @param value the long value
+     * @throws IOException
+     */
+    public void writeLongBE(OutputStream output, long value) throws IOException
+    {
+        writeBuffer[7] = (byte) ((value) & 0xff);
+        writeBuffer[6] = (byte) ((value >> 8) & 0xff);
+        writeBuffer[5] = (byte) ((value >> 16) & 0xff);
+        writeBuffer[4] = (byte) ((value >> 24) & 0xff);
+        writeBuffer[3] = (byte) ((value >> 32) & 0xff);
+        writeBuffer[2] = (byte) ((value >> 40) & 0xff);
+        writeBuffer[1] = (byte) ((value >> 48) & 0xff);
+        writeBuffer[0] = (byte) ((value >> 56) & 0xff);
+        output.write(writeBuffer, 0, 8);
+    }
+
+    public long readLongBE(byte[] inputBytes, int offset)
+    {
+        return (((inputBytes[7+ offset] & 0xff))
+                + ((inputBytes[6 + offset] & 0xff) << 8)
+                + ((inputBytes[5 + offset] & 0xff) << 16)
+                + ((long) (inputBytes[4 + offset] & 0xff) << 24)
+                + ((long) (inputBytes[3 + offset] & 0xff) << 32)
+                + ((long) (inputBytes[2 + offset] & 0xff) << 40)
+                + ((long) (inputBytes[1 + offset] & 0xff) << 48)
+                + ((long) (inputBytes[offset] & 0xff) << 56));
+    }
+
+    /**
+     * Write an int value into the output in little endian.
      *
      * @param output the output
      * @param value the long value
@@ -267,6 +297,31 @@ public class EncodingUtils
                 + ((inputBytes[1 + offset] & 0xff) << 8)
                 + ((inputBytes[2 + offset] & 0xff) << 16)
                 + ((inputBytes[3 + offset] & 0xff) << 24)
+        );
+    }
+
+    /**
+     * Write an int value into the output in big endian.
+     *
+     * @param output the output
+     * @param value the long value
+     * @throws IOException
+     */
+    public void writeIntBE(OutputStream output, int value) throws IOException
+    {
+        writeBuffer[3] = (byte) ((value) & 0xff);
+        writeBuffer[2] = (byte) ((value >> 8) & 0xff);
+        writeBuffer[1] = (byte) ((value >> 16) & 0xff);
+        writeBuffer[0] = (byte) ((value >> 24) & 0xff);
+        output.write(writeBuffer, 0, 4);
+    }
+
+    public int readIntBE(byte[] inputBytes, int offset)
+    {
+        return (((inputBytes[3 + offset] & 0xff))
+                + ((inputBytes[2 + offset] & 0xff) << 8)
+                + ((inputBytes[1 + offset] & 0xff) << 16)
+                + ((inputBytes[offset] & 0xff) << 24)
         );
     }
 
@@ -1092,8 +1147,7 @@ public class EncodingUtils
             encoder.onMalformedInput(CodingErrorAction.REPLACE);
             encoder.onUnmappableCharacter(CodingErrorAction.REPLACE);
         }
-        ByteBuffer bytes =
-                encoder.encode(CharBuffer.wrap(string.toCharArray()));
+        ByteBuffer bytes = encoder.encode(CharBuffer.wrap(string.toCharArray()));
         if (replace)
         {
             encoder.onMalformedInput(CodingErrorAction.REPORT);

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/StringColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/StringColumnWriter.java
@@ -124,7 +124,9 @@ public class StringColumnWriter extends BaseColumnWriter
         for (int i = 0; i < curPartLength; i++)
         {
             curPixelEleIndex++;
-            if (columnVector.isNull[i + curPartOffset])
+            // add starts even if the current value is null, this is for random access
+            startsArray.add(startOffset);
+            if (columnVector.isNull[curPartOffset + i])
             {
                 hasNull = true;
                 pixelStatRecorder.increment();
@@ -132,7 +134,6 @@ public class StringColumnWriter extends BaseColumnWriter
             else
             {
                 outputStream.write(values[curPartOffset + i], vOffsets[curPartOffset + i], vLens[curPartOffset + i]);
-                startsArray.add(startOffset);
                 startOffset += vLens[curPartOffset + i];
                 pixelStatRecorder.updateString(values[curPartOffset + i], vOffsets[curPartOffset + i],
                         vLens[curPartOffset + i], 1);

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/StringColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/StringColumnWriter.java
@@ -26,6 +26,7 @@ import io.pixelsdb.pixels.core.encoding.Dictionary;
 import io.pixelsdb.pixels.core.encoding.HashTableDictionary;
 import io.pixelsdb.pixels.core.encoding.RunLenIntEncoder;
 import io.pixelsdb.pixels.core.utils.DynamicIntArray;
+import io.pixelsdb.pixels.core.utils.EncodingUtils;
 import io.pixelsdb.pixels.core.vector.BinaryColumnVector;
 import io.pixelsdb.pixels.core.vector.ColumnVector;
 
@@ -56,8 +57,10 @@ import java.nio.ByteOrder;
 public class StringColumnWriter extends BaseColumnWriter
 {
     private final long[] curPixelVector = new long[pixelStride];      // current vector holding encoded values of string
-    private final DynamicIntArray lensArray = new DynamicIntArray();  // lengths of each string when un-encoded
+    private final DynamicIntArray startsArray = new DynamicIntArray();  // lengths of each string when un-encoded
     private final Dictionary dictionary = new HashTableDictionary(Constants.INIT_DICT_SIZE);
+    private final EncodingUtils encodingUtils;
+    private int startOffset = 0; // the start offset for the current string when un-encoded
     private boolean futureUseDictionaryEncoding;
     private boolean currentUseDictionaryEncoding;
     private boolean doneDictionaryEncodingCheck = false;
@@ -67,6 +70,7 @@ public class StringColumnWriter extends BaseColumnWriter
         super(type, pixelStride, isEncoding, byteOrder);
         this.futureUseDictionaryEncoding = isEncoding;
         this.currentUseDictionaryEncoding = isEncoding;
+        this.encodingUtils = new EncodingUtils();
         encoder = new RunLenIntEncoder(false, true);
     }
 
@@ -128,7 +132,8 @@ public class StringColumnWriter extends BaseColumnWriter
             else
             {
                 outputStream.write(values[curPartOffset + i], vOffsets[curPartOffset + i], vLens[curPartOffset + i]);
-                lensArray.add(vLens[curPartOffset + i]);
+                startsArray.add(startOffset);
+                startOffset += vLens[curPartOffset + i];
                 pixelStatRecorder.updateString(values[curPartOffset + i], vOffsets[curPartOffset + i],
                         vLens[curPartOffset + i], 1);
             }
@@ -190,7 +195,7 @@ public class StringColumnWriter extends BaseColumnWriter
         }
         else
         {
-            flushLens();
+            flushStarts();
         }
     }
 
@@ -210,22 +215,31 @@ public class StringColumnWriter extends BaseColumnWriter
     @Override
     public void close() throws IOException
     {
-        lensArray.clear();
+        startsArray.clear();
         dictionary.clear();
         encoder.close();
         super.close();
     }
 
-    private void flushLens() throws IOException
+    private void flushStarts() throws IOException
     {
         int lensFieldOffset = outputStream.size();
-        long[] tmpLens = new long[lensArray.size()];
-        for (int i = 0; i < lensArray.size(); i++)
+        startsArray.add(startOffset); // add the last start offset
+        if (byteOrder.equals(ByteOrder.LITTLE_ENDIAN))
         {
-            tmpLens[i] = lensArray.get(i);
+            for (int i = 0; i < startsArray.size(); i++)
+            {
+                encodingUtils.writeIntLE(outputStream, startsArray.get(i));
+            }
         }
-        lensArray.clear();
-        outputStream.write(encoder.encode(tmpLens));
+        else
+        {
+            for (int i = 0; i < startsArray.size(); i++)
+            {
+                encodingUtils.writeIntBE(outputStream, startsArray.get(i));
+            }
+        }
+        startsArray.clear();
 
         ByteBuffer offsetBuf = ByteBuffer.allocate(Integer.BYTES);
         offsetBuf.order(byteOrder);

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/TestByteBuf.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/TestByteBuf.java
@@ -29,6 +29,7 @@ import org.junit.Test;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 
 /**
  * pixels
@@ -45,6 +46,12 @@ public class TestByteBuf
         ByteBuffer buffer1 = DirectIoLib.allocateBuffer(10).getBuffer();
         System.out.println(buffer1.order());
         assert buffer1.order() == buffer.order();
+        ByteBuf buf = Unpooled.wrappedBuffer(buffer);
+        System.out.println(buf.order());
+        buf = buf.order(ByteOrder.LITTLE_ENDIAN);
+        System.out.println(buf.order());
+        ByteBuf buf1 = buf.slice(0, 5);
+        System.out.println(buf1.order());
     }
 
     @Test


### PR DESCRIPTION
The starts array is not encoded by runlength encoding, and it is padded for null values (we will make this configurable in the next step).
Some variable members in StringColumnReader are renamed:
originsOffset -> dictContentOffset,
startsOffset -> dictStartsOffset,
originBuf -> dictContentBuf,
starts -> dictStarts.
@yuly16 please help update the c++ StringColumnReader accordingly.