### PR TITLE
[Issue #556] fix time type and timestamp type

### DIFF
--- a/pixels-amphi/pixels-amphi/src/main/java/io/pixelsdb/pixels/amphi/downloader/PeerDownloader.java
+++ b/pixels-amphi/pixels-amphi/src/main/java/io/pixelsdb/pixels/amphi/downloader/PeerDownloader.java
@@ -48,7 +48,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static io.pixelsdb.pixels.core.TypeDescription.SHORT_DECIMAL_MAX_PRECISION;
+import static io.pixelsdb.pixels.core.TypeDescription.MAX_SHORT_DECIMAL_PRECISION;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -383,7 +383,7 @@ public class PeerDownloader
                     record.put(columns.get(i).getName(), dbcv.vector[rowIdx]);
                     break;
                 case DECIMAL:
-                    if (typeDesc.getPrecision() <= SHORT_DECIMAL_MAX_PRECISION) {
+                    if (typeDesc.getPrecision() <= MAX_SHORT_DECIMAL_PRECISION) {
                         DecimalColumnVector decv = (DecimalColumnVector) columnVectors.get(i);
                         StringBuilder sb = new StringBuilder();
                         decv.stringifyValue(sb, rowIdx);

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/ColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/ColumnReader.java
@@ -27,7 +27,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
-import static io.pixelsdb.pixels.core.TypeDescription.SHORT_DECIMAL_MAX_PRECISION;
+import static io.pixelsdb.pixels.core.TypeDescription.MAX_SHORT_DECIMAL_PRECISION;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -58,7 +58,7 @@ public abstract class ColumnReader implements Closeable
             case DOUBLE:
                 return new DoubleColumnReader(type);
             case DECIMAL: // Issue #196: precision and scale are passed through type.
-                if (type.getPrecision() <= SHORT_DECIMAL_MAX_PRECISION)
+                if (type.getPrecision() <= MAX_SHORT_DECIMAL_PRECISION)
                     return new DecimalColumnReader(type);
                 else
                     return new LongDecimalColumnReader(type);

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/TimestampColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/TimestampColumnReader.java
@@ -31,7 +31,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.sql.Timestamp;
 
 /**
  * pixels timestamp column reader
@@ -169,7 +168,7 @@ public class TimestampColumnReader extends ColumnReader
                 }
                 else
                 {
-                    columnVector.set(i + vectorIndex, new Timestamp(inputBuffer.getLong()));
+                    columnVector.set(i + vectorIndex, inputBuffer.getLong());
                 }
                 if (hasNull)
                 {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/stats/StatsRecorder.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/stats/StatsRecorder.java
@@ -27,7 +27,7 @@ import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
 
-import static io.pixelsdb.pixels.core.TypeDescription.SHORT_DECIMAL_MAX_PRECISION;
+import static io.pixelsdb.pixels.core.TypeDescription.MAX_SHORT_DECIMAL_PRECISION;
 
 /**
  * This is a base class for recording (updating) all kinds of column statistics during file writing.
@@ -211,7 +211,7 @@ public class StatsRecorder
                  * needed in other places, integer statistics can be converted to double
                  * using the precision and scale from the type in the file footer.
                  */
-                if (type.getPrecision() <= SHORT_DECIMAL_MAX_PRECISION)
+                if (type.getPrecision() <= MAX_SHORT_DECIMAL_PRECISION)
                     return new IntegerStatsRecorder();
                 else
                     return new Integer128StatsRecorder();
@@ -255,7 +255,7 @@ public class StatsRecorder
                  * needed in other places, integer statistics can be converted to double
                  * using the precision and scale from the type in the file footer.
                  */
-                if (type.getPrecision() <= SHORT_DECIMAL_MAX_PRECISION)
+                if (type.getPrecision() <= MAX_SHORT_DECIMAL_PRECISION)
                     return new IntegerStatsRecorder(statistic);
                 else
                     return new Integer128StatsRecorder(statistic);
@@ -341,7 +341,7 @@ public class StatsRecorder
             case LONG:
                 return GeneralRangeStats.fromStatsRecorder(type, (IntegerStatsRecorder) rangeStats);
             case DECIMAL:
-                if (type.getPrecision() <= SHORT_DECIMAL_MAX_PRECISION)
+                if (type.getPrecision() <= MAX_SHORT_DECIMAL_PRECISION)
                     return GeneralRangeStats.fromStatsRecorder(type, (IntegerStatsRecorder) rangeStats);
                 else
                     return GeneralRangeStats.fromStatsRecorder(type, (Integer128StatsRecorder) rangeStats);

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/stats/TimeStatsRecorder.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/stats/TimeStatsRecorder.java
@@ -107,7 +107,7 @@ public class TimeStatsRecorder
     @Override
     public void merge(StatsRecorder other)
     {
-        if (other instanceof TimestampColumnStats)
+        if (other instanceof TimeColumnStats)
         {
             TimeStatsRecorder tStat = (TimeStatsRecorder) other;
             if (tStat.hasMinimum)

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/stats/TimestampStatsRecorder.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/stats/TimestampStatsRecorder.java
@@ -24,7 +24,7 @@ import io.pixelsdb.pixels.core.PixelsProto;
 import java.sql.Timestamp;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static io.pixelsdb.pixels.core.vector.TimestampColumnVector.timestampToMicros;
+import static io.pixelsdb.pixels.core.utils.DatetimeUtils.timestampToMicros;
 
 /**
  * pixels

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/utils/DatetimeUtils.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/utils/DatetimeUtils.java
@@ -177,7 +177,7 @@ public class DatetimeUtils
         firstColon = localTime.indexOf(':');
         secondColon = localTime.indexOf(':', firstColon+1);
         decimalPoint = localTime.indexOf('.', secondColon + 1);
-        if ((firstColon > 0) && (secondColon > 0) && (secondColon < s.length()-1))
+        if ((firstColon > 0) && (secondColon > 0) && (secondColon < localTime.length()-1))
         {
             hour = Integer.parseInt(localTime.substring(0, firstColon));
             minute = Integer.parseInt(localTime.substring(firstColon+1, secondColon));

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/utils/DatetimeUtils.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/utils/DatetimeUtils.java
@@ -20,6 +20,7 @@
 package io.pixelsdb.pixels.core.utils;
 
 import java.sql.Date;
+import java.sql.Time;
 import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.util.TimeZone;
@@ -151,5 +152,45 @@ public class DatetimeUtils
     public static int millisInDay(long millis)
     {
         return (int)(millis % 86400000);
+    }
+
+    public static Time parseTime(String s)
+    {
+        long hour;
+        long minute;
+        long second;
+        long millis;
+        int firstColon;
+        int secondColon;
+        int decimalPoint;
+
+        if (s == null)
+        {
+            throw new IllegalArgumentException("the input string is null");
+        }
+
+        firstColon = s.indexOf(':');
+        secondColon = s.indexOf(':', firstColon+1);
+        decimalPoint = s.indexOf('.', secondColon + 1);
+        if ((firstColon > 0) && (secondColon > 0) && (secondColon < s.length()-1))
+        {
+            hour = Integer.parseInt(s.substring(0, firstColon));
+            minute = Integer.parseInt(s.substring(firstColon+1, secondColon));
+
+            if (decimalPoint > 0 && decimalPoint < s.length()-1)
+            {
+                second = Integer.parseInt(s.substring(secondColon+1, decimalPoint));
+                millis = Integer.parseInt(s.substring(decimalPoint+1));
+            }
+            else
+            {
+                second = Integer.parseInt(s.substring(secondColon+1));
+                millis = 0;
+            }
+        } else {
+            throw new java.lang.IllegalArgumentException();
+        }
+
+        return new Time(hour * 3600000L + minute * 60000L + second * 1000L + millis + TIMEZONE_OFFSET);
     }
 }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/utils/DatetimeUtils.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/utils/DatetimeUtils.java
@@ -20,7 +20,6 @@
 package io.pixelsdb.pixels.core.utils;
 
 import java.sql.Date;
-import java.sql.Time;
 import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.util.TimeZone;
@@ -154,12 +153,12 @@ public class DatetimeUtils
         return (int)(millis % 86400000);
     }
 
-    public static Time parseTime(String s)
+    public static int parseTime(String s)
     {
-        long hour;
-        long minute;
-        long second;
-        long millis;
+        int hour;
+        int minute;
+        int second;
+        int millis;
         int firstColon;
         int secondColon;
         int decimalPoint;
@@ -191,6 +190,6 @@ public class DatetimeUtils
             throw new java.lang.IllegalArgumentException();
         }
 
-        return new Time(hour * 3600000L + minute * 60000L + second * 1000L + millis + TIMEZONE_OFFSET);
+        return hour * 3600000 + minute * 60000 + second * 1000 + millis;
     }
 }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/utils/DatetimeUtils.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/utils/DatetimeUtils.java
@@ -153,7 +153,13 @@ public class DatetimeUtils
         return (int)(millis % 86400000);
     }
 
-    public static int parseTime(String s)
+    /**
+     * Convert a string representation of the time in the current local timezone to the
+     * milliseconds since the start of the day in UTC time.
+     * @param localTime the string representation of local time, in the format of HH:mm:ss[.SSS]
+     * @return the milliseconds in the day
+     */
+    public static int parseTime(String localTime)
     {
         int hour;
         int minute;
@@ -163,33 +169,33 @@ public class DatetimeUtils
         int secondColon;
         int decimalPoint;
 
-        if (s == null)
+        if (localTime == null)
         {
             throw new IllegalArgumentException("the input string is null");
         }
 
-        firstColon = s.indexOf(':');
-        secondColon = s.indexOf(':', firstColon+1);
-        decimalPoint = s.indexOf('.', secondColon + 1);
+        firstColon = localTime.indexOf(':');
+        secondColon = localTime.indexOf(':', firstColon+1);
+        decimalPoint = localTime.indexOf('.', secondColon + 1);
         if ((firstColon > 0) && (secondColon > 0) && (secondColon < s.length()-1))
         {
-            hour = Integer.parseInt(s.substring(0, firstColon));
-            minute = Integer.parseInt(s.substring(firstColon+1, secondColon));
+            hour = Integer.parseInt(localTime.substring(0, firstColon));
+            minute = Integer.parseInt(localTime.substring(firstColon+1, secondColon));
 
-            if (decimalPoint > 0 && decimalPoint < s.length()-1)
+            if (decimalPoint > 0 && decimalPoint < localTime.length()-1)
             {
-                second = Integer.parseInt(s.substring(secondColon+1, decimalPoint));
-                millis = Integer.parseInt(s.substring(decimalPoint+1));
+                second = Integer.parseInt(localTime.substring(secondColon+1, decimalPoint));
+                millis = Integer.parseInt(localTime.substring(decimalPoint+1));
             }
             else
             {
-                second = Integer.parseInt(s.substring(secondColon+1));
+                second = Integer.parseInt(localTime.substring(secondColon+1));
                 millis = 0;
             }
         } else {
             throw new java.lang.IllegalArgumentException();
         }
 
-        return hour * 3600000 + minute * 60000 + second * 1000 + millis;
+        return (int) ((hour * 3600000L + minute * 60000L + second * 1000L + millis - TIMEZONE_OFFSET) % 86400000);
     }
 }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/utils/DatetimeUtils.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/utils/DatetimeUtils.java
@@ -154,9 +154,9 @@ public class DatetimeUtils
     }
 
     /**
-     * Convert a string representation of the time in the current local timezone to the
-     * milliseconds since the start of the day in UTC time.
-     * @param localTime the string representation of local time, in the format of HH:mm:ss[.SSS]
+     * Convert a string representation of the time to the milliseconds since the start of the day.
+     * Timezone is not considered and does not have any effect on the conversion.
+     * @param localTime the string representation of the time, in the format of HH:mm:ss[.SSS]
      * @return the milliseconds in the day
      */
     public static int parseTime(String localTime)

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/utils/DatetimeUtils.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/utils/DatetimeUtils.java
@@ -196,6 +196,6 @@ public class DatetimeUtils
             throw new java.lang.IllegalArgumentException();
         }
 
-        return (int) ((hour * 3600000L + minute * 60000L + second * 1000L + millis - TIMEZONE_OFFSET) % 86400000);
+        return hour * 3600000 + minute * 60000 + second * 1000 + millis;
     }
 }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/utils/DatetimeUtils.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/utils/DatetimeUtils.java
