### PR TITLE
[Issue #538] support encoding levels and dictionary encoding without cascading RLE

### DIFF
--- a/pixels-amphi/pixels-amphi/pom.xml
+++ b/pixels-amphi/pixels-amphi/pom.xml
@@ -178,7 +178,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.4</version>
+                <version>3.2.2</version>
+                <configuration>
+                    <createDependencyReducedPom>false</createDependencyReducedPom>
+                </configuration>
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/pixels-cli/pom.xml
+++ b/pixels-cli/pom.xml
@@ -129,7 +129,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.0</version>
+                <version>3.2.2</version>
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/pixels-cli/src/main/java/io/pixelsdb/pixels/cli/Main.java
+++ b/pixels-cli/src/main/java/io/pixelsdb/pixels/cli/Main.java
@@ -122,7 +122,7 @@ public class Main
                         .help("Specify the split regex of each row in a file");
                 argumentParser.addArgument("-c", "--consumer_thread_num").setDefault("4").required(true)
                         .help("specify the number of consumer threads used for data generation");
-                argumentParser.addArgument("-e", "--enable_encoding").setDefault(true)
+                argumentParser.addArgument("-e", "--encoding_level").setDefault(true)
                         .help("specify the option of enabling encoding or not");
                 argumentParser.addArgument("-l", "--loading_data_paths")
                         .help("specify the path of loading data");

--- a/pixels-cli/src/main/java/io/pixelsdb/pixels/cli/executor/LoadExecutor.java
+++ b/pixels-cli/src/main/java/io/pixelsdb/pixels/cli/executor/LoadExecutor.java
@@ -26,6 +26,7 @@ import io.pixelsdb.pixels.common.exception.MetadataException;
 import io.pixelsdb.pixels.common.physical.Storage;
 import io.pixelsdb.pixels.common.physical.StorageFactory;
 import io.pixelsdb.pixels.common.utils.ConfigFactory;
+import io.pixelsdb.pixels.core.encoding.EncodingLevel;
 import net.sourceforge.argparse4j.inf.Namespace;
 
 import java.util.List;
@@ -50,8 +51,8 @@ public class LoadExecutor implements CommandExecutor
         String regex = ns.getString("row_regex");
         String paths = ns.getString("loading_data_paths");
         int threadNum = Integer.parseInt(ns.getString("consumer_thread_num"));
-        boolean enableEncoding = Boolean.parseBoolean(ns.getString("enable_encoding"));
-        System.out.println("enable encoding: " + enableEncoding);
+        EncodingLevel encodingLevel = EncodingLevel.from(Integer.parseInt(ns.getString("encoding_level")));
+        System.out.println("encoding level: " + encodingLevel);
         String[] loadingDataPaths = null;
         if (paths != null)
         {
@@ -69,7 +70,7 @@ public class LoadExecutor implements CommandExecutor
 
         Storage storage = StorageFactory.Instance().getStorage(origin);
 
-        Parameters parameters = new Parameters(schemaName, tableName, rowNum, regex, enableEncoding, loadingDataPaths);
+        Parameters parameters = new Parameters(schemaName, tableName, rowNum, regex, encodingLevel, loadingDataPaths);
 
         // source already exist, producer option is false, add list of source to the queue
         List<String> fileList = storage.listPaths(origin);

--- a/pixels-cli/src/main/java/io/pixelsdb/pixels/cli/load/Parameters.java
+++ b/pixels-cli/src/main/java/io/pixelsdb/pixels/cli/load/Parameters.java
@@ -25,6 +25,7 @@ import io.pixelsdb.pixels.common.metadata.domain.Column;
 import io.pixelsdb.pixels.common.metadata.domain.Layout;
 import io.pixelsdb.pixels.common.metadata.domain.Ordered;
 import io.pixelsdb.pixels.common.utils.ConfigFactory;
+import io.pixelsdb.pixels.core.encoding.EncodingLevel;
 
 import javax.annotation.Nullable;
 import java.util.Arrays;
@@ -41,7 +42,7 @@ public class Parameters
     private String[] loadingPaths;
     private String schema;
     private int[] orderMapping;
-    private final boolean enableEncoding;
+    private final EncodingLevel encodingLevel;
 
     public String[] getLoadingPaths()
     {
@@ -68,20 +69,20 @@ public class Parameters
         return regex;
     }
 
-    public boolean isEnableEncoding()
+    public EncodingLevel getEncodingLevel()
     {
-        return enableEncoding;
+        return encodingLevel;
     }
 
     public Parameters(String dbName, String tableName, int maxRowNum, String regex,
-                      boolean enableEncoding, @Nullable String[] loadingPaths)
+                      EncodingLevel encodingLevel, @Nullable String[] loadingPaths)
     {
         this.dbName = dbName;
         this.tableName = tableName;
         this.maxRowNum = maxRowNum;
         this.regex = regex;
         this.loadingPaths = loadingPaths;
-        this.enableEncoding = enableEncoding;
+        this.encodingLevel = encodingLevel;
     }
 
     /**

--- a/pixels-cli/src/main/java/io/pixelsdb/pixels/cli/load/PixelsConsumer.java
+++ b/pixels-cli/src/main/java/io/pixelsdb/pixels/cli/load/PixelsConsumer.java
@@ -26,6 +26,7 @@ import io.pixelsdb.pixels.common.utils.DateUtil;
 import io.pixelsdb.pixels.core.PixelsWriter;
 import io.pixelsdb.pixels.core.PixelsWriterImpl;
 import io.pixelsdb.pixels.core.TypeDescription;
+import io.pixelsdb.pixels.core.encoding.EncodingLevel;
 import io.pixelsdb.pixels.core.vector.ColumnVector;
 import io.pixelsdb.pixels.core.vector.VectorizedRowBatch;
 
@@ -70,7 +71,7 @@ public class PixelsConsumer extends Consumer
             int[] orderMapping = parameters.getOrderMapping();
             int maxRowNum = parameters.getMaxRowNum();
             String regex = parameters.getRegex();
-            boolean enableEncoding = parameters.isEnableEncoding();
+            EncodingLevel encodingLevel = parameters.getEncodingLevel();
             if (regex.equals("\\s"))
             {
                 regex = " ";
@@ -136,7 +137,7 @@ public class PixelsConsumer extends Consumer
                                     .setBlockSize(blockSize)
                                     .setReplication(replication)
                                     .setBlockPadding(true)
-                                    .setEncoding(enableEncoding)
+                                    .setEncodingLevel(encodingLevel)
                                     .setCompressionBlockSize(1)
                                     .build();
                         }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/encoding/EncodingLevel.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/encoding/EncodingLevel.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2023 PixelsDB.
+ *
+ * This file is part of Pixels.
+ *
+ * Pixels is free software: you can redistribute it and/or modify
+ * it under the terms of the Affero GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * Pixels is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Affero GNU General Public License for more details.
+ *
+ * You should have received a copy of the Affero GNU General Public
+ * License along with Pixels.  If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package io.pixelsdb.pixels.core.encoding;
+
+import io.pixelsdb.pixels.common.exception.InvalidArgumentException;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Higher encoding level may have better compression ratio but higher computation overhead.
+ * @author hank
+ * @create 2023-08-12
+ */
+public enum EncodingLevel
+{
+    EL0(0), EL1(1), EL2(2);
+
+    private final int level;
+
+    EncodingLevel (int level)
+    {
+        this.level = level;
+    }
+
+    public static EncodingLevel from (int level)
+    {
+        switch (level)
+        {
+            case 0:
+                return EL0;
+            case 1:
+                return EL1;
+            case 2:
+                return EL2;
+            default:
+                throw new InvalidArgumentException("invalid encoding level " + level);
+        }
+    }
+
+    public static EncodingLevel from (String level)
+    {
+        requireNonNull(level, "level is null");
+        return from(Integer.parseInt(level));
+    }
+
+    public static boolean isValid(int level)
+    {
+        return level >= 0 && level <= 2;
+    }
+
+    public boolean ge(int level)
+    {
+        checkArgument(isValid(level), "leve is invalid");
+        return this.level >= level;
+    }
+
+    public boolean ge(EncodingLevel encodingLevel)
+    {
+        requireNonNull(level, "level is null");
+        return this.level >= encodingLevel.level;
+    }
+
+    public boolean equals(int level)
+    {
+        return this.level == level;
+    }
+
+    public boolean equals(EncodingLevel other)
+    {
+        // enums in Java can be compared using '=='.
+        return this == other;
+    }
+}

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/DecimalColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/DecimalColumnReader.java
@@ -96,8 +96,8 @@ public class DecimalColumnReader extends ColumnReader
         if (offset == 0)
         {
             this.inputBuffer = input;
-            // using little endian, for that the long values were written in little endian
-            this.inputBuffer.order(ByteOrder.LITTLE_ENDIAN);
+            boolean littleEndian = chunkIndex.hasLittleEndian() && chunkIndex.getLittleEndian();
+            this.inputBuffer.order(littleEndian ? ByteOrder.LITTLE_ENDIAN : ByteOrder.BIG_ENDIAN);
             inputIndex = this.inputBuffer.position();
             // isNull
             isNullOffset = inputIndex + (int) chunkIndex.getIsNullOffset();

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/DoubleColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/DoubleColumnReader.java
@@ -88,8 +88,8 @@ public class DoubleColumnReader extends ColumnReader
         if (offset == 0)
         {
             this.inputBuffer = input;
-            // using little endian, for that the long values were written in little endian
-            this.inputBuffer.order(ByteOrder.LITTLE_ENDIAN);
+            boolean littleEndian = chunkIndex.hasLittleEndian() && chunkIndex.getLittleEndian();
+            this.inputBuffer.order(littleEndian ? ByteOrder.LITTLE_ENDIAN : ByteOrder.BIG_ENDIAN);
             inputIndex = inputBuffer.position();
             // isNull
             isNullOffset = inputIndex + (int) chunkIndex.getIsNullOffset();

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/FloatColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/FloatColumnReader.java
@@ -87,8 +87,8 @@ public class FloatColumnReader extends ColumnReader
         if (offset == 0)
         {
             this.inputBuffer = input;
-            // using little endian, for that float is encoded into int by little endian
-            this.inputBuffer.order(ByteOrder.LITTLE_ENDIAN);
+            boolean littleEndian = chunkIndex.hasLittleEndian() && chunkIndex.getLittleEndian();
+            this.inputBuffer.order(littleEndian ? ByteOrder.LITTLE_ENDIAN : ByteOrder.BIG_ENDIAN);
             inputIndex = inputBuffer.position();
             isNullOffset = inputIndex + (int) chunkIndex.getIsNullOffset();
             hasNull = true;

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/LongDecimalColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/LongDecimalColumnReader.java
@@ -96,8 +96,8 @@ public class LongDecimalColumnReader extends ColumnReader
         if (offset == 0)
         {
             this.inputBuffer = input;
-            // using little endian, for that the long values were written in little endian
-            this.inputBuffer.order(ByteOrder.LITTLE_ENDIAN);
+            boolean littleEndian = chunkIndex.hasLittleEndian() && chunkIndex.getLittleEndian();
+            this.inputBuffer.order(littleEndian ? ByteOrder.LITTLE_ENDIAN : ByteOrder.BIG_ENDIAN);
             inputIndex = inputBuffer.position();
             // isNull
             isNullOffset = inputIndex + (int) chunkIndex.getIsNullOffset();

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/StringColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/StringColumnReader.java
@@ -359,7 +359,13 @@ public class StringColumnReader extends ColumnReader
 
             // read starts, the last two integers (8 bytes) are the origin offset and starts offset
             int startsBufLength = inputLength - dictStartsOffset - 2 * Integer.BYTES;
-            ByteBuf startsBuf = inputBuffer.slice(dictStartsOffset, startsBufLength).order(byteOrder);
+            inputBuffer.markReaderIndex();
+            inputBuffer.readerIndex(dictStartsOffset);
+            byte[] b = new byte[startsBufLength];
+            inputBuffer.readBytes(b, 0, startsBufLength);
+            ByteBuf startsBuf = Unpooled.wrappedBuffer(b).order(byteOrder);
+            inputBuffer.resetReaderIndex();
+            //ByteBuf startsBuf = inputBuffer.slice(dictStartsOffset, startsBufLength).order(byteOrder);
 
             /*
              * DO NOT use dictContentOffset as bufferStart, as multiple input buffers read from disk (not from pixels cache)

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/StringColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/StringColumnReader.java
@@ -359,13 +359,7 @@ public class StringColumnReader extends ColumnReader
 
             // read starts, the last two integers (8 bytes) are the origin offset and starts offset
             int startsBufLength = inputLength - dictStartsOffset - 2 * Integer.BYTES;
-            inputBuffer.markReaderIndex();
-            inputBuffer.readerIndex(dictStartsOffset);
-            byte[] b = new byte[startsBufLength];
-            inputBuffer.readBytes(b, 0, startsBufLength);
-            ByteBuf startsBuf = Unpooled.wrappedBuffer(b).order(byteOrder);
-            inputBuffer.resetReaderIndex();
-            //ByteBuf startsBuf = inputBuffer.slice(dictStartsOffset, startsBufLength).order(byteOrder);
+            ByteBuf startsBuf = inputBuffer.slice(dictStartsOffset, startsBufLength).order(byteOrder);
 
             /*
              * DO NOT use dictContentOffset as bufferStart, as multiple input buffers read from disk (not from pixels cache)
@@ -423,7 +417,7 @@ public class StringColumnReader extends ColumnReader
                 dictStarts = new int[startsSize];
                 for (int i = 0; i < startsSize; ++i)
                 {
-                    dictStarts[i++] = bufferStart + startsBuf.readInt();
+                    dictStarts[i] = bufferStart + startsBuf.readInt();
                 }
                 contentDecoder = null;
             }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/StringColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/StringColumnReader.java
@@ -335,7 +335,7 @@ public class StringColumnReader extends ColumnReader
             dictStartsOffset = inputBuffer.readInt();
             inputBuffer.resetReaderIndex();
             // read buffers
-            contentBuf = inputBuffer.slice(0, dictContentOffset);
+            contentBuf = inputBuffer.slice(0, dictContentOffset).order(byteOrder);
             if (this.inputBuffer.hasArray())
             {
                 dictContentBuf = inputBuffer.slice(dictContentOffset, dictStartsOffset - dictContentOffset);
@@ -356,9 +356,10 @@ public class StringColumnReader extends ColumnReader
                 inputBuffer.getBytes(dictContentOffset, bytes, 0, dictStartsOffset - dictContentOffset);
                 dictContentBuf = Unpooled.wrappedBuffer(bytes);
             }
+
             // read starts, the last two integers (8 bytes) are the origin offset and starts offset
             int startsBufLength = inputLength - dictStartsOffset - 2 * Integer.BYTES;
-            ByteBuf startsBuf = inputBuffer.slice(dictStartsOffset, startsBufLength);
+            ByteBuf startsBuf = inputBuffer.slice(dictStartsOffset, startsBufLength).order(byteOrder);
 
             /*
              * DO NOT use dictContentOffset as bufferStart, as multiple input buffers read from disk (not from pixels cache)

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/utils/BitUtils.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/utils/BitUtils.java
@@ -219,7 +219,7 @@ public class BitUtils
     {
         /**
          * Issue #99:
-         * Use as least as variables as possible to reduce stack footprint
+         * Use as fewer variables as possible to reduce stack footprint
          * and thus improve performance.
          */
         byte bitsLeft = 8, b;

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/LongDecimalColumnVector.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/LongDecimalColumnVector.java
@@ -36,7 +36,9 @@ import static java.util.Objects.requireNonNull;
 
 /**
  * This class is similar to {@link DecimalColumnVector}, but supports long decimals
- * with max precision and scale 38.
+ * with max precision and scale 38. Each long decimal is stored as two continuous
+ * 64-bit integers in the vector, with the high 64 bits in the lower index. This is
+ * not affected by the endianness of the column reader or writer.
  *
  * Created at: 01/07/2022
  * Author: hank

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/BaseColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/BaseColumnWriter.java
@@ -71,11 +71,9 @@ public abstract class BaseColumnWriter implements ColumnWriter
         this.byteOrder = requireNonNull(byteOrder, "byteOrder is null");
         this.isNull = new boolean[pixelStride];
 
-        this.columnChunkIndex =
-                PixelsProto.ColumnChunkIndex.newBuilder()
-                        .setLittleEndian(byteOrder.equals(ByteOrder.LITTLE_ENDIAN));
-        this.columnChunkStat =
-                PixelsProto.ColumnStatistic.newBuilder();
+        this.columnChunkIndex = PixelsProto.ColumnChunkIndex.newBuilder()
+                .setLittleEndian(byteOrder.equals(ByteOrder.LITTLE_ENDIAN));
+        this.columnChunkStat = PixelsProto.ColumnStatistic.newBuilder();
         this.pixelStatRecorder = StatsRecorder.create(type);
         this.columnChunkStatRecorder = StatsRecorder.create(type);
 

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/BaseColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/BaseColumnWriter.java
@@ -22,6 +22,7 @@ package io.pixelsdb.pixels.core.writer;
 import io.pixelsdb.pixels.core.PixelsProto;
 import io.pixelsdb.pixels.core.TypeDescription;
 import io.pixelsdb.pixels.core.encoding.Encoder;
+import io.pixelsdb.pixels.core.encoding.EncodingLevel;
 import io.pixelsdb.pixels.core.stats.StatsRecorder;
 import io.pixelsdb.pixels.core.utils.BitUtils;
 import io.pixelsdb.pixels.core.vector.ColumnVector;
@@ -40,7 +41,7 @@ import static java.util.Objects.requireNonNull;
 public abstract class BaseColumnWriter implements ColumnWriter
 {
     final int pixelStride;                     // indicate num of elements in a pixel
-    final boolean isEncoding;                  // indicate if encoding enabled during writing
+    final EncodingLevel encodingLevel;         // indicate the encoding level during writing
     final ByteOrder byteOrder;                 // indicate the endianness used during writing
     final boolean[] isNull;
     private final PixelsProto.ColumnChunkIndex.Builder columnChunkIndex;
@@ -63,11 +64,11 @@ public abstract class BaseColumnWriter implements ColumnWriter
     final ByteArrayOutputStream outputStream;  // column chunk content
     private final ByteArrayOutputStream isNullStream;  // column chunk isNull
 
-    public BaseColumnWriter(TypeDescription type, int pixelStride, boolean isEncoding, ByteOrder byteOrder)
+    public BaseColumnWriter(TypeDescription type, int pixelStride, EncodingLevel encodingLevel, ByteOrder byteOrder)
     {
         this.type = requireNonNull(type, "type is null");
         this.pixelStride = pixelStride;
-        this.isEncoding = isEncoding;
+        this.encodingLevel = encodingLevel;
         this.byteOrder = requireNonNull(byteOrder, "byteOrder is null");
         this.isNull = new boolean[pixelStride];
 

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/BinaryColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/BinaryColumnWriter.java
@@ -20,6 +20,7 @@
 package io.pixelsdb.pixels.core.writer;
 
 import io.pixelsdb.pixels.core.TypeDescription;
+import io.pixelsdb.pixels.core.encoding.EncodingLevel;
 import io.pixelsdb.pixels.core.vector.BinaryColumnVector;
 import io.pixelsdb.pixels.core.vector.ColumnVector;
 
@@ -41,9 +42,9 @@ public class BinaryColumnWriter extends BaseColumnWriter
     private final int maxLength;
     private int numTruncated;
 
-    public BinaryColumnWriter(TypeDescription type, int pixelStride, boolean isEncoding, ByteOrder byteOrder)
+    public BinaryColumnWriter(TypeDescription type, int pixelStride, EncodingLevel encodingLevel, ByteOrder byteOrder)
     {
-        super(type, pixelStride, isEncoding, byteOrder);
+        super(type, pixelStride, encodingLevel, byteOrder);
         this.maxLength = type.getMaxLength();
         this.numTruncated = 0;
     }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/BooleanColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/BooleanColumnWriter.java
@@ -20,6 +20,7 @@
 package io.pixelsdb.pixels.core.writer;
 
 import io.pixelsdb.pixels.core.TypeDescription;
+import io.pixelsdb.pixels.core.encoding.EncodingLevel;
 import io.pixelsdb.pixels.core.utils.BitUtils;
 import io.pixelsdb.pixels.core.vector.ByteColumnVector;
 import io.pixelsdb.pixels.core.vector.ColumnVector;
@@ -37,9 +38,9 @@ public class BooleanColumnWriter extends BaseColumnWriter
 {
     private final byte[] curPixelVector = new byte[pixelStride];
 
-    public BooleanColumnWriter(TypeDescription type, int pixelStride, boolean isEncoding, ByteOrder byteOrder)
+    public BooleanColumnWriter(TypeDescription type, int pixelStride, EncodingLevel encodingLevel, ByteOrder byteOrder)
     {
-        super(type, pixelStride, isEncoding, byteOrder);
+        super(type, pixelStride, encodingLevel, byteOrder);
     }
 
     @Override

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/ByteColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/ByteColumnWriter.java
@@ -21,6 +21,7 @@ package io.pixelsdb.pixels.core.writer;
 
 import io.pixelsdb.pixels.core.PixelsProto;
 import io.pixelsdb.pixels.core.TypeDescription;
+import io.pixelsdb.pixels.core.encoding.EncodingLevel;
 import io.pixelsdb.pixels.core.encoding.RunLenByteEncoder;
 import io.pixelsdb.pixels.core.vector.ColumnVector;
 import io.pixelsdb.pixels.core.vector.LongColumnVector;
@@ -37,9 +38,9 @@ public class ByteColumnWriter extends BaseColumnWriter
 {
     private final byte[] curPixelVector = new byte[pixelStride];
 
-    public ByteColumnWriter(TypeDescription type, int pixelStride, boolean isEncoding, ByteOrder byteOrder)
+    public ByteColumnWriter(TypeDescription type, int pixelStride, EncodingLevel encodingLevel, ByteOrder byteOrder)
     {
-        super(type, pixelStride, isEncoding, byteOrder);
+        super(type, pixelStride, encodingLevel, byteOrder);
         encoder = new RunLenByteEncoder();
     }
 
@@ -99,7 +100,7 @@ public class ByteColumnWriter extends BaseColumnWriter
             pixelStatRecorder.updateInteger(curPixelVector[i], 1);
         }
 
-        if (isEncoding)
+        if (encodingLevel.ge(EncodingLevel.EL1))
         {
             outputStream.write(encoder.encode(curPixelVector, 0, curPixelVectorIndex));
         }
@@ -114,7 +115,7 @@ public class ByteColumnWriter extends BaseColumnWriter
     @Override
     public PixelsProto.ColumnEncoding.Builder getColumnChunkEncoding()
     {
-        if (isEncoding)
+        if (encodingLevel.ge(EncodingLevel.EL1))
         {
             return PixelsProto.ColumnEncoding.newBuilder()
                     .setKind(PixelsProto.ColumnEncoding.Kind.RUNLENGTH);

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/CharColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/CharColumnWriter.java
@@ -20,6 +20,7 @@
 package io.pixelsdb.pixels.core.writer;
 
 import io.pixelsdb.pixels.core.TypeDescription;
+import io.pixelsdb.pixels.core.encoding.EncodingLevel;
 
 import java.nio.ByteOrder;
 
@@ -32,8 +33,8 @@ import java.nio.ByteOrder;
  */
 public class CharColumnWriter extends VarcharColumnWriter
 {
-    public CharColumnWriter(TypeDescription type, int pixelStride, boolean isEncoding, ByteOrder byteOrder)
+    public CharColumnWriter(TypeDescription type, int pixelStride, EncodingLevel encodingLevel, ByteOrder byteOrder)
     {
-        super(type, pixelStride, isEncoding, byteOrder);
+        super(type, pixelStride, encodingLevel, byteOrder);
     }
 }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/ColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/ColumnWriter.java
@@ -21,6 +21,7 @@ package io.pixelsdb.pixels.core.writer;
 
 import io.pixelsdb.pixels.core.PixelsProto;
 import io.pixelsdb.pixels.core.TypeDescription;
+import io.pixelsdb.pixels.core.encoding.EncodingLevel;
 import io.pixelsdb.pixels.core.stats.StatsRecorder;
 import io.pixelsdb.pixels.core.vector.ColumnVector;
 
@@ -39,49 +40,49 @@ public interface ColumnWriter
     /**
      * Create a column writer according to the data type.
      * @param type the data type.
-     * @param pixelStride
-     * @param isEncoding set true if enable data encoding.
+     * @param pixelStride the pixel stride in the column
+     * @param encodingLevel the encoding level to be applied on the column
      * @return
      */
     static ColumnWriter newColumnWriter(TypeDescription type, int pixelStride,
-                                        boolean isEncoding, ByteOrder byteOrder)
+                                        EncodingLevel encodingLevel, ByteOrder byteOrder)
     {
         switch (type.getCategory())
         {
             case BOOLEAN:
-                return new BooleanColumnWriter(type, pixelStride, isEncoding, byteOrder);
+                return new BooleanColumnWriter(type, pixelStride, encodingLevel, byteOrder);
             case BYTE:
-                return new ByteColumnWriter(type, pixelStride, isEncoding, byteOrder);
+                return new ByteColumnWriter(type, pixelStride, encodingLevel, byteOrder);
             case SHORT:
             case INT:
             case LONG:
-                return new IntegerColumnWriter(type, pixelStride, isEncoding, byteOrder);
+                return new IntegerColumnWriter(type, pixelStride, encodingLevel, byteOrder);
             case FLOAT:
-                return new FloatColumnWriter(type, pixelStride, isEncoding, byteOrder);
+                return new FloatColumnWriter(type, pixelStride, encodingLevel, byteOrder);
             case DOUBLE:
-                return new DoubleColumnWriter(type, pixelStride, isEncoding, byteOrder);
+                return new DoubleColumnWriter(type, pixelStride, encodingLevel, byteOrder);
             case DECIMAL: // Issue #196: precision and scale are passed through type.
                 if (type.getPrecision() <= SHORT_DECIMAL_MAX_PRECISION)
-                    return new DecimalColumnWriter(type, pixelStride, isEncoding, byteOrder);
+                    return new DecimalColumnWriter(type, pixelStride, encodingLevel, byteOrder);
                 else
-                    return new LongDecimalColumnWriter(type, pixelStride, isEncoding, byteOrder);
+                    return new LongDecimalColumnWriter(type, pixelStride, encodingLevel, byteOrder);
             case STRING:
-                return new StringColumnWriter(type, pixelStride, isEncoding, byteOrder);
+                return new StringColumnWriter(type, pixelStride, encodingLevel, byteOrder);
             // Issue #196: max length of char, varchar, binary, and varbinary, are passed through type.
             case CHAR:
-                return new CharColumnWriter(type, pixelStride, isEncoding, byteOrder);
+                return new CharColumnWriter(type, pixelStride, encodingLevel, byteOrder);
             case VARCHAR:
-                return new VarcharColumnWriter(type, pixelStride, isEncoding, byteOrder);
+                return new VarcharColumnWriter(type, pixelStride, encodingLevel, byteOrder);
             case BINARY:
-                return new BinaryColumnWriter(type, pixelStride, isEncoding, byteOrder);
+                return new BinaryColumnWriter(type, pixelStride, encodingLevel, byteOrder);
             case VARBINARY:
-                return new VarbinaryColumnWriter(type, pixelStride, isEncoding, byteOrder);
+                return new VarbinaryColumnWriter(type, pixelStride, encodingLevel, byteOrder);
             case DATE:
-                return new DateColumnWriter(type, pixelStride, isEncoding, byteOrder);
+                return new DateColumnWriter(type, pixelStride, encodingLevel, byteOrder);
             case TIME:
-                return new TimeColumnWriter(type, pixelStride, isEncoding, byteOrder);
+                return new TimeColumnWriter(type, pixelStride, encodingLevel, byteOrder);
             case TIMESTAMP:
-                return new TimestampColumnWriter(type, pixelStride, isEncoding, byteOrder);
+                return new TimestampColumnWriter(type, pixelStride, encodingLevel, byteOrder);
             default:
                 throw new IllegalArgumentException("Bad schema type: " + type.getCategory());
         }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/DateColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/DateColumnWriter.java
@@ -21,6 +21,7 @@ package io.pixelsdb.pixels.core.writer;
 
 import io.pixelsdb.pixels.core.PixelsProto;
 import io.pixelsdb.pixels.core.TypeDescription;
+import io.pixelsdb.pixels.core.encoding.EncodingLevel;
 import io.pixelsdb.pixels.core.encoding.RunLenIntEncoder;
 import io.pixelsdb.pixels.core.vector.ColumnVector;
 import io.pixelsdb.pixels.core.vector.DateColumnVector;
@@ -41,9 +42,9 @@ public class DateColumnWriter extends BaseColumnWriter
 {
     private final int[] curPixelVector = new int[pixelStride];
 
-    public DateColumnWriter(TypeDescription type, int pixelStride, boolean isEncoding, ByteOrder byteOrder)
+    public DateColumnWriter(TypeDescription type, int pixelStride, EncodingLevel encodingLevel, ByteOrder byteOrder)
     {
-        super(type, pixelStride, isEncoding, byteOrder);
+        super(type, pixelStride, encodingLevel, byteOrder);
         // Issue #94: Date.getTime() can be negative if the date is before 1970-1-1.
         encoder = new RunLenIntEncoder(true, true);
     }
@@ -99,7 +100,7 @@ public class DateColumnWriter extends BaseColumnWriter
             pixelStatRecorder.updateDate(curPixelVector[i]);
         }
 
-        if (isEncoding)
+        if (encodingLevel.ge(EncodingLevel.EL1))
         {
             int[] values = new int[curPixelVectorIndex];
             System.arraycopy(curPixelVector, 0, values, 0, curPixelVectorIndex);
@@ -123,7 +124,7 @@ public class DateColumnWriter extends BaseColumnWriter
     @Override
     public PixelsProto.ColumnEncoding.Builder getColumnChunkEncoding()
     {
-        if (isEncoding)
+        if (encodingLevel.ge(EncodingLevel.EL1))
         {
             return PixelsProto.ColumnEncoding.newBuilder()
                     .setKind(PixelsProto.ColumnEncoding.Kind.RUNLENGTH);

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/DecimalColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/DecimalColumnWriter.java
@@ -20,6 +20,7 @@
 package io.pixelsdb.pixels.core.writer;
 
 import io.pixelsdb.pixels.core.TypeDescription;
+import io.pixelsdb.pixels.core.encoding.EncodingLevel;
 import io.pixelsdb.pixels.core.utils.EncodingUtils;
 import io.pixelsdb.pixels.core.vector.ColumnVector;
 import io.pixelsdb.pixels.core.vector.DecimalColumnVector;
@@ -37,9 +38,9 @@ public class DecimalColumnWriter extends BaseColumnWriter
 {
     private final EncodingUtils encodingUtils;
 
-    public DecimalColumnWriter(TypeDescription type, int pixelStride, boolean isEncoding, ByteOrder byteOrder)
+    public DecimalColumnWriter(TypeDescription type, int pixelStride, EncodingLevel encodingLevel, ByteOrder byteOrder)
     {
-        super(type, pixelStride, isEncoding, byteOrder);
+        super(type, pixelStride, encodingLevel, byteOrder);
         encodingUtils = new EncodingUtils();
     }
 

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/DecimalColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/DecimalColumnWriter.java
@@ -48,6 +48,7 @@ public class DecimalColumnWriter extends BaseColumnWriter
     {
         DecimalColumnVector columnVector = (DecimalColumnVector) vector;
         long[] values = columnVector.vector;
+        boolean littleEndian = this.byteOrder.equals(ByteOrder.LITTLE_ENDIAN);
         for (int i = 0; i < length; i++)
         {
             isNull[curPixelIsNullIndex++] = vector.isNull[i];
@@ -59,7 +60,14 @@ public class DecimalColumnWriter extends BaseColumnWriter
             }
             else
             {
-                encodingUtils.writeLongLE(outputStream, values[i]);
+                if (littleEndian)
+                {
+                    encodingUtils.writeLongLE(outputStream, values[i]);
+                }
+                else
+                {
+                    encodingUtils.writeLongBE(outputStream, values[i]);
+                }
                 pixelStatRecorder.updateInteger(values[i], 1);
             }
             // if current pixel size satisfies the pixel stride, end the current pixel and start a new one

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/DoubleColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/DoubleColumnWriter.java
@@ -47,6 +47,7 @@ public class DoubleColumnWriter extends BaseColumnWriter
     {
         DoubleColumnVector columnVector = (DoubleColumnVector) vector;
         long[] values = columnVector.vector;
+        boolean littleEndian = this.byteOrder.equals(ByteOrder.LITTLE_ENDIAN);
         for (int i = 0; i < length; i++)
         {
             isNull[curPixelIsNullIndex++] = vector.isNull[i];
@@ -58,7 +59,14 @@ public class DoubleColumnWriter extends BaseColumnWriter
             }
             else
             {
-                encodingUtils.writeLongLE(outputStream, values[i]);
+                if (littleEndian)
+                {
+                    encodingUtils.writeLongLE(outputStream, values[i]);
+                }
+                else
+                {
+                    encodingUtils.writeLongBE(outputStream, values[i]);
+                }
                 pixelStatRecorder.updateDouble(Double.longBitsToDouble(values[i]));
             }
             // if current pixel size satisfies the pixel stride, end the current pixel and start a new one

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/DoubleColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/DoubleColumnWriter.java
@@ -20,6 +20,7 @@
 package io.pixelsdb.pixels.core.writer;
 
 import io.pixelsdb.pixels.core.TypeDescription;
+import io.pixelsdb.pixels.core.encoding.EncodingLevel;
 import io.pixelsdb.pixels.core.utils.EncodingUtils;
 import io.pixelsdb.pixels.core.vector.ColumnVector;
 import io.pixelsdb.pixels.core.vector.DoubleColumnVector;
@@ -36,9 +37,9 @@ public class DoubleColumnWriter extends BaseColumnWriter
 {
     private final EncodingUtils encodingUtils;
 
-    public DoubleColumnWriter(TypeDescription type, int pixelStride, boolean isEncoding, ByteOrder byteOrder)
+    public DoubleColumnWriter(TypeDescription type, int pixelStride, EncodingLevel encodingLevel, ByteOrder byteOrder)
     {
-        super(type, pixelStride, isEncoding, byteOrder);
+        super(type, pixelStride, encodingLevel, byteOrder);
         encodingUtils = new EncodingUtils();
     }
 

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/FloatColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/FloatColumnWriter.java
@@ -20,6 +20,7 @@
 package io.pixelsdb.pixels.core.writer;
 
 import io.pixelsdb.pixels.core.TypeDescription;
+import io.pixelsdb.pixels.core.encoding.EncodingLevel;
 import io.pixelsdb.pixels.core.utils.EncodingUtils;
 import io.pixelsdb.pixels.core.vector.ColumnVector;
 import io.pixelsdb.pixels.core.vector.DoubleColumnVector;
@@ -36,9 +37,9 @@ public class FloatColumnWriter extends BaseColumnWriter
 {
     private final EncodingUtils encodingUtils;
 
-    public FloatColumnWriter(TypeDescription type, int pixelStride, boolean isEncoding, ByteOrder byteOrder)
+    public FloatColumnWriter(TypeDescription type, int pixelStride, EncodingLevel encodingLevel, ByteOrder byteOrder)
     {
-        super(type, pixelStride, isEncoding, byteOrder);
+        super(type, pixelStride, encodingLevel, byteOrder);
         encodingUtils = new EncodingUtils();
     }
 

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/FloatColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/FloatColumnWriter.java
@@ -47,6 +47,7 @@ public class FloatColumnWriter extends BaseColumnWriter
     {
         DoubleColumnVector columnVector = (DoubleColumnVector) vector;
         long[] values = columnVector.vector;
+        boolean littleEndian = this.byteOrder.equals(ByteOrder.LITTLE_ENDIAN);
         for (int i = 0; i < length; i++)
         {
             isNull[curPixelIsNullIndex++] = columnVector.isNull[i];
@@ -59,7 +60,14 @@ public class FloatColumnWriter extends BaseColumnWriter
             else
             {
                 int v = (int) values[i];
-                encodingUtils.writeIntLE(outputStream, v);
+                if (littleEndian)
+                {
+                    encodingUtils.writeIntLE(outputStream, v);
+                }
+                else
+                {
+                    encodingUtils.writeLongBE(outputStream, v);
+                }
                 pixelStatRecorder.updateFloat(Float.intBitsToFloat(v));
             }
             // if current pixel size satisfies the pixel stride, end the current pixel and start a new one

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/IntegerColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/IntegerColumnWriter.java
@@ -21,6 +21,7 @@ package io.pixelsdb.pixels.core.writer;
 
 import io.pixelsdb.pixels.core.PixelsProto;
 import io.pixelsdb.pixels.core.TypeDescription;
+import io.pixelsdb.pixels.core.encoding.EncodingLevel;
 import io.pixelsdb.pixels.core.encoding.RunLenIntEncoder;
 import io.pixelsdb.pixels.core.vector.ColumnVector;
 import io.pixelsdb.pixels.core.vector.LongColumnVector;
@@ -41,9 +42,9 @@ public class IntegerColumnWriter extends BaseColumnWriter
     private final long[] curPixelVector = new long[pixelStride];        // current pixel value vector haven't written out yet
     private final boolean isLong;                                       // current column type is long or int, used for the first pixel
 
-    public IntegerColumnWriter(TypeDescription type, int pixelStride, boolean isEncoding, ByteOrder byteOrder)
+    public IntegerColumnWriter(TypeDescription type, int pixelStride, EncodingLevel encodingLevel, ByteOrder byteOrder)
     {
-        super(type, pixelStride, isEncoding, byteOrder);
+        super(type, pixelStride, encodingLevel, byteOrder);
         encoder = new RunLenIntEncoder();
         this.isLong = type.getCategory() == TypeDescription.Category.LONG;
     }
@@ -103,7 +104,7 @@ public class IntegerColumnWriter extends BaseColumnWriter
         }
 
         // write out current pixel vector
-        if (isEncoding)
+        if (encodingLevel.ge(EncodingLevel.EL1))
         {
             outputStream.write(encoder.encode(curPixelVector, 0, curPixelVectorIndex));
         }
@@ -137,7 +138,7 @@ public class IntegerColumnWriter extends BaseColumnWriter
     @Override
     public PixelsProto.ColumnEncoding.Builder getColumnChunkEncoding()
     {
-        if (isEncoding)
+        if (encodingLevel.ge(EncodingLevel.EL1))
         {
             return PixelsProto.ColumnEncoding.newBuilder()
                     .setKind(PixelsProto.ColumnEncoding.Kind.RUNLENGTH);

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/LongDecimalColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/LongDecimalColumnWriter.java
@@ -20,6 +20,7 @@
 package io.pixelsdb.pixels.core.writer;
 
 import io.pixelsdb.pixels.core.TypeDescription;
+import io.pixelsdb.pixels.core.encoding.EncodingLevel;
 import io.pixelsdb.pixels.core.utils.EncodingUtils;
 import io.pixelsdb.pixels.core.vector.ColumnVector;
 import io.pixelsdb.pixels.core.vector.LongDecimalColumnVector;
@@ -38,9 +39,9 @@ public class LongDecimalColumnWriter extends BaseColumnWriter
 {
     private final EncodingUtils encodingUtils;
 
-    public LongDecimalColumnWriter(TypeDescription type, int pixelStride, boolean isEncoding, ByteOrder byteOrder)
+    public LongDecimalColumnWriter(TypeDescription type, int pixelStride, EncodingLevel encodingLevel, ByteOrder byteOrder)
     {
-        super(type, pixelStride, isEncoding, byteOrder);
+        super(type, pixelStride, encodingLevel, byteOrder);
         encodingUtils = new EncodingUtils();
     }
 

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/LongDecimalColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/LongDecimalColumnWriter.java
@@ -31,7 +31,7 @@ import java.nio.ByteOrder;
  * The column writer of long decimals.
  * <p><b>Note: it supports decimals with max precision and scale 38.</b></p>
  *
- * @date 01.07.2022
+ * @create 2022-07-01
  * @author hank
  */
 public class LongDecimalColumnWriter extends BaseColumnWriter
@@ -49,6 +49,7 @@ public class LongDecimalColumnWriter extends BaseColumnWriter
     {
         LongDecimalColumnVector columnVector = (LongDecimalColumnVector) vector;
         long[] values = columnVector.vector;
+        boolean littleEndian = this.byteOrder.equals(ByteOrder.LITTLE_ENDIAN);
         for (int i = 0; i < length; i++)
         {
             isNull[curPixelIsNullIndex++] = vector.isNull[i];
@@ -60,8 +61,16 @@ public class LongDecimalColumnWriter extends BaseColumnWriter
             }
             else
             {
-                encodingUtils.writeLongLE(outputStream, values[i*2]);
-                encodingUtils.writeLongLE(outputStream, values[i*2+1]);
+                if (littleEndian)
+                {
+                    encodingUtils.writeLongLE(outputStream, values[i * 2]);
+                    encodingUtils.writeLongLE(outputStream, values[i * 2 + 1]);
+                }
+                else
+                {
+                    encodingUtils.writeLongBE(outputStream, values[i * 2]);
+                    encodingUtils.writeLongBE(outputStream, values[i * 2 + 1]);
+                }
                 pixelStatRecorder.updateInteger128(values[i*2], values[i*2+1], 1);
             }
             // if current pixel size satisfies the pixel stride, end the current pixel and start a new one

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/TimeColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/TimeColumnWriter.java
@@ -21,6 +21,7 @@ package io.pixelsdb.pixels.core.writer;
 
 import io.pixelsdb.pixels.core.PixelsProto;
 import io.pixelsdb.pixels.core.TypeDescription;
+import io.pixelsdb.pixels.core.encoding.EncodingLevel;
 import io.pixelsdb.pixels.core.encoding.RunLenIntEncoder;
 import io.pixelsdb.pixels.core.vector.ColumnVector;
 import io.pixelsdb.pixels.core.vector.TimeColumnVector;
@@ -40,9 +41,9 @@ public class TimeColumnWriter extends BaseColumnWriter
 {
     private final int[] curPixelVector = new int[pixelStride];
 
-    public TimeColumnWriter(TypeDescription type, int pixelStride, boolean isEncoding, ByteOrder byteOrder)
+    public TimeColumnWriter(TypeDescription type, int pixelStride, EncodingLevel encodingLevel, ByteOrder byteOrder)
     {
-        super(type, pixelStride, isEncoding, byteOrder);
+        super(type, pixelStride, encodingLevel, byteOrder);
         // time is likely to be negative according to different time zone.
         encoder = new RunLenIntEncoder(true, true);
     }
@@ -98,7 +99,7 @@ public class TimeColumnWriter extends BaseColumnWriter
             pixelStatRecorder.updateTime(curPixelVector[i]);
         }
 
-        if (isEncoding)
+        if (encodingLevel.ge(EncodingLevel.EL1))
         {
             int[] values = new int[curPixelVectorIndex];
             System.arraycopy(curPixelVector, 0, values, 0, curPixelVectorIndex);
@@ -122,7 +123,7 @@ public class TimeColumnWriter extends BaseColumnWriter
     @Override
     public PixelsProto.ColumnEncoding.Builder getColumnChunkEncoding()
     {
-        if (isEncoding)
+        if (encodingLevel.ge(EncodingLevel.EL1))
         {
             return PixelsProto.ColumnEncoding.newBuilder()
                     .setKind(PixelsProto.ColumnEncoding.Kind.RUNLENGTH);

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/TimestampColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/TimestampColumnWriter.java
@@ -21,6 +21,7 @@ package io.pixelsdb.pixels.core.writer;
 
 import io.pixelsdb.pixels.core.PixelsProto;
 import io.pixelsdb.pixels.core.TypeDescription;
+import io.pixelsdb.pixels.core.encoding.EncodingLevel;
 import io.pixelsdb.pixels.core.encoding.RunLenIntEncoder;
 import io.pixelsdb.pixels.core.vector.ColumnVector;
 import io.pixelsdb.pixels.core.vector.TimestampColumnVector;
@@ -39,9 +40,9 @@ public class TimestampColumnWriter extends BaseColumnWriter
 {
     private final long[] curPixelVector = new long[pixelStride];
 
-    public TimestampColumnWriter(TypeDescription type, int pixelStride, boolean isEncoding, ByteOrder byteOrder)
+    public TimestampColumnWriter(TypeDescription type, int pixelStride, EncodingLevel encodingLevel, ByteOrder byteOrder)
     {
-        super(type, pixelStride, isEncoding, byteOrder);
+        super(type, pixelStride, encodingLevel, byteOrder);
         // Issue #94: time can be negative if it is before 1970-1-1 0:0:0.
         encoder = new RunLenIntEncoder(true, true);
     }
@@ -97,7 +98,7 @@ public class TimestampColumnWriter extends BaseColumnWriter
             pixelStatRecorder.updateTimestamp(curPixelVector[i]);
         }
 
-        if (isEncoding)
+        if (encodingLevel.ge(EncodingLevel.EL1))
         {
             long[] values = new long[curPixelVectorIndex];
             System.arraycopy(curPixelVector, 0, values, 0, curPixelVectorIndex);
@@ -121,7 +122,7 @@ public class TimestampColumnWriter extends BaseColumnWriter
     @Override
     public PixelsProto.ColumnEncoding.Builder getColumnChunkEncoding()
     {
-        if (isEncoding)
+        if (encodingLevel.ge(EncodingLevel.EL1))
         {
             return PixelsProto.ColumnEncoding.newBuilder()
                     .setKind(PixelsProto.ColumnEncoding.Kind.RUNLENGTH);

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/VarbinaryColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/VarbinaryColumnWriter.java
@@ -20,6 +20,7 @@
 package io.pixelsdb.pixels.core.writer;
 
 import io.pixelsdb.pixels.core.TypeDescription;
+import io.pixelsdb.pixels.core.encoding.EncodingLevel;
 
 import java.nio.ByteOrder;
 
@@ -29,8 +30,8 @@ import java.nio.ByteOrder;
  */
 public class VarbinaryColumnWriter extends BinaryColumnWriter
 {
-    public VarbinaryColumnWriter(TypeDescription type, int pixelStride, boolean isEncoding, ByteOrder byteOrder)
+    public VarbinaryColumnWriter(TypeDescription type, int pixelStride, EncodingLevel encodingLevel, ByteOrder byteOrder)
     {
-        super(type, pixelStride, isEncoding, byteOrder);
+        super(type, pixelStride, encodingLevel, byteOrder);
     }
 }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/VarcharColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/VarcharColumnWriter.java
@@ -20,6 +20,7 @@
 package io.pixelsdb.pixels.core.writer;
 
 import io.pixelsdb.pixels.core.TypeDescription;
+import io.pixelsdb.pixels.core.encoding.EncodingLevel;
 import io.pixelsdb.pixels.core.vector.BinaryColumnVector;
 import io.pixelsdb.pixels.core.vector.ColumnVector;
 
@@ -42,9 +43,9 @@ public class VarcharColumnWriter extends StringColumnWriter
     private final int maxLength;
     private int numTruncated;
 
-    public VarcharColumnWriter(TypeDescription type, int pixelStride, boolean isEncoding, ByteOrder byteOrder)
+    public VarcharColumnWriter(TypeDescription type, int pixelStride, EncodingLevel encodingLevel, ByteOrder byteOrder)
     {
-        super(type, pixelStride, isEncoding, byteOrder);
+        super(type, pixelStride, encodingLevel, byteOrder);
         this.maxLength = type.getMaxLength();
         this.numTruncated = 0;
     }

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/TestParams.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/TestParams.java
@@ -19,6 +19,8 @@
  */
 package io.pixelsdb.pixels.core;
 
+import io.pixelsdb.pixels.core.encoding.EncodingLevel;
+
 public class TestParams {
     public static String filePath = "";
     public static int rowNum = 10;
@@ -31,7 +33,7 @@ public class TestParams {
 
     public final static short blockReplication = 4;
     public final static boolean blockPadding = true;
-    public final static boolean encoding = true;
+    public final static EncodingLevel encodingLevel = EncodingLevel.EL0;
 
     public final static int compressionBlockSize = 16;
 }

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/writer/TestPixelsWriter.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/writer/TestPixelsWriter.java
@@ -89,7 +89,7 @@ public class TestPixelsWriter
                             .setBlockSize(TestParams.blockSize)
                             .setReplication(TestParams.blockReplication)
                             .setBlockPadding(TestParams.blockPadding)
-                            .setEncoding(TestParams.encoding)
+                            .setEncodingLevel(TestParams.encodingLevel)
                             .setCompressionBlockSize(TestParams.compressionBlockSize)
                             .build();
 
@@ -193,7 +193,7 @@ public class TestPixelsWriter
                             .setBlockSize(TestParams.blockSize)
                             .setReplication(TestParams.blockReplication)
                             .setBlockPadding(TestParams.blockPadding)
-                            .setEncoding(TestParams.encoding)
+                            .setEncodingLevel(TestParams.encodingLevel)
                             .setCompressionBlockSize(TestParams.compressionBlockSize)
                             .build();
 

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/writer/TestStringColumnWriter.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/writer/TestStringColumnWriter.java
@@ -20,6 +20,7 @@
 package io.pixelsdb.pixels.core.writer;
 
 import io.pixelsdb.pixels.core.TypeDescription;
+import io.pixelsdb.pixels.core.encoding.EncodingLevel;
 import io.pixelsdb.pixels.core.vector.BinaryColumnVector;
 import org.junit.Test;
 
@@ -44,7 +45,7 @@ public class TestStringColumnWriter
             stringColumnVector.add(UUID.randomUUID().toString());
         }
         StringColumnWriter stringColumnWriter = new StringColumnWriter(
-                TypeDescription.createString(), 10000, true, ByteOrder.BIG_ENDIAN);
+                TypeDescription.createString(), 10000, EncodingLevel.EL2, ByteOrder.BIG_ENDIAN);
         long startTime = System.currentTimeMillis();
         for (int i = 0; i < 1000; ++i)
         {

--- a/pixels-daemon/pom.xml
+++ b/pixels-daemon/pom.xml
@@ -118,7 +118,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.0</version>
+                <version>3.2.2</version>
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/pixels-example/src/main/java/io/pixelsdb/pixels/example/core/TestPixelsWriter.java
+++ b/pixels-example/src/main/java/io/pixelsdb/pixels/example/core/TestPixelsWriter.java
@@ -24,6 +24,7 @@ import io.pixelsdb.pixels.common.physical.StorageFactory;
 import io.pixelsdb.pixels.core.PixelsWriter;
 import io.pixelsdb.pixels.core.PixelsWriterImpl;
 import io.pixelsdb.pixels.core.TypeDescription;
+import io.pixelsdb.pixels.core.encoding.EncodingLevel;
 import io.pixelsdb.pixels.core.exception.PixelsWriterException;
 import io.pixelsdb.pixels.core.vector.*;
 
@@ -64,7 +65,7 @@ public class TestPixelsWriter
                             .setBlockSize(256 * 1024 * 1024)
                             .setReplication((short) 3)
                             .setBlockPadding(true)
-                            .setEncoding(true)
+                            .setEncodingLevel(EncodingLevel.EL2)
                             .setCompressionBlockSize(1)
                             .build();
 

--- a/pixels-executor/src/test/java/io/pixelsdb/pixels/executor/aggregation/TestAggregator.java
+++ b/pixels-executor/src/test/java/io/pixelsdb/pixels/executor/aggregation/TestAggregator.java
@@ -22,6 +22,7 @@ package io.pixelsdb.pixels.executor.aggregation;
 import io.pixelsdb.pixels.common.physical.Storage;
 import io.pixelsdb.pixels.common.physical.StorageFactory;
 import io.pixelsdb.pixels.core.*;
+import io.pixelsdb.pixels.core.encoding.EncodingLevel;
 import io.pixelsdb.pixels.core.reader.PixelsReaderOption;
 import io.pixelsdb.pixels.core.reader.PixelsRecordReader;
 import io.pixelsdb.pixels.core.vector.BinaryColumnVector;
@@ -82,7 +83,7 @@ public class TestAggregator
                 .setPath("/home/hank/Desktop/final_aggr.pxl")
                 .setRowGroupSize(268435456)
                 .setPixelStride(10000)
-                .setEncoding(true)
+                .setEncodingLevel(EncodingLevel.EL2)
                 .setPartitioned(false)
                 .setOverwrite(true).build();
 

--- a/pixels-executor/src/test/java/io/pixelsdb/pixels/executor/join/TestPartitioner.java
+++ b/pixels-executor/src/test/java/io/pixelsdb/pixels/executor/join/TestPartitioner.java
@@ -23,6 +23,7 @@ import io.pixelsdb.pixels.common.exception.InvalidArgumentException;
 import io.pixelsdb.pixels.common.physical.Storage;
 import io.pixelsdb.pixels.common.physical.StorageFactory;
 import io.pixelsdb.pixels.core.*;
+import io.pixelsdb.pixels.core.encoding.EncodingLevel;
 import io.pixelsdb.pixels.core.reader.PixelsReaderOption;
 import io.pixelsdb.pixels.core.reader.PixelsRecordReader;
 import io.pixelsdb.pixels.core.vector.BinaryColumnVector;
@@ -116,7 +117,7 @@ public class TestPartitioner
 
         PixelsWriter pixelsWriter = PixelsWriterImpl.newBuilder().setStorage(storage)
                 .setPath("/home/hank/Desktop/part-0").setPartitioned(true)
-                .setEncoding(true).setPixelStride(10000).setOverwrite(true)
+                .setEncodingLevel(EncodingLevel.EL2).setPixelStride(10000).setOverwrite(true)
                 .setPartKeyColumnIds(Arrays.asList(0))
                 .setRowGroupSize(268435456).setSchema(rowBatchSchema).build();
 
@@ -282,7 +283,7 @@ public class TestPartitioner
 
         PixelsWriter pixelsWriter = PixelsWriterImpl.newBuilder().setStorage(storage)
                 .setPath("/home/hank/Desktop/part-0").setPartitioned(true)
-                .setEncoding(true).setPixelStride(10000).setOverwrite(true)
+                .setEncodingLevel(EncodingLevel.EL2).setPixelStride(10000).setOverwrite(true)
                 .setPartKeyColumnIds(Arrays.asList(0))
                 .setRowGroupSize(268435456).setSchema(rowBatchSchema).build();
 

--- a/pixels-executor/src/test/java/io/pixelsdb/pixels/executor/predicate/TestPredicate.java
+++ b/pixels-executor/src/test/java/io/pixelsdb/pixels/executor/predicate/TestPredicate.java
@@ -23,6 +23,7 @@ import com.alibaba.fastjson.JSON;
 import io.pixelsdb.pixels.common.physical.Storage;
 import io.pixelsdb.pixels.common.physical.StorageFactory;
 import io.pixelsdb.pixels.core.*;
+import io.pixelsdb.pixels.core.encoding.EncodingLevel;
 import io.pixelsdb.pixels.core.reader.PixelsReaderOption;
 import io.pixelsdb.pixels.core.reader.PixelsRecordReader;
 import io.pixelsdb.pixels.core.utils.Bitmap;
@@ -178,7 +179,7 @@ public class TestPredicate
                 .setReplication(replication)
                 .setBlockPadding(true)
                 .setOverwrite(true) // set overwrite to true to avoid existence checking.
-                .setEncoding(true) // it is worth to do encoding
+                .setEncodingLevel(EncodingLevel.EL2) // it is worth to do encoding
                 .setCompressionBlockSize(1)
                 .build();
 

--- a/pixels-turbo/pixels-worker-common/src/main/java/io/pixelsdb/pixels/worker/common/WorkerCommon.java
+++ b/pixels-turbo/pixels-worker-common/src/main/java/io/pixelsdb/pixels/worker/common/WorkerCommon.java
@@ -25,6 +25,7 @@ import io.pixelsdb.pixels.common.physical.StorageFactory;
 import io.pixelsdb.pixels.common.turbo.Output;
 import io.pixelsdb.pixels.common.utils.ConfigFactory;
 import io.pixelsdb.pixels.core.*;
+import io.pixelsdb.pixels.core.encoding.EncodingLevel;
 import io.pixelsdb.pixels.core.reader.PixelsReaderOption;
 import io.pixelsdb.pixels.planner.plan.physical.domain.InputInfo;
 import io.pixelsdb.pixels.planner.plan.physical.domain.InputSplit;
@@ -384,7 +385,7 @@ public class WorkerCommon
                 .setStorage(storage)
                 .setPath(filePath)
                 .setOverwrite(true) // set overwrite to true to avoid existence checking.
-                .setEncoding(encoding)
+                .setEncodingLevel(EncodingLevel.EL2) // it is worth to do encoding
                 .setPartitioned(isPartitioned);
         if (isPartitioned)
         {

--- a/proto/pixels.proto
+++ b/proto/pixels.proto
@@ -255,10 +255,15 @@ message RowGroupFooter {
 message ColumnEncoding {
     enum Kind {
         NONE = 0;
+        // pixels cascades delta encoding adaptively on run-length encoding, so there is no explicit delta encoding
         RUNLENGTH = 1;
+        // since v0.2.0, dictionary encoding does not cascade other encoding schemes such as run-length by default
         DICTIONARY = 2;
+        // pixels applies bit-packing automatically on all boolean data, so there is no explicit bit-packing encoding
     }
 
     required Kind kind = 1;
     optional uint32 dictionarySize = 2;
+    // the explicit cascade encoding scheme specified by pixels writer
+    optional ColumnEncoding cascadeEncoding = 3;
 }


### PR DESCRIPTION
1. Support encoding levels in the column writers. The encoding level can be passed from pixels-cli's LOAD command using the `-e` parameter.
2. Support dictionary encoding without cascading run-length encoding for encoding level 1.
3. Remove adaptive encoding in StringColumnWriter. It was not implemented correctly.
4. Add the dictContent length as the last element into dictStarts. @yuly16 please update the C++ reader accordingly.

These modifications are tested on the test_null dataset.

@jingrongchen @huasiy please reload the data if the commit of this issue is merged into your branch.

Closes #538.