### PR TITLE
[Issue #549] fix dependencies for slf4j

### DIFF
--- a/pixels-cli/pom.xml
+++ b/pixels-cli/pom.xml
@@ -152,6 +152,7 @@
                                     <mainClass>${mainClass}</mainClass>
                                     <manifestEntries>
                                         <Add-Opens>java.base/sun.nio.ch java.base/java.nio</Add-Opens>
+                                        <Multi-Release>true</Multi-Release>
                                     </manifestEntries>
                                 </transformer>
                             </transformers>

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/natives/DirectIoLib.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/natives/DirectIoLib.java
@@ -24,8 +24,8 @@ import com.sun.jna.Platform;
 import com.sun.jna.Pointer;
 import com.sun.jna.ptr.PointerByReference;
 import io.pixelsdb.pixels.common.utils.ConfigFactory;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.FileDescriptor;
 import java.io.IOException;
@@ -51,7 +51,7 @@ import static io.pixelsdb.pixels.common.utils.JvmUtils.JavaVersion;
  */
 public class DirectIoLib
 {
-    private static final Logger logger = LoggerFactory.getLogger(DirectIoLib.class);
+    private static final Logger logger = LogManager.getLogger(DirectIoLib.class);
     /**
      * The soft block size for use with transfer multiples and memory alignment multiples
      */

--- a/pixels-daemon/pom.xml
+++ b/pixels-daemon/pom.xml
@@ -141,6 +141,7 @@
                                     <mainClass>${mainClass}</mainClass>
                                     <manifestEntries>
                                         <Add-Opens>java.base/sun.nio.ch java.base/java.nio</Add-Opens>
+                                        <Multi-Release>true</Multi-Release>
                                     </manifestEntries>
                                 </transformer>
                             </transformers>

--- a/pixels-turbo/pixels-invoker-vhive/pom.xml
+++ b/pixels-turbo/pixels-invoker-vhive/pom.xml
@@ -79,23 +79,6 @@
             <artifactId>commons-cli</artifactId>
             <optional>true</optional>
         </dependency>
-
-        <!-- logging -->
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-api</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j18-impl</artifactId>
-            <optional>true</optional>
-        </dependency>
     </dependencies>
 
     <build>

--- a/pixels-turbo/pixels-worker-common/pom.xml
+++ b/pixels-turbo/pixels-worker-common/pom.xml
@@ -72,23 +72,6 @@
             <groupId>com.alibaba</groupId>
             <artifactId>fastjson</artifactId>
         </dependency>
-
-        <!-- logging -->
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-api</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j18-impl</artifactId>
-            <optional>true</optional>
-        </dependency>
     </dependencies>
 
     <build>

--- a/pixels-turbo/pixels-worker-lambda/pom.xml
+++ b/pixels-turbo/pixels-worker-lambda/pom.xml
@@ -80,23 +80,6 @@
             <version>${dep.gson.version}</version>
             <optional>true</optional>
         </dependency>
-
-        <!-- logging -->
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-api</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j18-impl</artifactId>
-            <optional>true</optional>
-        </dependency>
     </dependencies>
 
     <build>

--- a/pixels-turbo/pixels-worker-lambda/pom.xml
+++ b/pixels-turbo/pixels-worker-lambda/pom.xml
@@ -118,6 +118,11 @@
                                 <!-- ServicesResourceTransformer merges the resources in META-INF/services -->
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                                 <transformer implementation="com.github.edwgiz.maven_shade_plugin.log4j2_cache_transformer.PluginsCacheFileTransformer"/>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <manifestEntries>
+                                        <Multi-Release>true</Multi-Release>
+                                    </manifestEntries>
+                                </transformer>
                             </transformers>
                         </configuration>
                     </execution>

--- a/pixels-turbo/pixels-worker-vhive/pom.xml
+++ b/pixels-turbo/pixels-worker-vhive/pom.xml
@@ -147,6 +147,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.3.0</version>
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/pixels-turbo/pixels-worker-vhive/pom.xml
+++ b/pixels-turbo/pixels-worker-vhive/pom.xml
@@ -140,23 +140,6 @@
             <artifactId>commons-net</artifactId>
             <optional>true</optional>
         </dependency>
-
-        <!-- logging -->
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-api</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j18-impl</artifactId>
-            <optional>true</optional>
-        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -255,6 +255,10 @@
                         <groupId>io.grpc</groupId>
                         <artifactId>grpc-core</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-api</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
 
@@ -295,14 +299,14 @@
                         <groupId>log4j</groupId>
                         <artifactId>log4j</artifactId>
                     </exclusion>
-                    <!--<exclusion>
+                    <exclusion>
                         <groupId>org.slf4j</groupId>
                         <artifactId>slf4j-log4j12</artifactId>
                     </exclusion>
                     <exclusion>
                         <groupId>org.slf4j</groupId>
                         <artifactId>slf4j-api</artifactId>
-                    </exclusion>-->
+                    </exclusion>
                     <exclusion>
                         <groupId>javax.servlet</groupId>
                         <artifactId>javax.servlet-api</artifactId>
@@ -540,11 +544,6 @@
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-api</artifactId>
-                <version>${dep.log4j.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-slf4j18-impl</artifactId>
                 <version>${dep.log4j.version}</version>
             </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -255,10 +255,6 @@
                         <groupId>io.grpc</groupId>
                         <artifactId>grpc-core</artifactId>
                     </exclusion>
-                    <exclusion>
-                        <groupId>org.slf4j</groupId>
-                        <artifactId>slf4j-api</artifactId>
-                    </exclusion>
                 </exclusions>
             </dependency>
 
@@ -302,10 +298,6 @@
                     <exclusion>
                         <groupId>org.slf4j</groupId>
                         <artifactId>slf4j-log4j12</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.slf4j</groupId>
-                        <artifactId>slf4j-api</artifactId>
                     </exclusion>
                     <exclusion>
                         <groupId>javax.servlet</groupId>
@@ -428,10 +420,10 @@
                 <artifactId>jedis</artifactId>
                 <version>${dep.jedis.version}</version>
                 <exclusions>
-                    <exclusion>
+                    <!--<exclusion>
                         <groupId>org.slf4j</groupId>
                         <artifactId>slf4j-api</artifactId>
-                    </exclusion>
+                    </exclusion>-->
                 </exclusions>
             </dependency>
 
@@ -546,6 +538,11 @@
                 <artifactId>log4j-api</artifactId>
                 <version>${dep.log4j.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-slf4j-impl</artifactId>
+                <version>${dep.log4j.version}</version>
+            </dependency>
 
             <!--profiling-->
             <dependency>
@@ -593,6 +590,12 @@
             <artifactId>log4j-api</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <optional>true</optional>
+        </dependency>
+
         <!-- testing -->
         <dependency>
             <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,9 @@
 
         <!-- logging -->
         <dep.log4j.version>2.17.1</dep.log4j.version>
+        <!-- we only use log4j in pixels, the following are for third-party libs -->
         <dep.commons-logging.version>1.2</dep.commons-logging.version>
+        <dep.slf4j.version>1.7.32</dep.slf4j.version>
 
         <!-- testing -->
         <dep.junit.version>4.13.1</dep.junit.version>
@@ -255,6 +257,10 @@
                         <groupId>io.grpc</groupId>
                         <artifactId>grpc-core</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-api</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
 
@@ -298,6 +304,10 @@
                     <exclusion>
                         <groupId>org.slf4j</groupId>
                         <artifactId>slf4j-log4j12</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-api</artifactId>
                     </exclusion>
                     <exclusion>
                         <groupId>javax.servlet</groupId>
@@ -420,10 +430,10 @@
                 <artifactId>jedis</artifactId>
                 <version>${dep.jedis.version}</version>
                 <exclusions>
-                    <!--<exclusion>
+                    <exclusion>
                         <groupId>org.slf4j</groupId>
                         <artifactId>slf4j-api</artifactId>
-                    </exclusion>-->
+                    </exclusion>
                 </exclusions>
             </dependency>
 
@@ -539,9 +549,16 @@
                 <version>${dep.log4j.version}</version>
             </dependency>
             <dependency>
+                <!-- this is only for third-party libs that use slf4j -->
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-slf4j-impl</artifactId>
                 <version>${dep.log4j.version}</version>
+            </dependency>
+            <dependency>
+                <!-- this is only for third-party libs that use slf4j -->
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>${dep.slf4j.version}</version>
             </dependency>
 
             <!--profiling-->
@@ -591,6 +608,7 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <!-- this is only for third-party libs that use slf4j -->
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
             <optional>true</optional>


### PR DESCRIPTION
Add log4j-slf4j-impl as the default binding of slf4j.
Add a unified dependency definition for slf4j-api and exclude slf4j-api dependency in other libs including jetcd, jedis, and hadoop. But we do not add this dependency to the modules by default. It can be added as needed in the future.