@@ -20,6 +20,7 @@
 package io.pixelsdb.pixels.core.utils;
 
 import java.sql.Date;
+import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.util.TimeZone;
 
@@ -30,6 +31,45 @@ import java.util.TimeZone;
 public class DatetimeUtils
 {
     private static long TIMEZONE_OFFSET = TimeZone.getDefault().getRawOffset();
+
+    private static final long MICROS_PER_MILLIS = 1000L;
+    private static final long NANOS_PER_MILLIS = 1000_000L;
+    private static final long MICROS_PER_SEC = 1000_000L;
+    private static final long NANOS_PER_MICROS = 1000L;
+
+    public static long microsToMillis(long micros)
+    {
+        return micros / MICROS_PER_MILLIS;
+    }
+
+    public static int microsToFracNanos(long micros)
+    {
+        return (int) (micros % MICROS_PER_SEC * NANOS_PER_MICROS);
+    }
+
+    public static long timestampToMicros(Timestamp timestamp)
+    {
+        return timestamp.getTime() * MICROS_PER_MILLIS +
+                timestamp.getNanos() % NANOS_PER_MILLIS / NANOS_PER_MICROS;
+    }
+
+    private static final long[] PRECISION_ROUND_FACTOR_FOR_MICROS = {
+            1000_000L, 100_000L, 10_000L, 1000L, 100L, 10L, 1L};
+
+    private static final int[] PRECISION_ROUND_FACTOR_FOR_MILLIS = {
+            1000, 100, 10, 1};
+
+    public static long roundMicrosToPrecision(long micros, int precision)
+    {
+        long roundFactor = PRECISION_ROUND_FACTOR_FOR_MICROS[precision];
+        return micros / roundFactor * roundFactor;
+    }
+
+    public static int roundMillisToPrecision(int millis, int precision)
+    {
+        int roundFactor = PRECISION_ROUND_FACTOR_FOR_MILLIS[precision];
+        return millis / roundFactor * roundFactor;
+    }
 
     public static void resetTimezoneOffset()
     {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/utils/Decimal.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/utils/Decimal.java
@@ -20,7 +20,7 @@
 package io.pixelsdb.pixels.core.utils;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static io.pixelsdb.pixels.core.TypeDescription.SHORT_DECIMAL_MAX_PRECISION;
+import static io.pixelsdb.pixels.core.TypeDescription.MAX_SHORT_DECIMAL_PRECISION;
 
 /**
  * Created at: 08/04/2022
@@ -59,7 +59,7 @@ public class Decimal implements Comparable<Decimal>
 
     public Decimal(long value, int precision, int scale)
     {
-        checkArgument(precision > 0 && scale >= 0 && precision >= scale && precision <= SHORT_DECIMAL_MAX_PRECISION,
+        checkArgument(precision > 0 && scale >= 0 && precision >= scale && precision <= MAX_SHORT_DECIMAL_PRECISION,
                 "invalid precision and scale (" + precision + "," + scale + ")");
         checkArgument(value < SCALE_FACTOR[precision], "overflow");
         this.value = value;

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/utils/LongDecimal.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/utils/LongDecimal.java
@@ -22,7 +22,7 @@ package io.pixelsdb.pixels.core.utils;
 import java.math.BigInteger;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static io.pixelsdb.pixels.core.TypeDescription.LONG_DECIMAL_MAX_PRECISION;
+import static io.pixelsdb.pixels.core.TypeDescription.MAX_LONG_DECIMAL_PRECISION;
 
 /**
  * @date 03/07/2022
@@ -78,7 +78,7 @@ public class LongDecimal implements Comparable<LongDecimal>
 
     public LongDecimal(Integer128 value, int precision, int scale)
     {
-        checkArgument(precision > 0 && scale >= 0 && precision >= scale && precision <= LONG_DECIMAL_MAX_PRECISION,
+        checkArgument(precision > 0 && scale >= 0 && precision >= scale && precision <= MAX_LONG_DECIMAL_PRECISION,
                 "invalid precision and scale (" + precision + "," + scale + ")");
         this.value = value;
         this.precision = precision;

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/DateColumnVector.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/DateColumnVector.java
@@ -78,7 +78,7 @@ public class DateColumnVector extends ColumnVector
         super(len);
 
         dates = new int[len];
-        memoryUsage += Integer.BYTES * len;
+        memoryUsage += (long) Integer.BYTES * len;
 
         scratchDate = new Date(0);
     }
@@ -342,7 +342,7 @@ public class DateColumnVector extends ColumnVector
         {
             ensureSize(writeIndex * 2, true);
         }
-        set(writeIndex++, stringToDay(value));
+        set(writeIndex++, stringDateToDay(value));
     }
 
     /**

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/DecimalColumnVector.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/DecimalColumnVector.java
@@ -26,8 +26,8 @@ import java.math.MathContext;
 import java.util.Arrays;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static io.pixelsdb.pixels.core.TypeDescription.SHORT_DECIMAL_MAX_PRECISION;
-import static io.pixelsdb.pixels.core.TypeDescription.SHORT_DECIMAL_MAX_SCALE;
+import static io.pixelsdb.pixels.core.TypeDescription.MAX_SHORT_DECIMAL_PRECISION;
+import static io.pixelsdb.pixels.core.TypeDescription.MAX_SHORT_DECIMAL_SCALE;
 import static java.math.BigDecimal.ROUND_HALF_UP;
 import static java.util.Objects.requireNonNull;
 
@@ -67,10 +67,10 @@ public class DecimalColumnVector extends ColumnVector
         {
             throw new IllegalArgumentException("precision " + precision + " is negative");
         }
-        else if (precision > SHORT_DECIMAL_MAX_PRECISION)
+        else if (precision > MAX_SHORT_DECIMAL_PRECISION)
         {
             throw new IllegalArgumentException("precision " + precision +
-                    " is out of the max precision " + SHORT_DECIMAL_MAX_PRECISION);
+                    " is out of the max precision " + MAX_SHORT_DECIMAL_PRECISION);
         }
         this.precision = precision;
 
@@ -78,10 +78,10 @@ public class DecimalColumnVector extends ColumnVector
         {
             throw new IllegalArgumentException("scale " + scale + " is negative");
         }
-        else if (scale > SHORT_DECIMAL_MAX_SCALE)
+        else if (scale > MAX_SHORT_DECIMAL_SCALE)
         {
             throw new IllegalArgumentException("scale " + scale +
-                    " is out of the max scale " + SHORT_DECIMAL_MAX_SCALE);
+                    " is out of the max scale " + MAX_SHORT_DECIMAL_SCALE);
         }
         else if (scale > precision)
         {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/LongDecimalColumnVector.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/LongDecimalColumnVector.java
@@ -29,8 +29,8 @@ import java.nio.ByteOrder;
 import java.util.Arrays;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static io.pixelsdb.pixels.core.TypeDescription.LONG_DECIMAL_MAX_PRECISION;
-import static io.pixelsdb.pixels.core.TypeDescription.LONG_DECIMAL_MAX_SCALE;
+import static io.pixelsdb.pixels.core.TypeDescription.MAX_LONG_DECIMAL_PRECISION;
+import static io.pixelsdb.pixels.core.TypeDescription.MAX_LONG_DECIMAL_SCALE;
 import static java.math.BigDecimal.ROUND_HALF_UP;
 import static java.util.Objects.requireNonNull;
 
@@ -67,10 +67,10 @@ public class LongDecimalColumnVector extends ColumnVector
         {
             throw new IllegalArgumentException("precision " + precision + " is negative");
         }
-        else if (precision > LONG_DECIMAL_MAX_PRECISION)
+        else if (precision > MAX_LONG_DECIMAL_PRECISION)
         {
             throw new IllegalArgumentException("precision " + precision +
-                    " is out of the max precision " + LONG_DECIMAL_MAX_PRECISION);
+                    " is out of the max precision " + MAX_LONG_DECIMAL_PRECISION);
         }
         this.precision = precision;
 
@@ -78,10 +78,10 @@ public class LongDecimalColumnVector extends ColumnVector
         {
             throw new IllegalArgumentException("scale " + scale + " is negative");
         }
-        else if (scale > LONG_DECIMAL_MAX_SCALE)
+        else if (scale > MAX_LONG_DECIMAL_SCALE)
         {
             throw new IllegalArgumentException("scale " + scale +
-                    " is out of the max scale " + LONG_DECIMAL_MAX_SCALE);
+                    " is out of the max scale " + MAX_LONG_DECIMAL_SCALE);
         }
         else if (scale > precision)
         {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/TimeColumnVector.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/TimeColumnVector.java
@@ -26,7 +26,7 @@ import java.util.Arrays;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.pixelsdb.pixels.core.utils.DatetimeUtils.millisInDay;
-import static io.pixelsdb.pixels.core.utils.DatetimeUtils.parseTime;
+import static io.pixelsdb.pixels.core.utils.DatetimeUtils.stringTimeToMillis;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -416,7 +416,7 @@ public class TimeColumnVector extends ColumnVector
         {
             ensureSize(writeIndex * 2, true);
         }
-        set(writeIndex++, parseTime(value));
+        set(writeIndex++, stringTimeToMillis(value));
     }
 
     /**

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/TimeColumnVector.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/TimeColumnVector.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.pixelsdb.pixels.core.utils.DatetimeUtils.millisInDay;
+import static io.pixelsdb.pixels.core.utils.DatetimeUtils.parseTime;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -415,7 +416,7 @@ public class TimeColumnVector extends ColumnVector
         {
             ensureSize(writeIndex * 2, true);
         }
-        set(writeIndex++, Time.valueOf(value));
+        set(writeIndex++, parseTime(value));
     }
 
     /**

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/TimestampColumnVector.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/TimestampColumnVector.java
@@ -381,7 +381,7 @@ public class TimestampColumnVector extends ColumnVector
         {
             ensureSize(writeIndex * 2, true);
         }
-        set(writeIndex++, Timestamp.valueOf(value));
+        set(writeIndex++, stringTimestampToMicros(value));
     }
 
     /**

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/TimestampColumnVector.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/TimestampColumnVector.java
@@ -25,6 +25,7 @@ import java.sql.Timestamp;
 import java.util.Arrays;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.pixelsdb.pixels.core.utils.DatetimeUtils.*;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -43,37 +44,6 @@ import static java.util.Objects.requireNonNull;
  */
 public class TimestampColumnVector extends ColumnVector
 {
-    private static final long MICROS_PER_MILLIS = 1000L;
-    private static final long NANOS_PER_MILLIS = 1000_000L;
-    private static final long MICROS_PER_SEC = 1000_000L;
-    private static final long NANOS_PER_MICROS = 1000L;
-
-    private static long microsToMillis(long micros)
-    {
-        return micros / MICROS_PER_MILLIS;
-    }
-
-    private static int microsToFracNanos(long micros)
-    {
-        return (int) (micros % MICROS_PER_SEC * NANOS_PER_MICROS);
-    }
-
-    public static long timestampToMicros(Timestamp timestamp)
-    {
-        return timestamp.getTime() * MICROS_PER_MILLIS +
-                timestamp.getNanos() % NANOS_PER_MILLIS / NANOS_PER_MICROS;
-    }
-
-    private static final long[] PRECISION_ROUND_FACTOR = {
-            1000_000L, 100_000L, 10_000L, 1000L, 100L, 10L, 1L
-    };
-
-    private long roundToPrecision(long micros)
-    {
-        long roundFactor = PRECISION_ROUND_FACTOR[precision];
-        return micros / roundFactor * roundFactor;
-    }
-
     private int precision;
 
     /*
@@ -435,7 +405,7 @@ public class TimestampColumnVector extends ColumnVector
         else
         {
             this.isNull[elementNum] = false;
-            this.times[elementNum] = roundToPrecision(timestampToMicros(timestamp));
+            this.times[elementNum] = roundMicrosToPrecision(timestampToMicros(timestamp), precision);
         }
     }
 
@@ -490,7 +460,7 @@ public class TimestampColumnVector extends ColumnVector
     {
         noNulls = true;
         isRepeating = true;
-        times[0] = roundToPrecision(timestampToMicros(timestamp));
+        times[0] = roundMicrosToPrecision(timestampToMicros(timestamp), precision);
     }
 
     @Override

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/ColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/ColumnWriter.java
@@ -28,7 +28,7 @@ import io.pixelsdb.pixels.core.vector.ColumnVector;
 import java.io.IOException;
 import java.nio.ByteOrder;
 
-import static io.pixelsdb.pixels.core.TypeDescription.SHORT_DECIMAL_MAX_PRECISION;
+import static io.pixelsdb.pixels.core.TypeDescription.MAX_SHORT_DECIMAL_PRECISION;
 
 /**
  * pixels
@@ -62,7 +62,7 @@ public interface ColumnWriter
             case DOUBLE:
                 return new DoubleColumnWriter(type, pixelStride, encodingLevel, byteOrder);
             case DECIMAL: // Issue #196: precision and scale are passed through type.
-                if (type.getPrecision() <= SHORT_DECIMAL_MAX_PRECISION)
+                if (type.getPrecision() <= MAX_SHORT_DECIMAL_PRECISION)
                     return new DecimalColumnWriter(type, pixelStride, encodingLevel, byteOrder);
                 else
                     return new LongDecimalColumnWriter(type, pixelStride, encodingLevel, byteOrder);

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/IntegerColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/IntegerColumnWriter.java
@@ -97,15 +97,13 @@ public class IntegerColumnWriter extends BaseColumnWriter
     @Override
     void newPixel() throws IOException
     {
-        // update stats
-        for (int i = 0; i < curPixelVectorIndex; i++)
-        {
-            pixelStatRecorder.updateInteger(curPixelVector[i], 1);
-        }
-
         // write out current pixel vector
         if (encodingLevel.ge(EncodingLevel.EL1))
         {
+            for (int i = 0; i < curPixelVectorIndex; i++)
+            {
+                pixelStatRecorder.updateInteger(curPixelVector[i], 1);
+            }
             outputStream.write(encoder.encode(curPixelVector, 0, curPixelVectorIndex));
         }
         else
@@ -118,6 +116,7 @@ public class IntegerColumnWriter extends BaseColumnWriter
                 for (int i = 0; i < curPixelVectorIndex; i++)
                 {
                     curVecPartitionBuffer.putLong(curPixelVector[i]);
+                    pixelStatRecorder.updateInteger(curPixelVector[i], 1);
                 }
             }
             else
@@ -127,6 +126,7 @@ public class IntegerColumnWriter extends BaseColumnWriter
                 for (int i = 0; i < curPixelVectorIndex; i++)
                 {
                     curVecPartitionBuffer.putInt((int) curPixelVector[i]);
+                    pixelStatRecorder.updateInteger(curPixelVector[i], 1);
                 }
             }
             outputStream.write(curVecPartitionBuffer.array());

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/TimeColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/TimeColumnWriter.java
@@ -94,13 +94,12 @@ public class TimeColumnWriter extends BaseColumnWriter
     @Override
     public void newPixel() throws IOException
     {
-        for (int i = 0; i < curPixelVectorIndex; i++)
-        {
-            pixelStatRecorder.updateTime(curPixelVector[i]);
-        }
-
         if (encodingLevel.ge(EncodingLevel.EL1))
         {
+            for (int i = 0; i < curPixelVectorIndex; i++)
+            {
+                pixelStatRecorder.updateTime(curPixelVector[i]);
+            }
             int[] values = new int[curPixelVectorIndex];
             System.arraycopy(curPixelVector, 0, values, 0, curPixelVectorIndex);
             outputStream.write(encoder.encode(values));
@@ -113,6 +112,7 @@ public class TimeColumnWriter extends BaseColumnWriter
             for (int i = 0; i < curPixelVectorIndex; i++)
             {
                 curVecPartitionBuffer.putInt(curPixelVector[i]);
+                pixelStatRecorder.updateTime(curPixelVector[i]);
             }
             outputStream.write(curVecPartitionBuffer.array());
         }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/TimestampColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/TimestampColumnWriter.java
@@ -93,13 +93,12 @@ public class TimestampColumnWriter extends BaseColumnWriter
     @Override
     public void newPixel() throws IOException
     {
-        for (int i = 0; i < curPixelVectorIndex; i++)
-        {
-            pixelStatRecorder.updateTimestamp(curPixelVector[i]);
-        }
-
         if (encodingLevel.ge(EncodingLevel.EL1))
         {
+            for (int i = 0; i < curPixelVectorIndex; i++)
+            {
+                pixelStatRecorder.updateTimestamp(curPixelVector[i]);
+            }
             long[] values = new long[curPixelVectorIndex];
             System.arraycopy(curPixelVector, 0, values, 0, curPixelVectorIndex);
             outputStream.write(encoder.encode(values));
@@ -112,6 +111,7 @@ public class TimestampColumnWriter extends BaseColumnWriter
             for (int i = 0; i < curPixelVectorIndex; i++)
             {
                 curVecPartitionBuffer.putLong(curPixelVector[i]);
+                pixelStatRecorder.updateTimestamp(curPixelVector[i]);
             }
             outputStream.write(curVecPartitionBuffer.array());
         }

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/utils/TestDateTimeUtils.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/utils/TestDateTimeUtils.java
@@ -36,7 +36,7 @@ public class TestDateTimeUtils
     @Test
     public void testTimeFormat()
     {
-        Time time = parseTime("15:36:59.123");
+        Time time = new Time(parseTime("15:36:59.123"));
         System.out.println(time);
         System.out.println(time.getTime());
     }

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/utils/TestDateTimeUtils.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/utils/TestDateTimeUtils.java
@@ -22,7 +22,10 @@ package io.pixelsdb.pixels.core.utils;
 import org.junit.Test;
 
 import java.sql.Date;
+import java.sql.Time;
 import java.util.TimeZone;
+
+import static io.pixelsdb.pixels.core.utils.DatetimeUtils.parseTime;
 
 /**
  * @author hank
@@ -30,6 +33,14 @@ import java.util.TimeZone;
  */
 public class TestDateTimeUtils
 {
+    @Test
+    public void testTimeFormat()
+    {
+        Time time = parseTime("15:36:59.123");
+        System.out.println(time);
+        System.out.println(time.getTime());
+    }
+
     @Test
     public void testGetDaysSinceEpoch()
     {

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/utils/TestDateTimeUtils.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/utils/TestDateTimeUtils.java
@@ -23,9 +23,13 @@ import org.junit.Test;
 
 import java.sql.Date;
 import java.sql.Time;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
 import java.util.TimeZone;
 
-import static io.pixelsdb.pixels.core.utils.DatetimeUtils.parseTime;
+import static io.pixelsdb.pixels.core.utils.DatetimeUtils.SQL_LOCAL_DATE_TIME;
+import static io.pixelsdb.pixels.core.utils.DatetimeUtils.stringTimeToMillis;
 
 /**
  * @author hank
@@ -36,9 +40,17 @@ public class TestDateTimeUtils
     @Test
     public void testTimeFormat()
     {
-        Time time = new Time(parseTime("15:36:59.123"));
+        Time time = new Time(stringTimeToMillis("15:36:59.123"));
         System.out.println(time);
         System.out.println(time.getTime());
+        long timestamp = LocalDateTime.of(
+                1970, 1, 1, 23, 59, 59,
+                128000000).toEpochSecond(ZoneOffset.UTC);
+        System.out.println(timestamp);
+        System.out.println(LocalTime.parse("20:38:47.123").toNanoOfDay());
+        LocalDateTime localDateTime = LocalDateTime.parse("1970-01-01 20:38:47.12345", SQL_LOCAL_DATE_TIME);
+        System.out.println(localDateTime.toEpochSecond(ZoneOffset.UTC));
+        System.out.println(localDateTime.getNano());
     }
 
     @Test
@@ -48,7 +60,7 @@ public class TestDateTimeUtils
         System.out.println(TimeZone.getDefault().getDisplayName() + ", offset=" +
                 TimeZone.getDefault().getRawOffset());
         day1 = DatetimeUtils.sqlDateToDay(Date.valueOf("2023-03-05"));
-        day2 = DatetimeUtils.stringToDay("2023-03-05");
+        day2 = DatetimeUtils.stringDateToDay("2023-03-05");
         day3 = DatetimeUtils.localMillisToUtcDays(Date.valueOf("2023-03-05").getTime());
         assert day1 == day2 && day2 == day3;
 
@@ -57,7 +69,7 @@ public class TestDateTimeUtils
                 TimeZone.getDefault().getRawOffset());
         DatetimeUtils.resetTimezoneOffset();
         day1 = DatetimeUtils.sqlDateToDay(Date.valueOf("2023-03-05"));
-        day2 = DatetimeUtils.stringToDay("2023-03-05");
+        day2 = DatetimeUtils.stringDateToDay("2023-03-05");
         day3 = DatetimeUtils.localMillisToUtcDays(Date.valueOf("2023-03-05").getTime());
         assert day1 == day2 && day2 == day3;
 
@@ -66,7 +78,7 @@ public class TestDateTimeUtils
                 TimeZone.getDefault().getRawOffset());
         DatetimeUtils.resetTimezoneOffset();
         day1 = DatetimeUtils.sqlDateToDay(Date.valueOf("2023-03-05"));
-        day2 = DatetimeUtils.stringToDay("2023-03-05");
+        day2 = DatetimeUtils.stringDateToDay("2023-03-05");
         day3 = DatetimeUtils.localMillisToUtcDays(Date.valueOf("2023-03-05").getTime());
         assert day1 == day2 && day2 == day3;
 
@@ -75,7 +87,7 @@ public class TestDateTimeUtils
                 TimeZone.getDefault().getRawOffset());
         DatetimeUtils.resetTimezoneOffset();
         day1 = DatetimeUtils.sqlDateToDay(Date.valueOf("2023-03-05"));
-        day2 = DatetimeUtils.stringToDay("2023-03-05");
+        day2 = DatetimeUtils.stringDateToDay("2023-03-05");
         day3 = DatetimeUtils.localMillisToUtcDays(Date.valueOf("2023-03-05").getTime());
         assert day1 == day2 && day2 == day3;
 
@@ -84,7 +96,7 @@ public class TestDateTimeUtils
                 TimeZone.getDefault().getRawOffset());
         DatetimeUtils.resetTimezoneOffset();
         day1 = DatetimeUtils.sqlDateToDay(Date.valueOf("2023-03-05"));
-        day2 = DatetimeUtils.stringToDay("2023-03-05");
+        day2 = DatetimeUtils.stringDateToDay("2023-03-05");
         day3 = DatetimeUtils.localMillisToUtcDays(Date.valueOf("2023-03-05").getTime());
         assert day1 == day2 && day2 == day3;
 
@@ -93,7 +105,7 @@ public class TestDateTimeUtils
                 TimeZone.getDefault().getRawOffset());
         DatetimeUtils.resetTimezoneOffset();
         day1 = DatetimeUtils.sqlDateToDay(Date.valueOf("2023-03-05"));
-        day2 = DatetimeUtils.stringToDay("2023-03-05");
+        day2 = DatetimeUtils.stringDateToDay("2023-03-05");
         day3 = DatetimeUtils.localMillisToUtcDays(Date.valueOf("2023-03-05").getTime());
         assert day1 == day2 && day2 == day3;
 
@@ -102,7 +114,7 @@ public class TestDateTimeUtils
                 TimeZone.getDefault().getRawOffset());
         DatetimeUtils.resetTimezoneOffset();
         day1 = DatetimeUtils.sqlDateToDay(Date.valueOf("2023-03-05"));
-        day2 = DatetimeUtils.stringToDay("2023-03-05");
+        day2 = DatetimeUtils.stringDateToDay("2023-03-05");
         day3 = DatetimeUtils.localMillisToUtcDays(Date.valueOf("2023-03-05").getTime());
         assert day1 == day2 && day2 == day3;
 
@@ -111,7 +123,7 @@ public class TestDateTimeUtils
                 TimeZone.getDefault().getRawOffset());
         DatetimeUtils.resetTimezoneOffset();
         day1 = DatetimeUtils.sqlDateToDay(Date.valueOf("2023-03-05"));
-        day2 = DatetimeUtils.stringToDay("2023-03-05");
+        day2 = DatetimeUtils.stringDateToDay("2023-03-05");
         day3 = DatetimeUtils.localMillisToUtcDays(Date.valueOf("2023-03-05").getTime());
         assert day1 == day2 && day2 == day3;
     }


### PR DESCRIPTION
1. support precision for time type. This is optional by early Presto but required by Trino.
2. fix stats recorder for time.
3. fix reading non-encoded timestamp columns. The bug was caused by the wrong precision when casting formats.
4. revise parsing string to time and timestamp values.
5. fix the timezone offset problem for timestamp.