### PR TITLE
[Issue #549] resolve conflict bindings between log4j and slf4j

### DIFF
--- a/pixels-cli/pom.xml
+++ b/pixels-cli/pom.xml
@@ -108,6 +108,13 @@
             <version>${dep.argparse4j.version}</version>
             <optional>true</optional>
         </dependency>
+
+        <dependency>
+            <!-- this is only for third-party libs that use slf4j -->
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pixels-daemon/pom.xml
+++ b/pixels-daemon/pom.xml
@@ -98,6 +98,13 @@
             <artifactId>grpc-stub</artifactId>
             <optional>true</optional>
         </dependency>
+
+        <dependency>
+            <!-- this is only for third-party libs that use slf4j -->
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pixels-example/pom.xml
+++ b/pixels-example/pom.xml
@@ -96,6 +96,13 @@
             <artifactId>netty-all</artifactId>
             <optional>true</optional>
         </dependency>
+
+        <dependency>
+            <!-- this is only for third-party libs that use slf4j -->
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pixels-turbo/pixels-worker-lambda/pom.xml
+++ b/pixels-turbo/pixels-worker-lambda/pom.xml
@@ -80,6 +80,13 @@
             <version>${dep.gson.version}</version>
             <optional>true</optional>
         </dependency>
+
+        <dependency>
+            <!-- this is only for third-party libs that use slf4j -->
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pixels-turbo/pixels-worker-vhive/pom.xml
+++ b/pixels-turbo/pixels-worker-vhive/pom.xml
@@ -140,6 +140,13 @@
             <artifactId>commons-net</artifactId>
             <optional>true</optional>
         </dependency>
+
+        <dependency>
+            <!-- this is only for third-party libs that use slf4j -->
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -548,7 +548,7 @@
                 <version>${dep.log4j.version}</version>
             </dependency>
             <dependency>
-                <!-- this is only for third-party libs that use slf4j -->
+                <!-- the default binding from slf4j to log4j, be careful of other conflict bindings -->
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-slf4j-impl</artifactId>
                 <version>${dep.log4j.version}</version>
@@ -598,12 +598,6 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <!-- this is only for third-party libs that use slf4j -->
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
             <optional>true</optional>
         </dependency>
 


### PR DESCRIPTION
Only add the binding when there are no other bindings. Otherwise, there will be conflict bindings problems.