### PR TITLE
[Issue #564] Fix Pixels C++ Reader filter pushdown segmentation fault

### DIFF
--- a/cpp/pixels-core/lib/reader/PixelsRecordReaderImpl.cpp
+++ b/cpp/pixels-core/lib/reader/PixelsRecordReaderImpl.cpp
@@ -198,11 +198,12 @@ std::shared_ptr<VectorizedRowBatch> PixelsRecordReaderImpl::readBatch(bool reuse
 
     // read vectors
     for(int i = 0; i < resultColumns.size(); i++) {
-        if(filterMask != nullptr) {
-            if(filterMask->isNone()) {
-                break;
-            }
-        }
+        // TODO: Refer to Issue #564. Disable data skipping
+        //if(filterMask != nullptr) {
+        //    if(filterMask->isNone()) {
+        //        break;
+        //    }
+        //}
         // Skip the columns that calculate the filter mask, since they are already processed
         int index = curChunkBufferIndex.at(i);
         if(std::find(filterColumnIndex.begin(), filterColumnIndex.end(), index) != filterColumnIndex.end()) {


### PR DESCRIPTION
Disable data skipping, otherwise segmentation fault happens.