### PR TITLE
[Issue #545] support nulls padding in the file format

### DIFF
--- a/docs/TPC-H.md
+++ b/docs/TPC-H.md
@@ -40,7 +40,7 @@ Then use the following commands in pixels-cli to load data for the TPC-H tables:
 LOAD -o file:///data/tpch/100g/customer -s tpch -t customer -n 319150 -r \| -c 1
 LOAD -o file:///data/tpch/100g/lineitem -s tpch -t lineitem -n 600040 -r \| -c 1
 LOAD -o file:///data/tpch/100g/nation -s tpch -t nation -n 100 -r \| -c 1
-LOAD -o file:///data/tpch/100g/orders -s tpch -t orders -n 638300 -r \| -c 1
+LOAD -o file:///scratch/data/tpch-300g/orders/ -s tpch -t orders -n 638300 -r \| -c 1 -e 2 -p true
 LOAD -o file:///data/tpch/100g/part -s tpch -t part -n 769240 -r \| -c 1
 LOAD -o file:///data/tpch/100g/partsupp -s tpch -t partsupp -n 360370 -r \| -c 1
 LOAD -o file:///data/tpch/100g/region -s tpch -t region -n 10 -r \| -c 1

--- a/docs/TPC-H.md
+++ b/docs/TPC-H.md
@@ -40,7 +40,7 @@ Then use the following commands in pixels-cli to load data for the TPC-H tables:
 LOAD -o file:///data/tpch/100g/customer -s tpch -t customer -n 319150 -r \| -c 1
 LOAD -o file:///data/tpch/100g/lineitem -s tpch -t lineitem -n 600040 -r \| -c 1
 LOAD -o file:///data/tpch/100g/nation -s tpch -t nation -n 100 -r \| -c 1
-LOAD -o file:///scratch/data/tpch-300g/orders/ -s tpch -t orders -n 638300 -r \| -c 1 -e 2 -p true
+LOAD -o file:///scratch/data/tpch-300g/orders/ -s tpch -t orders -n 638300 -r \| -c 1
 LOAD -o file:///data/tpch/100g/part -s tpch -t part -n 769240 -r \| -c 1
 LOAD -o file:///data/tpch/100g/partsupp -s tpch -t partsupp -n 360370 -r \| -c 1
 LOAD -o file:///data/tpch/100g/region -s tpch -t region -n 10 -r \| -c 1

--- a/pixels-amphi/pixels-amphi/src/main/java/io/pixelsdb/pixels/amphi/downloader/PeerDownloader.java
+++ b/pixels-amphi/pixels-amphi/src/main/java/io/pixelsdb/pixels/amphi/downloader/PeerDownloader.java
@@ -378,6 +378,9 @@ public class PeerDownloader
                     record.put(columns.get(i).getName(), tscv.times[rowIdx]);
                     break;
                 case FLOAT:
+                    FloatColumnVector fcv = (FloatColumnVector) columnVectors.get(i);
+                    record.put(columns.get(i).getName(), fcv.vector[rowIdx]);
+                    break;
                 case DOUBLE:
                     DoubleColumnVector dbcv = (DoubleColumnVector) columnVectors.get(i);
                     record.put(columns.get(i).getName(), dbcv.vector[rowIdx]);

--- a/pixels-cli/src/main/java/io/pixelsdb/pixels/cli/Main.java
+++ b/pixels-cli/src/main/java/io/pixelsdb/pixels/cli/Main.java
@@ -123,7 +123,9 @@ public class Main
                 argumentParser.addArgument("-c", "--consumer_thread_num").setDefault("4").required(true)
                         .help("specify the number of consumer threads used for data generation");
                 argumentParser.addArgument("-e", "--encoding_level").setDefault("2")
-                        .help("specify the the encoding level for data loading");
+                        .help("specify the encoding level for data loading");
+                argumentParser.addArgument("-p", "--nulls_padding").setDefault(false)
+                        .help("specify whether nulls padding is enabled");
                 argumentParser.addArgument("-l", "--loading_data_paths")
                         .help("specify the paths where the data is loaded into");
 

--- a/pixels-cli/src/main/java/io/pixelsdb/pixels/cli/executor/LoadExecutor.java
+++ b/pixels-cli/src/main/java/io/pixelsdb/pixels/cli/executor/LoadExecutor.java
@@ -53,6 +53,7 @@ public class LoadExecutor implements CommandExecutor
         int threadNum = Integer.parseInt(ns.getString("consumer_thread_num"));
         EncodingLevel encodingLevel = EncodingLevel.from(Integer.parseInt(ns.getString("encoding_level")));
         System.out.println("encoding level: " + encodingLevel);
+        boolean nullsPadding = Boolean.parseBoolean(ns.getString("nulls_padding"));
         String[] loadingDataPaths = null;
         if (paths != null)
         {
@@ -70,7 +71,8 @@ public class LoadExecutor implements CommandExecutor
 
         Storage storage = StorageFactory.Instance().getStorage(origin);
 
-        Parameters parameters = new Parameters(schemaName, tableName, rowNum, regex, encodingLevel, loadingDataPaths);
+        Parameters parameters = new Parameters(schemaName, tableName, rowNum, regex,
+                encodingLevel, nullsPadding, loadingDataPaths);
 
         // source already exist, producer option is false, add list of source to the queue
         List<String> fileList = storage.listPaths(origin);

--- a/pixels-cli/src/main/java/io/pixelsdb/pixels/cli/load/Parameters.java
+++ b/pixels-cli/src/main/java/io/pixelsdb/pixels/cli/load/Parameters.java
@@ -43,6 +43,7 @@ public class Parameters
     private String schema;
     private int[] orderMapping;
     private final EncodingLevel encodingLevel;
+    private final boolean nullsPadding;
 
     public String[] getLoadingPaths()
     {
@@ -74,8 +75,13 @@ public class Parameters
         return encodingLevel;
     }
 
+    public boolean isNullsPadding()
+    {
+        return nullsPadding;
+    }
+
     public Parameters(String dbName, String tableName, int maxRowNum, String regex,
-                      EncodingLevel encodingLevel, @Nullable String[] loadingPaths)
+                      EncodingLevel encodingLevel, boolean nullsPadding, @Nullable String[] loadingPaths)
     {
         this.dbName = dbName;
         this.tableName = tableName;
@@ -83,6 +89,7 @@ public class Parameters
         this.regex = regex;
         this.loadingPaths = loadingPaths;
         this.encodingLevel = encodingLevel;
+        this.nullsPadding = nullsPadding;
     }
 
     /**

--- a/pixels-cli/src/main/java/io/pixelsdb/pixels/cli/load/PixelsConsumer.java
+++ b/pixels-cli/src/main/java/io/pixelsdb/pixels/cli/load/PixelsConsumer.java
@@ -72,6 +72,7 @@ public class PixelsConsumer extends Consumer
             int maxRowNum = parameters.getMaxRowNum();
             String regex = parameters.getRegex();
             EncodingLevel encodingLevel = parameters.getEncodingLevel();
+            boolean nullsPadding = parameters.isNullsPadding();
             if (regex.equals("\\s"))
             {
                 regex = " ";
@@ -138,6 +139,7 @@ public class PixelsConsumer extends Consumer
                                     .setReplication(replication)
                                     .setBlockPadding(true)
                                     .setEncodingLevel(encodingLevel)
+                                    .setNullsPadding(nullsPadding)
                                     .setCompressionBlockSize(1)
                                     .build();
                         }

--- a/pixels-core/pom.xml
+++ b/pixels-core/pom.xml
@@ -76,6 +76,13 @@
             <artifactId>jetcd-core</artifactId>
             <optional>true</optional>
         </dependency>
+
+        <dependency>
+            <!-- this is only for third-party libs that use slf4j -->
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/TypeDescription.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/TypeDescription.java
@@ -1087,6 +1087,7 @@ public final class TypeDescription
             case TIMESTAMP:
                 return new TimestampColumnVector(maxSize, precision);
             case FLOAT:
+                return new FloatColumnVector(maxSize);
             case DOUBLE:
                 return new DoubleColumnVector(maxSize);
             case DECIMAL:

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/encoding/EncodingLevel.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/encoding/EncodingLevel.java
@@ -66,6 +66,11 @@ public enum EncodingLevel
         return level >= 0 && level <= 2;
     }
 
+    /**
+     * Grater than or equal to.
+     * @param level the other encoding level
+     * @return true if this encoding level is greater than or equal to the other encoding level
+     */
     public boolean ge(int level)
     {
         checkArgument(isValid(level), "leve is invalid");

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/encoding/EncodingLevel.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/encoding/EncodingLevel.java
@@ -72,6 +72,11 @@ public enum EncodingLevel
         return this.level >= level;
     }
 
+    /**
+     * Grater than or equal to.
+     * @param encodingLevel the other encoding level
+     * @return true if this encoding level is greater than or equal to the other encoding level
+     */
     public boolean ge(EncodingLevel encodingLevel)
     {
         requireNonNull(level, "level is null");

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/BooleanColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/BooleanColumnReader.java
@@ -98,6 +98,7 @@ public class BooleanColumnReader extends ColumnReader
             elementIndex = 0;
             isNullBitIndex = 8;
         }
+        boolean nullsPadding = chunkIndex.hasNullsPadding() && chunkIndex.getNullsPadding();
         for (int i = 0; i < size; i++)
         {
             if (elementIndex % pixelStride == 0)

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/BooleanColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/BooleanColumnReader.java
@@ -140,6 +140,7 @@ public class BooleanColumnReader extends ColumnReader
                 {
                     BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset);
                     isNullOffset += bytesToDeCompact;
+                    columnVector.noNulls = false;
                 }
                 else
                 {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/BooleanColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/BooleanColumnReader.java
@@ -30,7 +30,7 @@ import java.nio.ByteBuffer;
 import java.util.Arrays;
 
 /**
- * @author guodong
+ * @author guodong, hank
  */
 public class BooleanColumnReader extends ColumnReader
 {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/BooleanColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/BooleanColumnReader.java
@@ -27,6 +27,7 @@ import io.pixelsdb.pixels.core.vector.ColumnVector;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 
 /**
  * @author guodong
@@ -35,8 +36,12 @@ public class BooleanColumnReader extends ColumnReader
 {
     private ByteBuffer inputBuffer;
     private byte[] bits;
-    private byte[] isNull = new byte[8];
-    private int bitsIndex = 0;
+    private byte[] isNull;
+    /**
+     * The index of {@link #bits} if the column chunk is not nulls-padded,
+     * or the index of {@link #inputBuffer} if the column chunk is nulls-padded.
+     */
+    private int bitsOrInputIndex = 0;
     private int isNullOffset = 0;
     private int isNullBitIndex = 0;
 
@@ -84,54 +89,107 @@ public class BooleanColumnReader extends ColumnReader
                      ColumnVector vector, PixelsProto.ColumnChunkIndex chunkIndex)
     {
         ByteColumnVector columnVector = (ByteColumnVector) vector;
+        int bytesToDeCompact;
+        boolean nullsPadding = chunkIndex.hasNullsPadding() && chunkIndex.getNullsPadding();
         if (offset == 0)
         {
-            bits = new byte[input.remaining() * 8];
             // read content
             this.inputBuffer = input;
-            BitUtils.bitWiseDeCompact(bits, input, input.position(), input.remaining());
+            if (!nullsPadding)
+            {
+                // Issue #545: de-compact the byte before isNullOffset instead of the whole chunk
+                bytesToDeCompact = chunkIndex.getIsNullOffset();
+                bits = new byte[bytesToDeCompact * 8];
+                BitUtils.bitWiseDeCompact(bits, input, input.position(), bytesToDeCompact);
+                isNull = new byte[8];
+            }
+            else
+            {
+                // we will try to de-compact directly into the vector of the column chunk
+                bits = null;
+                isNull = null;
+            }
             // read isNull
-            isNullOffset = input.position() + (int) chunkIndex.getIsNullOffset();
+            isNullOffset = input.position() + chunkIndex.getIsNullOffset();
             // re-init
-            bitsIndex = 0;
+            bitsOrInputIndex = 0;
             hasNull = true;
             elementIndex = 0;
             isNullBitIndex = 8;
         }
-        boolean nullsPadding = chunkIndex.hasNullsPadding() && chunkIndex.getNullsPadding();
-        for (int i = 0; i < size; i++)
+        if (nullsPadding)
         {
-            if (elementIndex % pixelStride == 0)
+            // read without copying the de-compacted content and isNull
+            int numLeft = size, numToRead;
+            for (int i = vectorIndex; numLeft > 0;)
             {
+                if (elementIndex / pixelStride < (elementIndex + numLeft) / pixelStride)
+                {
+                    // read to the end of the current pixel
+                    numToRead = pixelStride - elementIndex % pixelStride;
+                }
+                else
+                {
+                    numToRead = numLeft;
+                }
+                bytesToDeCompact = (numToRead + 7) / 8;
+                // read isNull
                 int pixelId = elementIndex / pixelStride;
                 hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
-                // skip padding bits
-                bitsIndex = (int) Math.ceil((double) bitsIndex / 8.0d) * 8;
-                if (hasNull && isNullBitIndex > 0)
+                if (hasNull)
+                {
+                    BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset);
+                    isNullOffset += bytesToDeCompact;
+                }
+                else
+                {
+                    Arrays.fill(columnVector.isNull, i, i + numToRead, false);
+                }
+                // read content
+                BitUtils.bitWiseDeCompact(columnVector.vector, i, numToRead, inputBuffer, bitsOrInputIndex);
+                // update variables
+                numLeft -= numToRead;
+                elementIndex += numToRead;
+                i += numToRead;
+                bitsOrInputIndex += bytesToDeCompact;
+            }
+        }
+        else
+        {
+            for (int i = 0; i < size; i++)
+            {
+                if (elementIndex % pixelStride == 0)
+                {
+                    int pixelId = elementIndex / pixelStride;
+                    hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
+                    // skip the padding bits at the end of the previous pixel
+                    bitsOrInputIndex = (bitsOrInputIndex + 7) / 8 * 8;
+                    if (hasNull && isNullBitIndex > 0)
+                    {
+                        BitUtils.bitWiseDeCompact(this.isNull, inputBuffer, isNullOffset++, 1);
+                        isNullBitIndex = 0;
+                    }
+                }
+                if (hasNull && isNullBitIndex >= 8)
                 {
                     BitUtils.bitWiseDeCompact(this.isNull, inputBuffer, isNullOffset++, 1);
                     isNullBitIndex = 0;
                 }
+                if (hasNull && isNull[isNullBitIndex] == 1)
+                {
+                    columnVector.isNull[i + vectorIndex] = true;
+                    columnVector.noNulls = false;
+                }
+                else
+                {
+                    columnVector.vector[i + vectorIndex] = bits[bitsOrInputIndex++];
+                }
+                if (hasNull)
+                {
+                    isNullBitIndex++;
+                }
+                elementIndex++;
             }
-            if (hasNull && isNullBitIndex >= 8)
-            {
-                BitUtils.bitWiseDeCompact(this.isNull, inputBuffer, isNullOffset++, 1);
-                isNullBitIndex = 0;
-            }
-            if (hasNull && isNull[isNullBitIndex] == 1)
-            {
-                columnVector.isNull[i + vectorIndex] = true;
-                columnVector.noNulls = false;
-            }
-            else
-            {
-                columnVector.vector[i + vectorIndex] = bits[bitsIndex++];
-            }
-            if (hasNull)
-            {
-                isNullBitIndex++;
-            }
-            elementIndex++;
         }
     }
 }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/CharColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/CharColumnReader.java
@@ -24,8 +24,7 @@ import io.pixelsdb.pixels.core.TypeDescription;
 /**
  * This class is the same as String and Varchar column reader.
  * It does not pad zeros at the end of a value for performance reasons.
- * @author guodong
- * @author hank
+ * @author guodong, hank
  */
 public class CharColumnReader extends StringColumnReader
 {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/ColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/ColumnReader.java
@@ -85,6 +85,11 @@ public abstract class ColumnReader implements Closeable
         }
     }
 
+    public ColumnReader(TypeDescription type)
+    {
+        this.type = requireNonNull(type, "type is null");
+    }
+
     /**
      * Read values from input buffer.
      * Values after specified offset are going to be put into the specified vector.
@@ -103,11 +108,6 @@ public abstract class ColumnReader implements Closeable
                               int offset, int size, int pixelStride, final int vectorIndex,
                               ColumnVector vector, PixelsProto.ColumnChunkIndex chunkIndex) throws IOException;
 
-    public ColumnReader(TypeDescription type)
-    {
-        this.type = requireNonNull(type, "type is null");
-    }
-
     /**
      * Closes this column reader and releases any resources associated
      * with it. If the column reader is already closed then invoking this
@@ -122,5 +122,5 @@ public abstract class ColumnReader implements Closeable
      * @throws IOException if an I/O error occurs
      */
     @Override
-    abstract public void close() throws IOException;
+    public abstract void close() throws IOException;
 }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/DateColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/DateColumnReader.java
@@ -47,8 +47,6 @@ public class DateColumnReader extends ColumnReader
     private InputStream inputStream = null;
     private RunLenIntDecoder decoder = null;
     private int isNullOffset = 0;
-    private int isNullBitIndex = 0;
-    private byte[] isNull = new byte[8];
 
     DateColumnReader(TypeDescription type)
     {
@@ -71,7 +69,10 @@ public class DateColumnReader extends ColumnReader
     @Override
     public void close() throws IOException
     {
-        isNull = null;
+        if (inputStream != null)
+        {
+            inputStream.close();
+        }
     }
 
     /**
@@ -108,7 +109,6 @@ public class DateColumnReader extends ColumnReader
             isNullOffset = inputBuffer.position() + chunkIndex.getIsNullOffset();
             hasNull = true;
             elementIndex = 0;
-            isNullBitIndex = 8;
         }
 
         boolean decoding = encoding.getKind().equals(PixelsProto.ColumnEncoding.Kind.RUNLENGTH);

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/DateColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/DateColumnReader.java
@@ -115,7 +115,6 @@ public class DateColumnReader extends ColumnReader
 
         if (encoding.getKind().equals(PixelsProto.ColumnEncoding.Kind.RUNLENGTH))
         {
-            checkArgument(!nullsPadding, "nullsPadding should not be enabled for encoded column chunk");
             for (int i = 0; i < size; i++)
             {
                 if (elementIndex % pixelStride == 0)

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/DateColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/DateColumnReader.java
@@ -68,7 +68,7 @@ public class DateColumnReader extends ColumnReader
     @Override
     public void close() throws IOException
     {
-
+        isNull = null;
     }
 
     /**
@@ -101,7 +101,7 @@ public class DateColumnReader extends ColumnReader
             this.inputBuffer.order(littleEndian ? ByteOrder.LITTLE_ENDIAN : ByteOrder.BIG_ENDIAN);
             inputStream = new ByteBufferInputStream(inputBuffer, inputBuffer.position(), inputBuffer.limit());
             decoder = new RunLenIntDecoder(inputStream, true);
-            isNullOffset = inputBuffer.position() + (int) chunkIndex.getIsNullOffset();
+            isNullOffset = inputBuffer.position() + chunkIndex.getIsNullOffset();
             hasNull = true;
             elementIndex = 0;
             isNullBitIndex = 8;

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/DateColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/DateColumnReader.java
@@ -36,7 +36,7 @@ import java.util.Arrays;
 import static com.google.common.base.Preconditions.checkArgument;
 
 /**
- * Pixels date column reader
+ * Pixels date column reader.
  * All date values are translated to the specified time zone after read from file.
  *
  * @author hank

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/DecimalColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/DecimalColumnReader.java
@@ -42,9 +42,7 @@ public class DecimalColumnReader extends ColumnReader
 {
     // private final EncodingUtils encodingUtils;
     private ByteBuffer inputBuffer;
-    private byte[] isNull = new byte[8];
     private int isNullOffset = 0;
-    private int isNullBitIndex = 0;
     private int inputIndex = 0;
 
     DecimalColumnReader(TypeDescription type)
@@ -70,7 +68,6 @@ public class DecimalColumnReader extends ColumnReader
     public void close() throws IOException
     {
         this.inputBuffer = null;
-        this.isNull = null;
     }
 
     /**
@@ -108,82 +105,56 @@ public class DecimalColumnReader extends ColumnReader
             // re-init
             hasNull = true;
             elementIndex = 0;
-            isNullBitIndex = 8;
         }
         boolean nullsPadding = chunkIndex.hasNullsPadding() && chunkIndex.getNullsPadding();
-        if (nullsPadding)
+        // read without copying the de-compacted content and isNull
+        int numLeft = size, numToRead, bytesToDeCompact;
+        for (int i = vectorIndex; numLeft > 0; )
         {
-            // read without copying the de-compacted content and isNull
-            int numLeft = size, numToRead, bytesToDeCompact;
-            for (int i = vectorIndex; numLeft > 0; )
+            if (elementIndex / pixelStride < (elementIndex + numLeft) / pixelStride)
             {
-                if (elementIndex / pixelStride < (elementIndex + numLeft) / pixelStride)
-                {
-                    // read to the end of the current pixel
-                    numToRead = pixelStride - elementIndex % pixelStride;
-                } else
-                {
-                    numToRead = numLeft;
-                }
-                bytesToDeCompact = (numToRead + 7) / 8;
-                // read isNull
-                int pixelId = elementIndex / pixelStride;
-                hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
-                if (hasNull)
-                {
-                    BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset);
-                    isNullOffset += bytesToDeCompact;
-                    columnVector.noNulls = false;
-                } else
-                {
-                    Arrays.fill(columnVector.isNull, i, i + numToRead, false);
-                }
-                // read content
+                // read to the end of the current pixel
+                numToRead = pixelStride - elementIndex % pixelStride;
+            } else
+            {
+                numToRead = numLeft;
+            }
+            bytesToDeCompact = (numToRead + 7) / 8;
+            // read isNull
+            int pixelId = elementIndex / pixelStride;
+            hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
+            if (hasNull)
+            {
+                BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset);
+                isNullOffset += bytesToDeCompact;
+                columnVector.noNulls = false;
+            } else
+            {
+                Arrays.fill(columnVector.isNull, i, i + numToRead, false);
+            }
+            // read content
+            if (nullsPadding)
+            {
                 for (int j = i; j < i + numToRead; ++j)
                 {
                     columnVector.vector[j] = inputBuffer.getLong(inputIndex);
                     inputIndex += Long.BYTES;
                 }
-                // update variables
-                numLeft -= numToRead;
-                elementIndex += numToRead;
-                i += numToRead;
-            }
-        }
-        else
-        {
-            for (int i = 0; i < size; i++)
+            } else
             {
-                if (elementIndex % pixelStride == 0)
+                for (int j = i; j < i + numToRead; ++j)
                 {
-                    int pixelId = elementIndex / pixelStride;
-                    hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
-                    if (hasNull && isNullBitIndex > 0)
+                    if (!(hasNull && columnVector.isNull[j]))
                     {
-                        BitUtils.bitWiseDeCompact(isNull, inputBuffer, isNullOffset++, 1);
-                        isNullBitIndex = 0;
+                        columnVector.vector[j] = this.inputBuffer.getLong(inputIndex);
+                        inputIndex += Long.BYTES;
                     }
                 }
-                if (hasNull && isNullBitIndex >= 8)
-                {
-                    BitUtils.bitWiseDeCompact(isNull, inputBuffer, isNullOffset++, 1);
-                    isNullBitIndex = 0;
-                }
-                if (hasNull && isNull[isNullBitIndex] == 1)
-                {
-                    columnVector.isNull[i + vectorIndex] = true;
-                    columnVector.noNulls = false;
-                } else
-                {
-                    columnVector.vector[i + vectorIndex] = this.inputBuffer.getLong(inputIndex);
-                    inputIndex += Long.BYTES;
-                }
-                if (hasNull)
-                {
-                    isNullBitIndex++;
-                }
-                elementIndex++;
             }
+            // update variables
+            numLeft -= numToRead;
+            elementIndex += numToRead;
+            i += numToRead;
         }
     }
 }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/DecimalColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/DecimalColumnReader.java
@@ -100,7 +100,7 @@ public class DecimalColumnReader extends ColumnReader
             this.inputBuffer.order(littleEndian ? ByteOrder.LITTLE_ENDIAN : ByteOrder.BIG_ENDIAN);
             inputIndex = this.inputBuffer.position();
             // isNull
-            isNullOffset = inputIndex + (int) chunkIndex.getIsNullOffset();
+            isNullOffset = inputIndex + chunkIndex.getIsNullOffset();
             // re-init
             hasNull = true;
             elementIndex = 0;

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/DoubleColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/DoubleColumnReader.java
@@ -92,7 +92,7 @@ public class DoubleColumnReader extends ColumnReader
             this.inputBuffer.order(littleEndian ? ByteOrder.LITTLE_ENDIAN : ByteOrder.BIG_ENDIAN);
             inputIndex = inputBuffer.position();
             // isNull
-            isNullOffset = inputIndex + (int) chunkIndex.getIsNullOffset();
+            isNullOffset = inputIndex + chunkIndex.getIsNullOffset();
             // re-init
             hasNull = true;
             elementIndex = 0;

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/DoubleColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/DoubleColumnReader.java
@@ -28,9 +28,12 @@ import io.pixelsdb.pixels.core.vector.DoubleColumnVector;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.util.Arrays;
 
 /**
- * @author guodong
+ * @author guodong, hank
+ * @create 2017-12-06
+ * @update 2023-08-20 Zermatt: support nulls padding
  */
 public class DoubleColumnReader extends ColumnReader
 {
@@ -98,39 +101,81 @@ public class DoubleColumnReader extends ColumnReader
             elementIndex = 0;
             isNullBitIndex = 8;
         }
-        for (int i = 0; i < size; i++)
+        boolean nullsPadding = chunkIndex.hasNullsPadding() && chunkIndex.getNullsPadding();
+        if (nullsPadding)
         {
-            if (elementIndex % pixelStride == 0)
+            // read without copying the de-compacted content and isNull
+            int numLeft = size, numToRead, bytesToDeCompact;
+            for (int i = vectorIndex; numLeft > 0; )
             {
+                if (elementIndex / pixelStride < (elementIndex + numLeft) / pixelStride)
+                {
+                    // read to the end of the current pixel
+                    numToRead = pixelStride - elementIndex % pixelStride;
+                } else
+                {
+                    numToRead = numLeft;
+                }
+                bytesToDeCompact = (numToRead + 7) / 8;
+                // read isNull
                 int pixelId = elementIndex / pixelStride;
                 hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
-                if (hasNull && isNullBitIndex > 0)
+                if (hasNull)
+                {
+                    BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset);
+                    isNullOffset += bytesToDeCompact;
+                    columnVector.noNulls = false;
+                } else
+                {
+                    Arrays.fill(columnVector.isNull, i, i + numToRead, false);
+                }
+                // read content
+                for (int j = i; j < i + numToRead; ++j)
+                {
+                    columnVector.vector[j] = inputBuffer.getLong(inputIndex);
+                    inputIndex += Long.BYTES;
+                }
+                // update variables
+                numLeft -= numToRead;
+                elementIndex += numToRead;
+                i += numToRead;
+            }
+        }
+        else
+        {
+            for (int i = 0; i < size; i++)
+            {
+                if (elementIndex % pixelStride == 0)
+                {
+                    int pixelId = elementIndex / pixelStride;
+                    hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
+                    if (hasNull && isNullBitIndex > 0)
+                    {
+                        BitUtils.bitWiseDeCompact(isNull, inputBuffer, isNullOffset++, 1);
+                        isNullBitIndex = 0;
+                    }
+                }
+                if (hasNull && isNullBitIndex >= 8)
                 {
                     BitUtils.bitWiseDeCompact(isNull, inputBuffer, isNullOffset++, 1);
                     isNullBitIndex = 0;
                 }
+                if (hasNull && isNull[isNullBitIndex] == 1)
+                {
+                    columnVector.isNull[i + vectorIndex] = true;
+                    columnVector.noNulls = false;
+                } else
+                {
+                    // columnVector.vector[i + vectorIndex] = encodingUtils.readLongLE(this.input, inputIndex);
+                    columnVector.vector[i + vectorIndex] = this.inputBuffer.getLong(inputIndex);
+                    inputIndex += Long.BYTES;
+                }
+                if (hasNull)
+                {
+                    isNullBitIndex++;
+                }
+                elementIndex++;
             }
-            if (hasNull && isNullBitIndex >= 8)
-            {
-                BitUtils.bitWiseDeCompact(isNull, inputBuffer, isNullOffset++, 1);
-                isNullBitIndex = 0;
-            }
-            if (hasNull && isNull[isNullBitIndex] == 1)
-            {
-                columnVector.isNull[i + vectorIndex] = true;
-                columnVector.noNulls = false;
-            }
-            else
-            {
-                // columnVector.vector[i + vectorIndex] = encodingUtils.readLongLE(this.input, inputIndex);
-                columnVector.vector[i + vectorIndex] = this.inputBuffer.getLong(inputIndex);
-                inputIndex += Long.BYTES;
-            }
-            if (hasNull)
-            {
-                isNullBitIndex++;
-            }
-            elementIndex++;
         }
     }
 }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/FloatColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/FloatColumnReader.java
@@ -39,10 +39,8 @@ public class FloatColumnReader extends ColumnReader
 {
     // private final EncodingUtils encodingUtils;
     private ByteBuffer inputBuffer;
-    private byte[] isNull = new byte[8];
     private int inputIndex = 0;
     private int isNullOffset = 0;
-    private int isNullBitIndex = 0;
 
     FloatColumnReader(TypeDescription type)
     {
@@ -66,7 +64,6 @@ public class FloatColumnReader extends ColumnReader
     public void close() throws IOException
     {
         this.inputBuffer = null;
-        this.isNull = null;
     }
 
     /**
@@ -96,82 +93,56 @@ public class FloatColumnReader extends ColumnReader
             isNullOffset = inputIndex + chunkIndex.getIsNullOffset();
             hasNull = true;
             elementIndex = 0;
-            isNullBitIndex = 8;
         }
         boolean nullsPadding = chunkIndex.hasNullsPadding() && chunkIndex.getNullsPadding();
-        if (nullsPadding)
+        // read without copying the de-compacted content and isNull
+        int numLeft = size, numToRead, bytesToDeCompact;
+        for (int i = vectorIndex; numLeft > 0; )
         {
-            // read without copying the de-compacted content and isNull
-            int numLeft = size, numToRead, bytesToDeCompact;
-            for (int i = vectorIndex; numLeft > 0; )
+            if (elementIndex / pixelStride < (elementIndex + numLeft) / pixelStride)
             {
-                if (elementIndex / pixelStride < (elementIndex + numLeft) / pixelStride)
-                {
-                    // read to the end of the current pixel
-                    numToRead = pixelStride - elementIndex % pixelStride;
-                } else
-                {
-                    numToRead = numLeft;
-                }
-                bytesToDeCompact = (numToRead + 7) / 8;
-                // read isNull
-                int pixelId = elementIndex / pixelStride;
-                hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
-                if (hasNull)
-                {
-                    BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset);
-                    isNullOffset += bytesToDeCompact;
-                    columnVector.noNulls = false;
-                } else
-                {
-                    Arrays.fill(columnVector.isNull, i, i + numToRead, false);
-                }
-                // read content
+                // read to the end of the current pixel
+                numToRead = pixelStride - elementIndex % pixelStride;
+            } else
+            {
+                numToRead = numLeft;
+            }
+            bytesToDeCompact = (numToRead + 7) / 8;
+            // read isNull
+            int pixelId = elementIndex / pixelStride;
+            hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
+            if (hasNull)
+            {
+                BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset);
+                isNullOffset += bytesToDeCompact;
+                columnVector.noNulls = false;
+            } else
+            {
+                Arrays.fill(columnVector.isNull, i, i + numToRead, false);
+            }
+            // read content
+            if (nullsPadding)
+            {
                 for (int j = i; j < i + numToRead; ++j)
                 {
                     columnVector.vector[j] = inputBuffer.getInt(inputIndex);
                     inputIndex += Integer.BYTES;
                 }
-                // update variables
-                numLeft -= numToRead;
-                elementIndex += numToRead;
-                i += numToRead;
-            }
-        }
-        else
-        {
-            for (int i = 0; i < size; i++)
+            } else
             {
-                if (elementIndex % pixelStride == 0)
+                for (int j = i; j < i + numToRead; ++j)
                 {
-                    int pixelId = elementIndex / pixelStride;
-                    hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
-                    if (hasNull && isNullBitIndex > 0)
+                    if (!(hasNull && columnVector.isNull[j]))
                     {
-                        BitUtils.bitWiseDeCompact(this.isNull, inputBuffer, isNullOffset++, 1);
-                        isNullBitIndex = 0;
+                        columnVector.vector[j] = this.inputBuffer.getInt(inputIndex);
+                        inputIndex += Integer.BYTES;
                     }
                 }
-                if (hasNull && isNullBitIndex >= 8)
-                {
-                    BitUtils.bitWiseDeCompact(this.isNull, inputBuffer, isNullOffset++, 1);
-                    isNullBitIndex = 0;
-                }
-                if (hasNull && isNull[isNullBitIndex] == 1)
-                {
-                    columnVector.isNull[i + vectorIndex] = true;
-                    columnVector.noNulls = false;
-                } else
-                {
-                    columnVector.vector[i + vectorIndex] = this.inputBuffer.getInt(inputIndex);
-                    inputIndex += Integer.BYTES;
-                }
-                if (hasNull)
-                {
-                    isNullBitIndex++;
-                }
-                elementIndex++;
             }
+            // update variables
+            numLeft -= numToRead;
+            elementIndex += numToRead;
+            i += numToRead;
         }
     }
 }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/FloatColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/FloatColumnReader.java
@@ -28,9 +28,12 @@ import io.pixelsdb.pixels.core.vector.DoubleColumnVector;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.util.Arrays;
 
 /**
- * @author guodong
+ * @author guodong, hank
+ * @create 2017-12-06
+ * @update 2023-08-20 Zermatt: support nulls padding
  */
 public class FloatColumnReader extends ColumnReader
 {
@@ -95,38 +98,80 @@ public class FloatColumnReader extends ColumnReader
             elementIndex = 0;
             isNullBitIndex = 8;
         }
-        for (int i = 0; i < size; i++)
+        boolean nullsPadding = chunkIndex.hasNullsPadding() && chunkIndex.getNullsPadding();
+        if (nullsPadding)
         {
-            if (elementIndex % pixelStride == 0)
+            // read without copying the de-compacted content and isNull
+            int numLeft = size, numToRead, bytesToDeCompact;
+            for (int i = vectorIndex; numLeft > 0; )
             {
+                if (elementIndex / pixelStride < (elementIndex + numLeft) / pixelStride)
+                {
+                    // read to the end of the current pixel
+                    numToRead = pixelStride - elementIndex % pixelStride;
+                } else
+                {
+                    numToRead = numLeft;
+                }
+                bytesToDeCompact = (numToRead + 7) / 8;
+                // read isNull
                 int pixelId = elementIndex / pixelStride;
                 hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
-                if (hasNull && isNullBitIndex > 0)
+                if (hasNull)
+                {
+                    BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset);
+                    isNullOffset += bytesToDeCompact;
+                    columnVector.noNulls = false;
+                } else
+                {
+                    Arrays.fill(columnVector.isNull, i, i + numToRead, false);
+                }
+                // read content
+                for (int j = i; j < i + numToRead; ++j)
+                {
+                    columnVector.vector[j] = inputBuffer.getInt(inputIndex);
+                    inputIndex += Integer.BYTES;
+                }
+                // update variables
+                numLeft -= numToRead;
+                elementIndex += numToRead;
+                i += numToRead;
+            }
+        }
+        else
+        {
+            for (int i = 0; i < size; i++)
+            {
+                if (elementIndex % pixelStride == 0)
+                {
+                    int pixelId = elementIndex / pixelStride;
+                    hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
+                    if (hasNull && isNullBitIndex > 0)
+                    {
+                        BitUtils.bitWiseDeCompact(this.isNull, inputBuffer, isNullOffset++, 1);
+                        isNullBitIndex = 0;
+                    }
+                }
+                if (hasNull && isNullBitIndex >= 8)
                 {
                     BitUtils.bitWiseDeCompact(this.isNull, inputBuffer, isNullOffset++, 1);
                     isNullBitIndex = 0;
                 }
+                if (hasNull && isNull[isNullBitIndex] == 1)
+                {
+                    columnVector.isNull[i + vectorIndex] = true;
+                    columnVector.noNulls = false;
+                } else
+                {
+                    columnVector.vector[i + vectorIndex] = this.inputBuffer.getInt(inputIndex);
+                    inputIndex += Integer.BYTES;
+                }
+                if (hasNull)
+                {
+                    isNullBitIndex++;
+                }
+                elementIndex++;
             }
-            if (hasNull && isNullBitIndex >= 8)
-            {
-                BitUtils.bitWiseDeCompact(this.isNull, inputBuffer, isNullOffset++, 1);
-                isNullBitIndex = 0;
-            }
-            if (hasNull && isNull[isNullBitIndex] == 1)
-            {
-                columnVector.isNull[i + vectorIndex] = true;
-                columnVector.noNulls = false;
-            }
-            else
-            {
-                columnVector.vector[i + vectorIndex] = this.inputBuffer.getInt(inputIndex);
-                inputIndex += 4;
-            }
-            if (hasNull)
-            {
-                isNullBitIndex++;
-            }
-            elementIndex++;
         }
     }
 }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/FloatColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/FloatColumnReader.java
@@ -90,7 +90,7 @@ public class FloatColumnReader extends ColumnReader
             boolean littleEndian = chunkIndex.hasLittleEndian() && chunkIndex.getLittleEndian();
             this.inputBuffer.order(littleEndian ? ByteOrder.LITTLE_ENDIAN : ByteOrder.BIG_ENDIAN);
             inputIndex = inputBuffer.position();
-            isNullOffset = inputIndex + (int) chunkIndex.getIsNullOffset();
+            isNullOffset = inputIndex + chunkIndex.getIsNullOffset();
             hasNull = true;
             elementIndex = 0;
             isNullBitIndex = 8;

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/FloatColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/FloatColumnReader.java
@@ -23,7 +23,7 @@ import io.pixelsdb.pixels.core.PixelsProto;
 import io.pixelsdb.pixels.core.TypeDescription;
 import io.pixelsdb.pixels.core.utils.BitUtils;
 import io.pixelsdb.pixels.core.vector.ColumnVector;
-import io.pixelsdb.pixels.core.vector.DoubleColumnVector;
+import io.pixelsdb.pixels.core.vector.FloatColumnVector;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -86,7 +86,7 @@ public class FloatColumnReader extends ColumnReader
                      int offset, int size, int pixelStride, final int vectorIndex,
                      ColumnVector vector, PixelsProto.ColumnChunkIndex chunkIndex)
     {
-        DoubleColumnVector columnVector = (DoubleColumnVector) vector;
+        FloatColumnVector columnVector = (FloatColumnVector) vector;
         if (offset == 0)
         {
             this.inputBuffer = input;

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/IntegerColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/IntegerColumnReader.java
@@ -44,8 +44,6 @@ public class IntegerColumnReader extends ColumnReader
     private ByteBuffer inputBuffer;
     private InputStream inputStream;
     private int isNullOffset = 0;
-    private int isNullBitIndex = 0;
-    private byte[] isNull = new byte[8];
 
     /**
      * True if the data type of the values is long (int64), otherwise the data type is int32.
@@ -80,7 +78,6 @@ public class IntegerColumnReader extends ColumnReader
             this.decoder = null;
         }
         this.inputBuffer = null;
-        this.isNull = null;
     }
 
     /**
@@ -118,7 +115,6 @@ public class IntegerColumnReader extends ColumnReader
             // re-init
             hasNull = true;
             elementIndex = 0;
-            isNullBitIndex = 8;
             if (encoding.getKind().equals(PixelsProto.ColumnEncoding.Kind.NONE))
             {
                 isLong = type.getCategory() == TypeDescription.Category.LONG;

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/IntegerColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/IntegerColumnReader.java
@@ -111,7 +111,7 @@ public class IntegerColumnReader extends ColumnReader
             inputStream = new ByteBufferInputStream(inputBuffer, inputBuffer.position(), inputBuffer.limit());
             decoder = new RunLenIntDecoder(inputStream, true);
             // isNull
-            isNullOffset = inputBuffer.position() + (int) chunkIndex.getIsNullOffset();
+            isNullOffset = inputBuffer.position() + chunkIndex.getIsNullOffset();
             // re-init
             hasNull = true;
             elementIndex = 0;

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/LongDecimalColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/LongDecimalColumnReader.java
@@ -28,12 +28,14 @@ import io.pixelsdb.pixels.core.vector.LongDecimalColumnVector;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.util.Arrays;
 
 /**
  * The column reader of long decimals with max precision and scale 38.
  *
- * @date 2022-07-03
  * @author hank
+ * @create 2022-07-03
+ * @update 2023-08-20 Zermatt: support nulls padding
  */
 public class LongDecimalColumnReader extends ColumnReader
 {
@@ -106,41 +108,85 @@ public class LongDecimalColumnReader extends ColumnReader
             elementIndex = 0;
             isNullBitIndex = 8;
         }
-        for (int i = 0; i < size; i++)
+        boolean nullsPadding = chunkIndex.hasNullsPadding() && chunkIndex.getNullsPadding();
+        if (nullsPadding)
         {
-            if (elementIndex % pixelStride == 0)
+            // read without copying the de-compacted content and isNull
+            int numLeft = size, numToRead, bytesToDeCompact;
+            for (int i = vectorIndex; numLeft > 0; )
             {
+                if (elementIndex / pixelStride < (elementIndex + numLeft) / pixelStride)
+                {
+                    // read to the end of the current pixel
+                    numToRead = pixelStride - elementIndex % pixelStride;
+                } else
+                {
+                    numToRead = numLeft;
+                }
+                bytesToDeCompact = (numToRead + 7) / 8;
+                // read isNull
                 int pixelId = elementIndex / pixelStride;
                 hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
-                if (hasNull && isNullBitIndex > 0)
+                if (hasNull)
+                {
+                    BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset);
+                    isNullOffset += bytesToDeCompact;
+                    columnVector.noNulls = false;
+                } else
+                {
+                    Arrays.fill(columnVector.isNull, i, i + numToRead, false);
+                }
+                // read content
+                for (int j = i; j < i + numToRead; ++j)
+                {
+                    columnVector.vector[j << 1] = inputBuffer.getLong(inputIndex);
+                    inputIndex += Long.BYTES;
+                    columnVector.vector[(j << 1) + 1] = inputBuffer.getLong(inputIndex);
+                    inputIndex += Long.BYTES;
+                }
+                // update variables
+                numLeft -= numToRead;
+                elementIndex += numToRead;
+                i += numToRead;
+            }
+        }
+        else
+        {
+            for (int i = 0; i < size; i++)
+            {
+                if (elementIndex % pixelStride == 0)
+                {
+                    int pixelId = elementIndex / pixelStride;
+                    hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
+                    if (hasNull && isNullBitIndex > 0)
+                    {
+                        BitUtils.bitWiseDeCompact(isNull, inputBuffer, isNullOffset++, 1);
+                        isNullBitIndex = 0;
+                    }
+                }
+                if (hasNull && isNullBitIndex >= 8)
                 {
                     BitUtils.bitWiseDeCompact(isNull, inputBuffer, isNullOffset++, 1);
                     isNullBitIndex = 0;
                 }
+                if (hasNull && isNull[isNullBitIndex] == 1)
+                {
+                    columnVector.isNull[i + vectorIndex] = true;
+                    columnVector.noNulls = false;
+                } else
+                {
+                    int index = (i + vectorIndex) << 1;
+                    columnVector.vector[index] = this.inputBuffer.getLong(inputIndex);
+                    inputIndex += Long.BYTES;
+                    columnVector.vector[index + 1] = this.inputBuffer.getLong(inputIndex);
+                    inputIndex += Long.BYTES;
+                }
+                if (hasNull)
+                {
+                    isNullBitIndex++;
+                }
+                elementIndex++;
             }
-            if (hasNull && isNullBitIndex >= 8)
-            {
-                BitUtils.bitWiseDeCompact(isNull, inputBuffer, isNullOffset++, 1);
-                isNullBitIndex = 0;
-            }
-            if (hasNull && isNull[isNullBitIndex] == 1)
-            {
-                columnVector.isNull[i + vectorIndex] = true;
-                columnVector.noNulls = false;
-            }
-            else
-            {
-                int index = (i+vectorIndex)*2;
-                columnVector.vector[index] = this.inputBuffer.getLong(inputIndex);
-                inputIndex += Long.BYTES;
-                columnVector.vector[index+1] = this.inputBuffer.getLong(inputIndex);
-                inputIndex += Long.BYTES;
-            }
-            if (hasNull)
-            {
-                isNullBitIndex++;
-            }
-            elementIndex++;
         }
     }
 }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/LongDecimalColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/LongDecimalColumnReader.java
@@ -100,7 +100,7 @@ public class LongDecimalColumnReader extends ColumnReader
             this.inputBuffer.order(littleEndian ? ByteOrder.LITTLE_ENDIAN : ByteOrder.BIG_ENDIAN);
             inputIndex = inputBuffer.position();
             // isNull
-            isNullOffset = inputIndex + (int) chunkIndex.getIsNullOffset();
+            isNullOffset = inputIndex + chunkIndex.getIsNullOffset();
             // re-init
             hasNull = true;
             elementIndex = 0;

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/LongDecimalColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/LongDecimalColumnReader.java
@@ -41,9 +41,7 @@ public class LongDecimalColumnReader extends ColumnReader
 {
     // private final EncodingUtils encodingUtils;
     private ByteBuffer inputBuffer;
-    private byte[] isNull = new byte[8];
     private int isNullOffset = 0;
-    private int isNullBitIndex = 0;
     private int inputIndex = 0;
 
     LongDecimalColumnReader(TypeDescription type)
@@ -68,7 +66,6 @@ public class LongDecimalColumnReader extends ColumnReader
     public void close() throws IOException
     {
         this.inputBuffer = null;
-        this.isNull = null;
     }
 
     /**
@@ -106,37 +103,36 @@ public class LongDecimalColumnReader extends ColumnReader
             // re-init
             hasNull = true;
             elementIndex = 0;
-            isNullBitIndex = 8;
         }
         boolean nullsPadding = chunkIndex.hasNullsPadding() && chunkIndex.getNullsPadding();
-        if (nullsPadding)
+        // read without copying the de-compacted content and isNull
+        int numLeft = size, numToRead, bytesToDeCompact;
+        for (int i = vectorIndex; numLeft > 0; )
         {
-            // read without copying the de-compacted content and isNull
-            int numLeft = size, numToRead, bytesToDeCompact;
-            for (int i = vectorIndex; numLeft > 0; )
+            if (elementIndex / pixelStride < (elementIndex + numLeft) / pixelStride)
             {
-                if (elementIndex / pixelStride < (elementIndex + numLeft) / pixelStride)
-                {
-                    // read to the end of the current pixel
-                    numToRead = pixelStride - elementIndex % pixelStride;
-                } else
-                {
-                    numToRead = numLeft;
-                }
-                bytesToDeCompact = (numToRead + 7) / 8;
-                // read isNull
-                int pixelId = elementIndex / pixelStride;
-                hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
-                if (hasNull)
-                {
-                    BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset);
-                    isNullOffset += bytesToDeCompact;
-                    columnVector.noNulls = false;
-                } else
-                {
-                    Arrays.fill(columnVector.isNull, i, i + numToRead, false);
-                }
-                // read content
+                // read to the end of the current pixel
+                numToRead = pixelStride - elementIndex % pixelStride;
+            } else
+            {
+                numToRead = numLeft;
+            }
+            bytesToDeCompact = (numToRead + 7) / 8;
+            // read isNull
+            int pixelId = elementIndex / pixelStride;
+            hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
+            if (hasNull)
+            {
+                BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset);
+                isNullOffset += bytesToDeCompact;
+                columnVector.noNulls = false;
+            } else
+            {
+                Arrays.fill(columnVector.isNull, i, i + numToRead, false);
+            }
+            // read content
+            if (nullsPadding)
+            {
                 for (int j = i; j < i + numToRead; ++j)
                 {
                     columnVector.vector[j << 1] = inputBuffer.getLong(inputIndex);
@@ -144,49 +140,24 @@ public class LongDecimalColumnReader extends ColumnReader
                     columnVector.vector[(j << 1) + 1] = inputBuffer.getLong(inputIndex);
                     inputIndex += Long.BYTES;
                 }
-                // update variables
-                numLeft -= numToRead;
-                elementIndex += numToRead;
-                i += numToRead;
-            }
-        }
-        else
-        {
-            for (int i = 0; i < size; i++)
+            } else
             {
-                if (elementIndex % pixelStride == 0)
+                for (int j = i; j < i + numToRead; ++j)
                 {
-                    int pixelId = elementIndex / pixelStride;
-                    hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
-                    if (hasNull && isNullBitIndex > 0)
+                    if (!(hasNull && columnVector.isNull[j]))
                     {
-                        BitUtils.bitWiseDeCompact(isNull, inputBuffer, isNullOffset++, 1);
-                        isNullBitIndex = 0;
+                        int index = j << 1;
+                        columnVector.vector[index] = this.inputBuffer.getLong(inputIndex);
+                        inputIndex += Long.BYTES;
+                        columnVector.vector[index + 1] = this.inputBuffer.getLong(inputIndex);
+                        inputIndex += Long.BYTES;
                     }
                 }
-                if (hasNull && isNullBitIndex >= 8)
-                {
-                    BitUtils.bitWiseDeCompact(isNull, inputBuffer, isNullOffset++, 1);
-                    isNullBitIndex = 0;
-                }
-                if (hasNull && isNull[isNullBitIndex] == 1)
-                {
-                    columnVector.isNull[i + vectorIndex] = true;
-                    columnVector.noNulls = false;
-                } else
-                {
-                    int index = (i + vectorIndex) << 1;
-                    columnVector.vector[index] = this.inputBuffer.getLong(inputIndex);
-                    inputIndex += Long.BYTES;
-                    columnVector.vector[index + 1] = this.inputBuffer.getLong(inputIndex);
-                    inputIndex += Long.BYTES;
-                }
-                if (hasNull)
-                {
-                    isNullBitIndex++;
-                }
-                elementIndex++;
             }
+            // update variables
+            numLeft -= numToRead;
+            elementIndex += numToRead;
+            i += numToRead;
         }
     }
 }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/PixelsReaderOption.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/PixelsReaderOption.java
@@ -37,13 +37,12 @@ public class PixelsReaderOption
     private int rgStart = 0;
     private int rgLen = -1;     // -1 means reading to the end of the file
 
-    public PixelsReaderOption()
-    {
-    }
+    public PixelsReaderOption() { }
 
-    public void includeCols(String[] columnNames)
+    public PixelsReaderOption includeCols(String[] columnNames)
     {
         this.includedCols = columnNames;
+        return this;
     }
 
     public String[] getIncludedCols()
@@ -51,9 +50,10 @@ public class PixelsReaderOption
         return includedCols;
     }
 
-    public void predicate(PixelsPredicate predicate)
+    public PixelsReaderOption predicate(PixelsPredicate predicate)
     {
         this.predicate = predicate;
+        return this;
     }
 
     public Optional<PixelsPredicate> getPredicate()
@@ -65,9 +65,10 @@ public class PixelsReaderOption
         return Optional.of(predicate);
     }
 
-    public void skipCorruptRecords(boolean skipCorruptRecords)
+    public PixelsReaderOption skipCorruptRecords(boolean skipCorruptRecords)
     {
         this.skipCorruptRecords = skipCorruptRecords;
+        return this;
     }
 
     public boolean isSkipCorruptRecords()
@@ -75,9 +76,10 @@ public class PixelsReaderOption
         return skipCorruptRecords;
     }
 
-    public void transId(long transId)
+    public PixelsReaderOption transId(long transId)
     {
         this.transId = transId;
+        return this;
     }
 
     public long getTransId()
@@ -85,10 +87,11 @@ public class PixelsReaderOption
         return this.transId;
     }
 
-    public void rgRange(int rgStart, int rgLen)
+    public PixelsReaderOption rgRange(int rgStart, int rgLen)
     {
         this.rgStart = rgStart;
         this.rgLen = rgLen;
+        return this;
     }
 
     public int getRGStart()
@@ -101,9 +104,10 @@ public class PixelsReaderOption
         return this.rgLen;
     }
 
-    public void tolerantSchemaEvolution(boolean tolerantSchemaEvolution)
+    public PixelsReaderOption tolerantSchemaEvolution(boolean tolerantSchemaEvolution)
     {
         this.tolerantSchemaEvolution = tolerantSchemaEvolution;
+        return this;
     }
 
     public boolean isTolerantSchemaEvolution()
@@ -111,9 +115,10 @@ public class PixelsReaderOption
         return tolerantSchemaEvolution;
     }
 
-    public void enableEncodedColumnVector(boolean enableEncodedColumnVector)
+    public PixelsReaderOption enableEncodedColumnVector(boolean enableEncodedColumnVector)
     {
         this.enableEncodedColumnVector = enableEncodedColumnVector;
+        return this;
     }
 
     public boolean isEnableEncodedColumnVector()

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/PixelsRecordReaderImpl.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/PixelsRecordReaderImpl.java
@@ -722,7 +722,7 @@ public class PixelsRecordReaderImpl implements PixelsRecordReader
                  * readCost.setMs(readTimeMs);
                  * readPerfMetrics.addSeqRead(readCost);
                  */
-                actionFutures.add(requestBatch.add(transId, chunk.offset, (int)chunk.length)
+                actionFutures.add(requestBatch.add(transId, chunk.offset, chunk.length)
                         .thenAccept(resp ->
                 {
                     if (resp != null)
@@ -1204,9 +1204,9 @@ public class PixelsRecordReaderImpl implements PixelsRecordReader
         public final int rowGroupId;
         public final int columnId;
         public final long offset;
-        public final long length;
+        public final int length;
 
-        public ChunkId(int rowGroupId, int columnId, long offset, long length)
+        public ChunkId(int rowGroupId, int columnId, long offset, int length)
         {
             this.rowGroupId = rowGroupId;
             this.columnId = columnId;

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/StringColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/StringColumnReader.java
@@ -244,7 +244,7 @@ public class StringColumnReader extends ColumnReader
                     columnVector.dictOffsets = dictStarts;
                 }
                 checkArgument(columnVector.dictArray == dictContentBuf.array(),
-                        "dictionaries from the column vector and the origins buffer are not consistent");
+                        "dictionaries in the column vector and the input buffer are inconsistent");
 
                 for (int i = 0; i < size; i++)
                 {
@@ -315,8 +315,6 @@ public class StringColumnReader extends ColumnReader
                 }
                 if (hasNull && isNull[isNullBitIndex] == 1)
                 {
-                    // skip the repeated starts for null values
-                    startsBuf.skipBytes(Integer.BYTES);
                     columnVector.isNull[i + vectorIndex] = true;
                     columnVector.noNulls = false;
                     if (nullsPadding)

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/StringColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/StringColumnReader.java
@@ -168,7 +168,7 @@ public class StringColumnReader extends ColumnReader
             ByteOrder byteOrder = littleEndian ? ByteOrder.LITTLE_ENDIAN : ByteOrder.BIG_ENDIAN;
             inputBuffer = Unpooled.wrappedBuffer(input).order(byteOrder);
             readContent(input.remaining(), encoding, byteOrder);
-            isNullOffset = (int) chunkIndex.getIsNullOffset();
+            isNullOffset = chunkIndex.getIsNullOffset();
             bufferOffset = 0;
             hasNull = true;
             elementIndex = 0;

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/StringColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/StringColumnReader.java
@@ -39,8 +39,9 @@ import java.nio.ByteOrder;
 import static com.google.common.base.Preconditions.checkArgument;
 
 /**
- * @author guodong
- * @author hank
+ * @author guodong, hank
+ * @create 2018-01-22
+ * @update 2023-08-21 support nulls padding
  */
 public class StringColumnReader extends ColumnReader
 {
@@ -174,6 +175,7 @@ public class StringColumnReader extends ColumnReader
             elementIndex = 0;
             isNullBitIndex = 8;
         }
+        boolean nullsPadding = chunkIndex.hasNullsPadding() && chunkIndex.getNullsPadding();
         // if dictionary encoded
         if (encoding.getKind().equals(PixelsProto.ColumnEncoding.Kind.DICTIONARY))
         {
@@ -182,6 +184,10 @@ public class StringColumnReader extends ColumnReader
                     .equals(PixelsProto.ColumnEncoding.Kind.RUNLENGTH))
             {
                 cascadeRLE = true;
+            }
+            if (nullsPadding && cascadeRLE)
+            {
+                throw new IllegalArgumentException("nulls padding is invalid when run-length encoding is cascaded");
             }
             if (vector instanceof BinaryColumnVector)
             {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/TimeColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/TimeColumnReader.java
@@ -68,6 +68,7 @@ public class TimeColumnReader extends ColumnReader
     @Override
     public void close() throws IOException
     {
+        isNull = null;
     }
 
     /**
@@ -100,7 +101,7 @@ public class TimeColumnReader extends ColumnReader
             this.inputBuffer.order(littleEndian ? ByteOrder.LITTLE_ENDIAN : ByteOrder.BIG_ENDIAN);
             inputStream = new ByteBufferInputStream(inputBuffer, inputBuffer.position(), inputBuffer.limit());
             decoder = new RunLenIntDecoder(inputStream, true);
-            isNullOffset = inputBuffer.position() + (int) chunkIndex.getIsNullOffset();
+            isNullOffset = inputBuffer.position() + chunkIndex.getIsNullOffset();
             hasNull = true;
             elementIndex = 0;
             isNullBitIndex = 8;

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/TimeColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/TimeColumnReader.java
@@ -33,8 +33,6 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.Arrays;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 /**
  * Pixels time column reader.
  * All time values are translated to the specified time zone after read from file.
@@ -115,7 +113,6 @@ public class TimeColumnReader extends ColumnReader
 
         if (encoding.getKind().equals(PixelsProto.ColumnEncoding.Kind.RUNLENGTH))
         {
-            checkArgument(!nullsPadding, "nullsPadding should not be enabled for encoded column chunk");
             for (int i = 0; i < size; i++)
             {
                 if (elementIndex % pixelStride == 0)

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/TimeColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/TimeColumnReader.java
@@ -111,119 +111,69 @@ public class TimeColumnReader extends ColumnReader
             isNullBitIndex = 8;
         }
 
-        if (encoding.getKind().equals(PixelsProto.ColumnEncoding.Kind.RUNLENGTH))
+        boolean decoding = encoding.getKind().equals(PixelsProto.ColumnEncoding.Kind.RUNLENGTH);
+        // read without copying the de-compacted content and isNull
+        int numLeft = size, numToRead, bytesToDeCompact;
+        for (int i = vectorIndex; numLeft > 0;)
         {
-            for (int i = 0; i < size; i++)
+            if (elementIndex / pixelStride < (elementIndex + numLeft) / pixelStride)
             {
-                if (elementIndex % pixelStride == 0)
-                {
-                    int pixelId = elementIndex / pixelStride;
-                    hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
-                    if (hasNull && isNullBitIndex > 0)
-                    {
-                        BitUtils.bitWiseDeCompact(isNull, inputBuffer, isNullOffset++, 1);
-                        isNullBitIndex = 0;
-                    }
-                }
-                if (hasNull && isNullBitIndex >= 8)
-                {
-                    BitUtils.bitWiseDeCompact(isNull, inputBuffer, isNullOffset++, 1);
-                    isNullBitIndex = 0;
-                }
-                if (hasNull && isNull[isNullBitIndex] == 1)
-                {
-                    columnVector.isNull[i + vectorIndex] = true;
-                    columnVector.noNulls = false;
-                }
-                else
-                {
-                    columnVector.set(i + vectorIndex, (int)decoder.next());
-                }
-                if (hasNull)
-                {
-                    isNullBitIndex++;
-                }
-                elementIndex++;
+                // read to the end of the current pixel
+                numToRead = pixelStride - elementIndex % pixelStride;
             }
-        }
-        else
-        {
-            if (nullsPadding)
+            else
             {
-                // read without copying the de-compacted content and isNull
-                int numLeft = size, numToRead, bytesToDeCompact;
-                for (int i = vectorIndex; numLeft > 0;)
+                numToRead = numLeft;
+            }
+            bytesToDeCompact = (numToRead + 7) / 8;
+            // read isNull
+            int pixelId = elementIndex / pixelStride;
+            hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
+            if (hasNull)
+            {
+                BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset);
+                isNullOffset += bytesToDeCompact;
+                columnVector.noNulls = false;
+            }
+            else
+            {
+                Arrays.fill(columnVector.isNull, i, i + numToRead, false);
+            }
+            // read content
+            if (decoding)
+            {
+                for (int j = i; j < i + numToRead; ++j)
                 {
-                    if (elementIndex / pixelStride < (elementIndex + numLeft) / pixelStride)
+                    if (!(hasNull && columnVector.isNull[j]))
                     {
-                        // read to the end of the current pixel
-                        numToRead = pixelStride - elementIndex % pixelStride;
+                        columnVector.set(j, (int) decoder.next());
                     }
-                    else
-                    {
-                        numToRead = numLeft;
-                    }
-                    bytesToDeCompact = (numToRead + 7) / 8;
-                    // read isNull
-                    int pixelId = elementIndex / pixelStride;
-                    hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
-                    if (hasNull)
-                    {
-                        BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset);
-                        isNullOffset += bytesToDeCompact;
-                        columnVector.noNulls = false;
-                    }
-                    else
-                    {
-                        Arrays.fill(columnVector.isNull, i, i + numToRead, false);
-                    }
-                    // read content
-                    for (int j = i; j < i + numToRead; ++j)
-                    {
-                        columnVector.set(j, inputBuffer.getInt());
-                    }
-                    // update variables
-                    numLeft -= numToRead;
-                    elementIndex += numToRead;
-                    i += numToRead;
                 }
             }
             else
             {
-                for (int i = 0; i < size; i++)
+                if (nullsPadding)
                 {
-                    if (elementIndex % pixelStride == 0)
+                    for (int j = i; j < i + numToRead; ++j)
                     {
-                        int pixelId = elementIndex / pixelStride;
-                        hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
-                        if (hasNull && isNullBitIndex > 0)
+                        columnVector.set(j, inputBuffer.getInt());
+                    }
+                } else
+                {
+                    for (int j = i; j < i + numToRead; ++j)
+                    {
+                        if (!(hasNull && columnVector.isNull[j]))
                         {
-                            BitUtils.bitWiseDeCompact(isNull, inputBuffer, isNullOffset++, 1);
-                            isNullBitIndex = 0;
+                            // If time column is not encoded, it is written as integers instead of longs.
+                            columnVector.set(j, inputBuffer.getInt());
                         }
                     }
-                    if (hasNull && isNullBitIndex >= 8)
-                    {
-                        BitUtils.bitWiseDeCompact(isNull, inputBuffer, isNullOffset++, 1);
-                        isNullBitIndex = 0;
-                    }
-                    if (hasNull && isNull[isNullBitIndex] == 1)
-                    {
-                        columnVector.isNull[i + vectorIndex] = true;
-                        columnVector.noNulls = false;
-                    }
-                    else
-                    {
-                        // If time column is not encoded, it is written as integers instead of longs.
-                        columnVector.set(i + vectorIndex, inputBuffer.getInt());
-                    }
-                    if (hasNull)
-                    {
-                        isNullBitIndex++;
-                    }
-                    elementIndex++;
                 }
             }
+            // update variables
+            numLeft -= numToRead;
+            elementIndex += numToRead;
+            i += numToRead;
         }
     }
 }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/TimeColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/TimeColumnReader.java
@@ -47,8 +47,6 @@ public class TimeColumnReader extends ColumnReader
     private InputStream inputStream = null;
     private RunLenIntDecoder decoder = null;
     private int isNullOffset = 0;
-    private int isNullBitIndex = 0;
-    private byte[] isNull = new byte[8];
 
     TimeColumnReader(TypeDescription type)
     {
@@ -71,7 +69,10 @@ public class TimeColumnReader extends ColumnReader
     @Override
     public void close() throws IOException
     {
-        isNull = null;
+        if (inputStream != null)
+        {
+            inputStream.close();
+        }
     }
 
     /**
@@ -108,7 +109,6 @@ public class TimeColumnReader extends ColumnReader
             isNullOffset = inputBuffer.position() + chunkIndex.getIsNullOffset();
             hasNull = true;
             elementIndex = 0;
-            isNullBitIndex = 8;
         }
 
         boolean decoding = encoding.getKind().equals(PixelsProto.ColumnEncoding.Kind.RUNLENGTH);

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/TimeColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/TimeColumnReader.java
@@ -31,12 +31,17 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.util.Arrays;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 /**
- * pixels time column reader
+ * Pixels time column reader.
  * All time values are translated to the specified time zone after read from file.
  *
  * @author hank
+ * @create 2021-04-28
+ * @update 2023-08-20 Zermatt: support nulls padding
  */
 public class TimeColumnReader extends ColumnReader
 {
@@ -90,6 +95,7 @@ public class TimeColumnReader extends ColumnReader
                      ColumnVector vector, PixelsProto.ColumnChunkIndex chunkIndex) throws IOException
     {
         TimeColumnVector columnVector = (TimeColumnVector) vector;
+        boolean nullsPadding = chunkIndex.hasNullsPadding() && chunkIndex.getNullsPadding();
         if (offset == 0)
         {
             if (inputStream != null)
@@ -109,6 +115,7 @@ public class TimeColumnReader extends ColumnReader
 
         if (encoding.getKind().equals(PixelsProto.ColumnEncoding.Kind.RUNLENGTH))
         {
+            checkArgument(!nullsPadding, "nullsPadding should not be enabled for encoded column chunk");
             for (int i = 0; i < size; i++)
             {
                 if (elementIndex % pixelStride == 0)
@@ -144,38 +151,81 @@ public class TimeColumnReader extends ColumnReader
         }
         else
         {
-            for (int i = 0; i < size; i++)
+            if (nullsPadding)
             {
-                if (elementIndex % pixelStride == 0)
+                // read without copying the de-compacted content and isNull
+                int numLeft = size, numToRead, bytesToDeCompact;
+                for (int i = vectorIndex; numLeft > 0;)
                 {
+                    if (elementIndex / pixelStride < (elementIndex + numLeft) / pixelStride)
+                    {
+                        // read to the end of the current pixel
+                        numToRead = pixelStride - elementIndex % pixelStride;
+                    }
+                    else
+                    {
+                        numToRead = numLeft;
+                    }
+                    bytesToDeCompact = (numToRead + 7) / 8;
+                    // read isNull
                     int pixelId = elementIndex / pixelStride;
                     hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
-                    if (hasNull && isNullBitIndex > 0)
+                    if (hasNull)
+                    {
+                        BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset);
+                        isNullOffset += bytesToDeCompact;
+                        columnVector.noNulls = false;
+                    }
+                    else
+                    {
+                        Arrays.fill(columnVector.isNull, i, i + numToRead, false);
+                    }
+                    // read content
+                    for (int j = i; j < i + numToRead; ++j)
+                    {
+                        columnVector.set(j, inputBuffer.getInt());
+                    }
+                    // update variables
+                    numLeft -= numToRead;
+                    elementIndex += numToRead;
+                    i += numToRead;
+                }
+            }
+            else
+            {
+                for (int i = 0; i < size; i++)
+                {
+                    if (elementIndex % pixelStride == 0)
+                    {
+                        int pixelId = elementIndex / pixelStride;
+                        hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
+                        if (hasNull && isNullBitIndex > 0)
+                        {
+                            BitUtils.bitWiseDeCompact(isNull, inputBuffer, isNullOffset++, 1);
+                            isNullBitIndex = 0;
+                        }
+                    }
+                    if (hasNull && isNullBitIndex >= 8)
                     {
                         BitUtils.bitWiseDeCompact(isNull, inputBuffer, isNullOffset++, 1);
                         isNullBitIndex = 0;
                     }
+                    if (hasNull && isNull[isNullBitIndex] == 1)
+                    {
+                        columnVector.isNull[i + vectorIndex] = true;
+                        columnVector.noNulls = false;
+                    }
+                    else
+                    {
+                        // If time column is not encoded, it is written as integers instead of longs.
+                        columnVector.set(i + vectorIndex, inputBuffer.getInt());
+                    }
+                    if (hasNull)
+                    {
+                        isNullBitIndex++;
+                    }
+                    elementIndex++;
                 }
-                if (hasNull && isNullBitIndex >= 8)
-                {
-                    BitUtils.bitWiseDeCompact(isNull, inputBuffer, isNullOffset++, 1);
-                    isNullBitIndex = 0;
-                }
-                if (hasNull && isNull[isNullBitIndex] == 1)
-                {
-                    columnVector.isNull[i + vectorIndex] = true;
-                    columnVector.noNulls = false;
-                }
-                else
-                {
-                    // If time column is not encoded, it is written as integers instead of longs.
-                    columnVector.set(i + vectorIndex, inputBuffer.getInt());
-                }
-                if (hasNull)
-                {
-                    isNullBitIndex++;
-                }
-                elementIndex++;
             }
         }
     }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/TimestampColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/TimestampColumnReader.java
@@ -69,6 +69,7 @@ public class TimestampColumnReader extends ColumnReader
     @Override
     public void close() throws IOException
     {
+        isNull = null;
     }
 
     /**
@@ -101,7 +102,7 @@ public class TimestampColumnReader extends ColumnReader
             this.inputBuffer.order(littleEndian ? ByteOrder.LITTLE_ENDIAN : ByteOrder.BIG_ENDIAN);
             inputStream = new ByteBufferInputStream(inputBuffer, inputBuffer.position(), inputBuffer.limit());
             decoder = new RunLenIntDecoder(inputStream, true);
-            isNullOffset = inputBuffer.position() + (int) chunkIndex.getIsNullOffset();
+            isNullOffset = inputBuffer.position() + chunkIndex.getIsNullOffset();
             hasNull = true;
             elementIndex = 0;
             isNullBitIndex = 8;

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/TimestampColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/TimestampColumnReader.java
@@ -111,117 +111,68 @@ public class TimestampColumnReader extends ColumnReader
             isNullBitIndex = 8;
         }
 
-        if (encoding.getKind().equals(PixelsProto.ColumnEncoding.Kind.RUNLENGTH))
+        boolean decoding = encoding.getKind().equals(PixelsProto.ColumnEncoding.Kind.RUNLENGTH);
+        // read without copying the de-compacted content and isNull
+        int numLeft = size, numToRead, bytesToDeCompact;
+        for (int i = vectorIndex; numLeft > 0;)
         {
-            for (int i = 0; i < size; i++)
+            if (elementIndex / pixelStride < (elementIndex + numLeft) / pixelStride)
             {
-                if (elementIndex % pixelStride == 0)
-                {
-                    int pixelId = elementIndex / pixelStride;
-                    hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
-                    if (hasNull && isNullBitIndex > 0)
-                    {
-                        BitUtils.bitWiseDeCompact(isNull, inputBuffer, isNullOffset++, 1);
-                        isNullBitIndex = 0;
-                    }
-                }
-                if (hasNull && isNullBitIndex >= 8)
-                {
-                    BitUtils.bitWiseDeCompact(isNull, inputBuffer, isNullOffset++, 1);
-                    isNullBitIndex = 0;
-                }
-                if (hasNull && isNull[isNullBitIndex] == 1)
-                {
-                    columnVector.isNull[i + vectorIndex] = true;
-                    columnVector.noNulls = false;
-                }
-                else
-                {
-                    columnVector.set(i + vectorIndex, decoder.next());
-                }
-                if (hasNull)
-                {
-                    isNullBitIndex++;
-                }
-                elementIndex++;
+                // read to the end of the current pixel
+                numToRead = pixelStride - elementIndex % pixelStride;
             }
-        }
-        else
-        {
-            if (nullsPadding)
+            else
             {
-                // read without copying the de-compacted content and isNull
-                int numLeft = size, numToRead, bytesToDeCompact;
-                for (int i = vectorIndex; numLeft > 0;)
+                numToRead = numLeft;
+            }
+            bytesToDeCompact = (numToRead + 7) / 8;
+            // read isNull
+            int pixelId = elementIndex / pixelStride;
+            hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
+            if (hasNull)
+            {
+                BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset);
+                isNullOffset += bytesToDeCompact;
+                columnVector.noNulls = false;
+            }
+            else
+            {
+                Arrays.fill(columnVector.isNull, i, i + numToRead, false);
+            }
+            // read content
+            if (decoding)
+            {
+                for (int j = i; j < i + numToRead; ++j)
                 {
-                    if (elementIndex / pixelStride < (elementIndex + numLeft) / pixelStride)
+                    if (!(hasNull && columnVector.isNull[j]))
                     {
-                        // read to the end of the current pixel
-                        numToRead = pixelStride - elementIndex % pixelStride;
+                        columnVector.set(j, decoder.next());
                     }
-                    else
-                    {
-                        numToRead = numLeft;
-                    }
-                    bytesToDeCompact = (numToRead + 7) / 8;
-                    // read isNull
-                    int pixelId = elementIndex / pixelStride;
-                    hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
-                    if (hasNull)
-                    {
-                        BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset);
-                        isNullOffset += bytesToDeCompact;
-                        columnVector.noNulls = false;
-                    }
-                    else
-                    {
-                        Arrays.fill(columnVector.isNull, i, i + numToRead, false);
-                    }
-                    // read content
-                    for (int j = i; j < i + numToRead; ++j)
-                    {
-                        columnVector.set(j, inputBuffer.getLong());
-                    }
-                    // update variables
-                    numLeft -= numToRead;
-                    elementIndex += numToRead;
-                    i += numToRead;
                 }
             }
             else
             {
-                for (int i = 0; i < size; i++)
+                if (nullsPadding)
                 {
-                    if (elementIndex % pixelStride == 0)
+                    for (int j = i; j < i + numToRead; ++j)
                     {
-                        int pixelId = elementIndex / pixelStride;
-                        hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
-                        if (hasNull && isNullBitIndex > 0)
+                        columnVector.set(j, inputBuffer.getLong());
+                    }
+                } else
+                {
+                    for (int j = i; j < i + numToRead; ++j)
+                    {
+                        if (!(hasNull && columnVector.isNull[j]))
                         {
-                            BitUtils.bitWiseDeCompact(isNull, inputBuffer, isNullOffset++, 1);
-                            isNullBitIndex = 0;
+                            columnVector.set(j, inputBuffer.getLong());
                         }
                     }
-                    if (hasNull && isNullBitIndex >= 8)
-                    {
-                        BitUtils.bitWiseDeCompact(isNull, inputBuffer, isNullOffset++, 1);
-                        isNullBitIndex = 0;
-                    }
-                    if (hasNull && isNull[isNullBitIndex] == 1)
-                    {
-                        columnVector.isNull[i + vectorIndex] = true;
-                        columnVector.noNulls = false;
-                    } else
-                    {
-                        columnVector.set(i + vectorIndex, inputBuffer.getLong());
-                    }
-                    if (hasNull)
-                    {
-                        isNullBitIndex++;
-                    }
-                    elementIndex++;
                 }
             }
+            // update variables
+            numLeft -= numToRead;
+            elementIndex += numToRead;
+            i += numToRead;
         }
     }
 }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/TimestampColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/TimestampColumnReader.java
@@ -47,8 +47,6 @@ public class TimestampColumnReader extends ColumnReader
     private InputStream inputStream = null;
     private RunLenIntDecoder decoder = null;
     private int isNullOffset = 0;
-    private int isNullBitIndex = 0;
-    private byte[] isNull = new byte[8];
 
     TimestampColumnReader(TypeDescription type)
     {
@@ -71,7 +69,10 @@ public class TimestampColumnReader extends ColumnReader
     @Override
     public void close() throws IOException
     {
-        isNull = null;
+        if (inputStream != null)
+        {
+            inputStream.close();
+        }
     }
 
     /**
@@ -108,7 +109,6 @@ public class TimestampColumnReader extends ColumnReader
             isNullOffset = inputBuffer.position() + chunkIndex.getIsNullOffset();
             hasNull = true;
             elementIndex = 0;
-            isNullBitIndex = 8;
         }
 
         boolean decoding = encoding.getKind().equals(PixelsProto.ColumnEncoding.Kind.RUNLENGTH);

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/TimestampColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/TimestampColumnReader.java
@@ -33,8 +33,6 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.Arrays;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 /**
  * Pixels timestamp column reader.
  * All timestamp values are translated to the specified time zone after read from file.
@@ -115,7 +113,6 @@ public class TimestampColumnReader extends ColumnReader
 
         if (encoding.getKind().equals(PixelsProto.ColumnEncoding.Kind.RUNLENGTH))
         {
-            checkArgument(!nullsPadding, "nullsPadding should not be enabled for encoded column chunk");
             for (int i = 0; i < size; i++)
             {
                 if (elementIndex % pixelStride == 0)

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/VarbinaryColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/VarbinaryColumnReader.java
@@ -22,8 +22,8 @@ package io.pixelsdb.pixels.core.reader;
 import io.pixelsdb.pixels.core.TypeDescription;
 
 /**
- * Created at: 2022-03-04
- * Author: hank
+ * @create 2022-03-04
+ * @author hank
  */
 public class VarbinaryColumnReader extends BinaryColumnReader
 {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/utils/BitUtils.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/utils/BitUtils.java
@@ -130,9 +130,9 @@ public class BitUtils
      */
     public static void bitWiseDeCompact(byte[] bits, byte[] input)
     {
-        /**
+        /*
          * Issue #99:
-         * Use as least as variables as possible to reduce stack footprint
+         * Use as fewer variables as possible to reduce stack footprint
          * and thus improve performance.
          */
          byte bitsLeft = 8;
@@ -151,6 +151,7 @@ public class BitUtils
     /**
      * Bit de-compaction
      *
+     * @param bits the de-compact (decode) result, each element is either 0 (false) or 1 (true)
      * @param input  input byte array
      * @param offset starting offset of the input
      * @param length byte length of the input
@@ -158,9 +159,9 @@ public class BitUtils
      */
     public static void bitWiseDeCompact(byte[] bits, byte[] input, int offset, int length)
     {
-        /**
+        /*
          * Issue #99:
-         * Use as least as variables as possible to reduce stack footprint
+         * Use as fewer variables as possible to reduce stack footprint
          * and thus improve performance.
          */
         byte bitsLeft = 8;
@@ -187,9 +188,9 @@ public class BitUtils
      */
     public static void bitWiseDeCompact(byte[] bits, ByteBuffer input, int offset, int length)
     {
-        /**
+        /*
          * Issue #99:
-         * Use as least variables as possible to reduce stack footprint
+         * Use as fewer variables as possible to reduce stack footprint
          * and thus improve performance.
          */
         byte bitsLeft = 8, b;
@@ -210,6 +211,7 @@ public class BitUtils
     /**
      * Bit de-compaction, this method does not modify the current position in input byte buffer.
      *
+     * @param bits the de-compact (decode) result, each element is either 0 (false) or 1 (true)
      * @param input input byte buffer, which can be direct.
      * @param offset starting offset of the input
      * @param length byte length of the input
@@ -217,7 +219,7 @@ public class BitUtils
      */
     public static void bitWiseDeCompact(byte[] bits, ByteBuf input, int offset, int length)
     {
-        /**
+        /*
          * Issue #99:
          * Use as fewer variables as possible to reduce stack footprint
          * and thus improve performance.
@@ -232,6 +234,87 @@ public class BitUtils
             {
                 bitsLeft --;
                 bits[index++] = (byte) (0x01 & (b >> bitsLeft));
+            }
+            bitsLeft = 8;
+        }
+    }
+
+    /**
+     * Bit de-compaction, this method does not modify the current position in input byte buffer.
+     * It always starts from the first bit of a byte in the input.
+     *
+     * @param bits the de-compact (decode) result, each element is either 0 (false) or 1 (true)
+     * @param bitsOffset the index in bits to start de-compact into
+     * @param bitsLength the number of bits to de-compact
+     * @param input input byte buffer, which can be direct
+     * @param offset starting offset of the input
+     * @return de-compacted bits
+     */
+    public static void bitWiseDeCompact(byte[] bits, int bitsOffset, int bitsLength, ByteBuffer input, int offset)
+    {
+        byte bitsLeft = 8, b;
+        int bitsEnd = bitsOffset + bitsLength;
+        for (int i = offset, bitsIndex = bitsOffset; bitsIndex < bitsEnd; ++i)
+        {
+            b = input.get(i);
+            while (bitsIndex < bitsEnd)
+            {
+                bitsLeft --;
+                bits[bitsIndex++] = (byte) (0x01 & (b >> bitsLeft));
+            }
+            bitsLeft = 8;
+        }
+    }
+
+    /**
+     * Bit de-compaction, this method does not modify the current position in input byte buffer.
+     * It always starts from the first bit of a byte in the input.
+     *
+     * @param bits the de-compact (decode) result, each element is true if the corresponding bit is 1
+     * @param bitsOffset the index in bits to start de-compact into
+     * @param bitsLength the number of bits to de-compact
+     * @param input input byte buffer, which can be direct
+     * @param offset starting offset of the input
+     * @return de-compacted bits
+     */
+    public static void bitWiseDeCompact(boolean[] bits, int bitsOffset, int bitsLength, ByteBuffer input, int offset)
+    {
+        byte bitsLeft = 8, b;
+        int bitsEnd = bitsOffset + bitsLength;
+        for (int i = offset, bitsIndex = bitsOffset; bitsIndex < bitsEnd; ++i)
+        {
+            b = input.get(i);
+            while (bitsIndex < bitsEnd)
+            {
+                bitsLeft --;
+                bits[bitsIndex++] = (0x01 & (b >> bitsLeft)) == 1;
+            }
+            bitsLeft = 8;
+        }
+    }
+
+    /**
+     * Bit de-compaction, this method does not modify the current position in input byte buffer.
+     * It always starts from the first bit of a byte in the input.
+     *
+     * @param bits the de-compact (decode) result, each element is true if the corresponding bit is 1
+     * @param bitsOffset the index in bits to start de-compact into
+     * @param bitsLength the number of bits to de-compact
+     * @param input input byte buffer, which can be direct
+     * @param offset starting offset of the input
+     * @return de-compacted bits
+     */
+    public static void bitWiseDeCompact(boolean[] bits, int bitsOffset, int bitsLength, ByteBuf input, int offset)
+    {
+        byte bitsLeft = 8, b;
+        int bitsEnd = bitsOffset + bitsLength;
+        for (int i = offset, bitsIndex = bitsOffset; bitsIndex < bitsEnd; ++i)
+        {
+            b = input.getByte(i);
+            while (bitsIndex < bitsEnd)
+            {
+                bitsLeft --;
+                bits[bitsIndex++] = (0x01 & (b >> bitsLeft)) == 1;
             }
             bitsLeft = 8;
         }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/utils/BitUtils.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/utils/BitUtils.java
@@ -257,7 +257,7 @@ public class BitUtils
         for (int i = offset, bitsIndex = bitsOffset; bitsIndex < bitsEnd; ++i)
         {
             b = input.get(i);
-            while (bitsIndex < bitsEnd)
+            while (bitsLeft > 0 && bitsIndex < bitsEnd)
             {
                 bitsLeft --;
                 bits[bitsIndex++] = (byte) (0x01 & (b >> bitsLeft));
@@ -284,7 +284,7 @@ public class BitUtils
         for (int i = offset, bitsIndex = bitsOffset; bitsIndex < bitsEnd; ++i)
         {
             b = input.get(i);
-            while (bitsIndex < bitsEnd)
+            while (bitsLeft > 0 && bitsIndex < bitsEnd)
             {
                 bitsLeft --;
                 bits[bitsIndex++] = (0x01 & (b >> bitsLeft)) == 1;
@@ -311,7 +311,7 @@ public class BitUtils
         for (int i = offset, bitsIndex = bitsOffset; bitsIndex < bitsEnd; ++i)
         {
             b = input.getByte(i);
-            while (bitsIndex < bitsEnd)
+            while (bitsLeft > 0 && bitsIndex < bitsEnd)
             {
                 bitsLeft --;
                 bits[bitsIndex++] = (0x01 & (b >> bitsLeft)) == 1;

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/BinaryColumnVector.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/BinaryColumnVector.java
@@ -37,7 +37,7 @@ import static sun.misc.Unsafe.ARRAY_BYTE_BASE_OFFSET;
  * explicitly present, as opposed to provided by a dictionary reference.
  * In some cases, all the values will be in the same byte array to begin with,
  * but this need not be the case. If each value is in a separate byte
- * array to start with, or not all of the values are in the same original
+ * array to start with, or not all the values are in the same original
  * byte array, you can still assign data by reference into this column vector.
  * This gives flexibility to use this in multiple situations.
  * <p>

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/BinaryColumnVector.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/BinaryColumnVector.java
@@ -43,9 +43,8 @@ import static sun.misc.Unsafe.ARRAY_BYTE_BASE_OFFSET;
  * <p>
  * When setting data by reference, the caller
  * is responsible for allocating the byte arrays used to hold the data.
- * You can also set data by value, as long as you call the initBuffer() method first.
- * You can mix "by value" and "by reference" in the same column vector,
- * though that use is probably not typical.
+ * You can also set data by value. You can mix "by value" and "by reference" in the
+ * same column vector, though that use is probably not typical.
  */
 public class BinaryColumnVector extends ColumnVector
 {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/ByteColumnVector.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/ByteColumnVector.java
@@ -47,8 +47,10 @@ public class ByteColumnVector extends ColumnVector
     public ByteColumnVector(int len)
     {
         super(len);
-        vector = new byte[len];
-        memoryUsage += Byte.BYTES * len;
+        // Issue #545: round vector capacity to a multiple of 8 for boolean columns with nulls padding enabled
+        int vectorCapacity = (len + 7) / 8 * 8;
+        vector = new byte[vectorCapacity];
+        memoryUsage += Byte.BYTES * vectorCapacity;
     }
 
     @Override

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/ByteColumnVector.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/ByteColumnVector.java
@@ -47,10 +47,8 @@ public class ByteColumnVector extends ColumnVector
     public ByteColumnVector(int len)
     {
         super(len);
-        // Issue #545: round vector capacity to a multiple of 8 for boolean columns with nulls padding enabled
-        int vectorCapacity = (len + 7) / 8 * 8;
-        vector = new byte[vectorCapacity];
-        memoryUsage += Byte.BYTES * vectorCapacity;
+        vector = new byte[len];
+        memoryUsage += Byte.BYTES * len;
     }
 
     @Override

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/ColumnVector.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/ColumnVector.java
@@ -92,8 +92,10 @@ public abstract class ColumnVector implements AutoCloseable
     public ColumnVector(int len)
     {
         this.length = len;
-        isNull = new boolean[len];
-        memoryUsage += len + Integer.BYTES*3 + 4;
+        // Issue #545: round isNull capacity to a multiple of 8 for direct de-compaction without copying
+        int isNullCapacity = (len + 7) / 8 * 8;
+        isNull = new boolean[isNullCapacity];
+        memoryUsage += isNullCapacity + Integer.BYTES * 3 + 4;
         noNulls = true;
         isRepeating = false;
         preFlattenNoNulls = true;

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/ColumnVector.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/ColumnVector.java
@@ -92,10 +92,8 @@ public abstract class ColumnVector implements AutoCloseable
     public ColumnVector(int len)
     {
         this.length = len;
-        // Issue #545: round isNull capacity to a multiple of 8 for direct de-compaction without copying
-        int isNullCapacity = (len + 7) / 8 * 8;
-        isNull = new boolean[isNullCapacity];
-        memoryUsage += isNullCapacity + Integer.BYTES * 3 + 4;
+        isNull = new boolean[len];
+        memoryUsage += len + Integer.BYTES * 3 + 4;
         noNulls = true;
         isRepeating = false;
         preFlattenNoNulls = true;

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/ColumnVector.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/ColumnVector.java
@@ -203,7 +203,7 @@ public abstract class ColumnVector implements AutoCloseable
     }
 
     /**
-     * Get the approximate (may be slightly lower than actual)
+     * Get the approximate (maybe slightly lower than actual)
      * cumulative memory usage, which is more meaningful for GC
      * performance tuning.
      *

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/DecimalColumnVector.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/DecimalColumnVector.java
@@ -41,8 +41,8 @@ import static java.util.Objects.requireNonNull;
  * <p><b>Note: it only supports short decimals with max precision
  * and scale 18.</b></p>
  *
- * Created at: 05/03/2022
- * Author: hank
+ * @author hank
+ * @create 2022-03-05
  */
 public class DecimalColumnVector extends ColumnVector
 {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/DictionaryColumnVector.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/DictionaryColumnVector.java
@@ -36,8 +36,8 @@ import static sun.misc.Unsafe.ARRAY_BYTE_BASE_OFFSET;
  * because only one dictionary is supported in this column vector.
  * </p>
  *
- * Created at: 28/01/2023
- * Author: hank
+ * @author hank
+ * @create 2023-01-28
  */
 public class DictionaryColumnVector extends ColumnVector
 {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/DoubleColumnVector.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/DoubleColumnVector.java
@@ -119,7 +119,13 @@ public class DoubleColumnVector extends ColumnVector
     @Override
     public void add(float value)
     {
-        add((double) value);
+        if (writeIndex >= getLength())
+        {
+            ensureSize(writeIndex * 2, true);
+        }
+        int index = writeIndex++;
+        vector[index] = Float.floatToIntBits(value);
+        isNull[index] = false;
     }
 
     @Override

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/LongColumnVector.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/LongColumnVector.java
@@ -100,6 +100,18 @@ public class LongColumnVector extends ColumnVector
     }
 
     @Override
+    public void add(int v)
+    {
+        if (writeIndex >= getLength())
+        {
+            ensureSize(writeIndex * 2, true);
+        }
+        int index = writeIndex++;
+        vector[index] = v;
+        isNull[index] = false;
+    }
+
+    @Override
     public int[] accumulateHashCode(int[] hashCode)
     {
         requireNonNull(hashCode, "hashCode is null");

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/LongDecimalColumnVector.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/LongDecimalColumnVector.java
@@ -40,8 +40,8 @@ import static java.util.Objects.requireNonNull;
  * 64-bit integers in the vector, with the high 64 bits in the lower index. This is
  * not affected by the endianness of the column reader or writer.
  *
- * Created at: 01/07/2022
- * Author: hank
+ * @author hank
+ * @create 2022-07-01
  */
 public class LongDecimalColumnVector extends ColumnVector
 {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/TimeColumnVector.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/TimeColumnVector.java
@@ -43,8 +43,8 @@ import static java.util.Objects.requireNonNull;
  * Generally, the caller will fill in a scratch time object with values from a row, work
  * using the scratch time, and then perhaps update the column vector row with a result.
  *
- * @create 2021-04-25
  * @author hank
+ * @create 2021-04-25
  */
 public class TimeColumnVector extends ColumnVector
 {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/TimestampColumnVector.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/vector/TimestampColumnVector.java
@@ -365,6 +365,16 @@ public class TimestampColumnVector extends ColumnVector
     }
 
     @Override
+    public void add(long micros)
+    {
+        if (writeIndex >= getLength())
+        {
+            ensureSize(writeIndex * 2, true);
+        }
+        set(writeIndex++, micros);
+    }
+
+    @Override
     public void add(Timestamp value)
     {
         if (writeIndex >= getLength())

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/BaseColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/BaseColumnWriter.java
@@ -71,11 +71,11 @@ public abstract class BaseColumnWriter implements ColumnWriter
         this.pixelStride = requireNonNull(writerOption, "writerOption is null").getPixelStride();
         this.encodingLevel = requireNonNull(writerOption.getEncodingLevel(), "encodingLevel is null");
         this.byteOrder = requireNonNull(writerOption.getByteOrder(), "byteOrder is null");
-        this.nullsPadding = writerOption.isNullsPadding();
+        this.nullsPadding = decideNullsPadding(writerOption);
         this.isNull = new boolean[pixelStride];
-
         this.columnChunkIndex = PixelsProto.ColumnChunkIndex.newBuilder()
-                .setLittleEndian(byteOrder.equals(ByteOrder.LITTLE_ENDIAN));
+                .setLittleEndian(byteOrder.equals(ByteOrder.LITTLE_ENDIAN))
+                .setNullsPadding(nullsPadding);
         this.columnChunkStat = PixelsProto.ColumnStatistic.newBuilder();
         this.pixelStatRecorder = StatsRecorder.create(type);
         this.columnChunkStatRecorder = StatsRecorder.create(type);
@@ -84,6 +84,9 @@ public abstract class BaseColumnWriter implements ColumnWriter
         this.outputStream = new ByteArrayOutputStream(pixelStride);
         this.isNullStream = new ByteArrayOutputStream(pixelStride);
     }
+
+    @Override
+    public abstract boolean decideNullsPadding(PixelsWriterOption writerOption);
 
     /**
      * Write ColumnVector

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/BaseColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/BaseColumnWriter.java
@@ -64,12 +64,12 @@ public abstract class BaseColumnWriter implements ColumnWriter
     final ByteArrayOutputStream outputStream;  // column chunk content
     private final ByteArrayOutputStream isNullStream;  // column chunk isNull
 
-    public BaseColumnWriter(TypeDescription type, int pixelStride, EncodingLevel encodingLevel, ByteOrder byteOrder)
+    public BaseColumnWriter(TypeDescription type, PixelsWriterOption writerOption)
     {
         this.type = requireNonNull(type, "type is null");
-        this.pixelStride = pixelStride;
-        this.encodingLevel = encodingLevel;
-        this.byteOrder = requireNonNull(byteOrder, "byteOrder is null");
+        this.pixelStride = writerOption.getPixelStride();
+        this.encodingLevel = writerOption.getEncodingLevel();
+        this.byteOrder = requireNonNull(writerOption.getByteOrder(), "byteOrder is null");
         this.isNull = new boolean[pixelStride];
 
         this.columnChunkIndex = PixelsProto.ColumnChunkIndex.newBuilder()

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/BaseColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/BaseColumnWriter.java
@@ -36,7 +36,9 @@ import static java.util.Objects.requireNonNull;
 /**
  * pixels
  *
- * @author guodong
+ * @author guodong, hank
+ * @create 2017-08-09
+ * @update 2023-08-16 Chamonix: support nulls padding
  */
 public abstract class BaseColumnWriter implements ColumnWriter
 {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/BaseColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/BaseColumnWriter.java
@@ -43,6 +43,7 @@ public abstract class BaseColumnWriter implements ColumnWriter
     final int pixelStride;                     // indicate num of elements in a pixel
     final EncodingLevel encodingLevel;         // indicate the encoding level during writing
     final ByteOrder byteOrder;                 // indicate the endianness used during writing
+    final boolean nullsPadding;                // indicate whether nulls are padded by arbitrary value
     final boolean[] isNull;
     private final PixelsProto.ColumnChunkIndex.Builder columnChunkIndex;
     private final PixelsProto.ColumnStatistic.Builder columnChunkStat;
@@ -67,9 +68,10 @@ public abstract class BaseColumnWriter implements ColumnWriter
     public BaseColumnWriter(TypeDescription type, PixelsWriterOption writerOption)
     {
         this.type = requireNonNull(type, "type is null");
-        this.pixelStride = writerOption.getPixelStride();
-        this.encodingLevel = writerOption.getEncodingLevel();
+        this.pixelStride = requireNonNull(writerOption, "writerOption is null").getPixelStride();
+        this.encodingLevel = requireNonNull(writerOption.getEncodingLevel(), "encodingLevel is null");
         this.byteOrder = requireNonNull(writerOption.getByteOrder(), "byteOrder is null");
+        this.nullsPadding = writerOption.isNullsPadding();
         this.isNull = new boolean[pixelStride];
 
         this.columnChunkIndex = PixelsProto.ColumnChunkIndex.newBuilder()

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/BinaryColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/BinaryColumnWriter.java
@@ -20,12 +20,10 @@
 package io.pixelsdb.pixels.core.writer;
 
 import io.pixelsdb.pixels.core.TypeDescription;
-import io.pixelsdb.pixels.core.encoding.EncodingLevel;
 import io.pixelsdb.pixels.core.vector.BinaryColumnVector;
 import io.pixelsdb.pixels.core.vector.ColumnVector;
 
 import java.io.IOException;
-import java.nio.ByteOrder;
 
 /**
  * pixels binary column writer.
@@ -42,9 +40,9 @@ public class BinaryColumnWriter extends BaseColumnWriter
     private final int maxLength;
     private int numTruncated;
 
-    public BinaryColumnWriter(TypeDescription type, int pixelStride, EncodingLevel encodingLevel, ByteOrder byteOrder)
+    public BinaryColumnWriter(TypeDescription type,  PixelsWriterOption writerOption)
     {
-        super(type, pixelStride, encodingLevel, byteOrder);
+        super(type, writerOption);
         this.maxLength = type.getMaxLength();
         this.numTruncated = 0;
     }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/BinaryColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/BinaryColumnWriter.java
@@ -28,7 +28,7 @@ import java.io.IOException;
 /**
  * pixels binary column writer.
  * each element consists of content length and content binary.
- * <p>TODO: this class is not yet finished.</p>
+ * TODO: this class is not yet finished.
  *
  * @author guodong
  * @author hank
@@ -102,5 +102,11 @@ public class BinaryColumnWriter extends BaseColumnWriter
         }
         System.arraycopy(columnVector.isNull, curPartOffset, isNull, curPixelIsNullIndex, curPartLength);
         curPixelIsNullIndex += curPartLength;
+    }
+
+    @Override
+    public boolean decideNullsPadding(PixelsWriterOption writerOption)
+    {
+        return writerOption.isNullsPadding();
     }
 }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/BinaryColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/BinaryColumnWriter.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 /**
  * pixels binary column writer.
  * each element consists of content length and content binary.
+ * <p>TODO: this class is not yet finished.</p>
  *
  * @author guodong
  * @author hank

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/BinaryColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/BinaryColumnWriter.java
@@ -30,8 +30,8 @@ import java.io.IOException;
  * each element consists of content length and content binary.
  * TODO: this class is not yet finished.
  *
- * @author guodong
- * @author hank
+ * @author guodong, hank
+ * @update 2023-08-16 Chamonix: support nulls padding
  */
 public class BinaryColumnWriter extends BaseColumnWriter
 {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/BooleanColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/BooleanColumnWriter.java
@@ -74,6 +74,19 @@ public class BooleanColumnWriter extends BaseColumnWriter
             {
                 hasNull = true;
                 pixelStatRecorder.increment();
+                if (nullsPadding)
+                {
+                    // padding 0 or previous value for nulls, this is friendly for run-length encoding
+                    if (curPixelVectorIndex <= 0)
+                    {
+                        curPixelVector[curPixelVectorIndex] = 0x00;
+                    }
+                    else
+                    {
+                        curPixelVector[curPixelVectorIndex] = curPixelVector[curPixelVectorIndex-1];
+                    }
+                    curPixelVectorIndex ++;
+                }
             }
             else
             {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/BooleanColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/BooleanColumnWriter.java
@@ -20,13 +20,11 @@
 package io.pixelsdb.pixels.core.writer;
 
 import io.pixelsdb.pixels.core.TypeDescription;
-import io.pixelsdb.pixels.core.encoding.EncodingLevel;
 import io.pixelsdb.pixels.core.utils.BitUtils;
 import io.pixelsdb.pixels.core.vector.ByteColumnVector;
 import io.pixelsdb.pixels.core.vector.ColumnVector;
 
 import java.io.IOException;
-import java.nio.ByteOrder;
 
 /**
  * Boolean column writer.
@@ -38,9 +36,9 @@ public class BooleanColumnWriter extends BaseColumnWriter
 {
     private final byte[] curPixelVector = new byte[pixelStride];
 
-    public BooleanColumnWriter(TypeDescription type, int pixelStride, EncodingLevel encodingLevel, ByteOrder byteOrder)
+    public BooleanColumnWriter(TypeDescription type,  PixelsWriterOption writerOption)
     {
-        super(type, pixelStride, encodingLevel, byteOrder);
+        super(type, writerOption);
     }
 
     @Override

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/BooleanColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/BooleanColumnWriter.java
@@ -76,16 +76,8 @@ public class BooleanColumnWriter extends BaseColumnWriter
                 pixelStatRecorder.increment();
                 if (nullsPadding)
                 {
-                    // padding 0 or previous value for nulls, this is friendly for run-length encoding
-                    if (curPixelVectorIndex <= 0)
-                    {
-                        curPixelVector[curPixelVectorIndex] = 0x00;
-                    }
-                    else
-                    {
-                        curPixelVector[curPixelVectorIndex] = curPixelVector[curPixelVectorIndex-1];
-                    }
-                    curPixelVectorIndex ++;
+                    // padding 0 for nulls
+                    curPixelVector[curPixelVectorIndex++] = 0x00;
                 }
             }
             else
@@ -108,5 +100,11 @@ public class BooleanColumnWriter extends BaseColumnWriter
         outputStream.write(BitUtils.bitWiseCompact(curPixelVector, curPixelVectorIndex));
 
         super.newPixel();
+    }
+
+    @Override
+    public boolean decideNullsPadding(PixelsWriterOption writerOption)
+    {
+        return writerOption.isNullsPadding();
     }
 }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/BooleanColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/BooleanColumnWriter.java
@@ -30,7 +30,8 @@ import java.io.IOException;
  * Boolean column writer.
  * Boolean values are compacted using bit-wise bytes, and then these integers are written out.
  *
- * @author guodong
+ * @author guodong, hank
+ * @update 2023-08-16 Chamonix: support nulls padding
  */
 public class BooleanColumnWriter extends BaseColumnWriter
 {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/ByteColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/ByteColumnWriter.java
@@ -27,7 +27,6 @@ import io.pixelsdb.pixels.core.vector.ColumnVector;
 import io.pixelsdb.pixels.core.vector.LongColumnVector;
 
 import java.io.IOException;
-import java.nio.ByteOrder;
 
 /**
  * pixels byte column writer
@@ -38,9 +37,9 @@ public class ByteColumnWriter extends BaseColumnWriter
 {
     private final byte[] curPixelVector = new byte[pixelStride];
 
-    public ByteColumnWriter(TypeDescription type, int pixelStride, EncodingLevel encodingLevel, ByteOrder byteOrder)
+    public ByteColumnWriter(TypeDescription type,  PixelsWriterOption writerOption)
     {
-        super(type, pixelStride, encodingLevel, byteOrder);
+        super(type, writerOption);
         encoder = new RunLenByteEncoder();
     }
 

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/ByteColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/ByteColumnWriter.java
@@ -36,11 +36,16 @@ import java.io.IOException;
 public class ByteColumnWriter extends BaseColumnWriter
 {
     private final byte[] curPixelVector = new byte[pixelStride];
+    private final boolean runlengthEncoding;
 
     public ByteColumnWriter(TypeDescription type,  PixelsWriterOption writerOption)
     {
         super(type, writerOption);
-        encoder = new RunLenByteEncoder();
+        runlengthEncoding = encodingLevel.ge(EncodingLevel.EL2);
+        if (runlengthEncoding)
+        {
+            encoder = new RunLenByteEncoder();
+        }
     }
 
     @Override
@@ -48,11 +53,6 @@ public class ByteColumnWriter extends BaseColumnWriter
     {
         LongColumnVector columnVector = (LongColumnVector) vector;
         long[] values = columnVector.vector;
-        byte[] bvalues = new byte[size];
-        for (int i = 0; i < size; i++)
-        {
-            bvalues[i] = (byte) values[i];
-        }
         int curPartLength;
         int curPartOffset = 0;
         int nextPartLength = size;
@@ -60,19 +60,19 @@ public class ByteColumnWriter extends BaseColumnWriter
         while ((curPixelIsNullIndex + nextPartLength) >= pixelStride)
         {
             curPartLength = pixelStride - curPixelIsNullIndex;
-            writeCurPartByte(columnVector, bvalues, curPartLength, curPartOffset);
+            writeCurPartByte(columnVector, values, curPartLength, curPartOffset);
             newPixel();
             curPartOffset += curPartLength;
             nextPartLength = size - curPartOffset;
         }
 
         curPartLength = nextPartLength;
-        writeCurPartByte(columnVector, bvalues, curPartLength, curPartOffset);
+        writeCurPartByte(columnVector, values, curPartLength, curPartOffset);
 
         return outputStream.size();
     }
 
-    private void writeCurPartByte(LongColumnVector columnVector, byte[] bvalues, int curPartLength, int curPartOffset)
+    private void writeCurPartByte(LongColumnVector columnVector, long[] values, int curPartLength, int curPartOffset)
     {
         for (int i = 0; i < curPartLength; i++)
         {
@@ -83,21 +83,12 @@ public class ByteColumnWriter extends BaseColumnWriter
                 pixelStatRecorder.increment();
                 if (nullsPadding)
                 {
-                    // padding 0 or previous value for nulls, this is friendly for run-length encoding
-                    if (curPixelVectorIndex <= 0)
-                    {
-                        curPixelVector[curPixelVectorIndex] = 0x00;
-                    }
-                    else
-                    {
-                        curPixelVector[curPixelVectorIndex] = curPixelVector[curPixelVectorIndex-1];
-                    }
-                    curPixelVectorIndex ++;
+                    // padding 0 for nulls
+                    curPixelVector[curPixelVectorIndex++] = 0x00;
                 }
-            }
-            else
+            } else
             {
-                curPixelVector[curPixelVectorIndex++] = bvalues[i + curPartOffset];
+                curPixelVector[curPixelVectorIndex++] = (byte) values[i + curPartOffset];
             }
         }
         System.arraycopy(columnVector.isNull, curPartOffset, isNull, curPixelIsNullIndex, curPartLength);
@@ -112,7 +103,7 @@ public class ByteColumnWriter extends BaseColumnWriter
             pixelStatRecorder.updateInteger(curPixelVector[i], 1);
         }
 
-        if (encodingLevel.ge(EncodingLevel.EL2))
+        if (runlengthEncoding)
         {
             outputStream.write(encoder.encode(curPixelVector, 0, curPixelVectorIndex));
         }
@@ -127,7 +118,7 @@ public class ByteColumnWriter extends BaseColumnWriter
     @Override
     public PixelsProto.ColumnEncoding.Builder getColumnChunkEncoding()
     {
-        if (encodingLevel.ge(EncodingLevel.EL2))
+        if (runlengthEncoding)
         {
             return PixelsProto.ColumnEncoding.newBuilder()
                     .setKind(PixelsProto.ColumnEncoding.Kind.RUNLENGTH);
@@ -139,7 +130,20 @@ public class ByteColumnWriter extends BaseColumnWriter
     @Override
     public void close() throws IOException
     {
-        encoder.close();
+        if (runlengthEncoding)
+        {
+            encoder.close();
+        }
         super.close();
+    }
+
+    @Override
+    public boolean decideNullsPadding(PixelsWriterOption writerOption)
+    {
+        if (writerOption.getEncodingLevel().ge(EncodingLevel.EL2))
+        {
+            return false;
+        }
+        return writerOption.isNullsPadding();
     }
 }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/ByteColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/ByteColumnWriter.java
@@ -100,7 +100,7 @@ public class ByteColumnWriter extends BaseColumnWriter
             pixelStatRecorder.updateInteger(curPixelVector[i], 1);
         }
 
-        if (encodingLevel.ge(EncodingLevel.EL1))
+        if (encodingLevel.ge(EncodingLevel.EL2))
         {
             outputStream.write(encoder.encode(curPixelVector, 0, curPixelVectorIndex));
         }
@@ -115,7 +115,7 @@ public class ByteColumnWriter extends BaseColumnWriter
     @Override
     public PixelsProto.ColumnEncoding.Builder getColumnChunkEncoding()
     {
-        if (encodingLevel.ge(EncodingLevel.EL1))
+        if (encodingLevel.ge(EncodingLevel.EL2))
         {
             return PixelsProto.ColumnEncoding.newBuilder()
                     .setKind(PixelsProto.ColumnEncoding.Kind.RUNLENGTH);

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/ByteColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/ByteColumnWriter.java
@@ -81,6 +81,19 @@ public class ByteColumnWriter extends BaseColumnWriter
             {
                 hasNull = true;
                 pixelStatRecorder.increment();
+                if (nullsPadding)
+                {
+                    // padding 0 or previous value for nulls, this is friendly for run-length encoding
+                    if (curPixelVectorIndex <= 0)
+                    {
+                        curPixelVector[curPixelVectorIndex] = 0x00;
+                    }
+                    else
+                    {
+                        curPixelVector[curPixelVectorIndex] = curPixelVector[curPixelVectorIndex-1];
+                    }
+                    curPixelVectorIndex ++;
+                }
             }
             else
             {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/ByteColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/ByteColumnWriter.java
@@ -23,8 +23,8 @@ import io.pixelsdb.pixels.core.PixelsProto;
 import io.pixelsdb.pixels.core.TypeDescription;
 import io.pixelsdb.pixels.core.encoding.EncodingLevel;
 import io.pixelsdb.pixels.core.encoding.RunLenByteEncoder;
+import io.pixelsdb.pixels.core.vector.ByteColumnVector;
 import io.pixelsdb.pixels.core.vector.ColumnVector;
-import io.pixelsdb.pixels.core.vector.LongColumnVector;
 
 import java.io.IOException;
 
@@ -51,8 +51,8 @@ public class ByteColumnWriter extends BaseColumnWriter
     @Override
     public int write(ColumnVector vector, int size) throws IOException
     {
-        LongColumnVector columnVector = (LongColumnVector) vector;
-        long[] values = columnVector.vector;
+        ByteColumnVector columnVector = (ByteColumnVector) vector;
+        byte[] values = columnVector.vector;
         int curPartLength;
         int curPartOffset = 0;
         int nextPartLength = size;
@@ -72,7 +72,7 @@ public class ByteColumnWriter extends BaseColumnWriter
         return outputStream.size();
     }
 
-    private void writeCurPartByte(LongColumnVector columnVector, long[] values, int curPartLength, int curPartOffset)
+    private void writeCurPartByte(ByteColumnVector columnVector, byte[] values, int curPartLength, int curPartOffset)
     {
         for (int i = 0; i < curPartLength; i++)
         {
@@ -88,7 +88,7 @@ public class ByteColumnWriter extends BaseColumnWriter
                 }
             } else
             {
-                curPixelVector[curPixelVectorIndex++] = (byte) values[i + curPartOffset];
+                curPixelVector[curPixelVectorIndex++] = values[i + curPartOffset];
             }
         }
         System.arraycopy(columnVector.isNull, curPartOffset, isNull, curPixelIsNullIndex, curPartLength);

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/ByteColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/ByteColumnWriter.java
@@ -31,7 +31,8 @@ import java.io.IOException;
 /**
  * pixels byte column writer
  *
- * @author guodong
+ * @author guodong, hank
+ * @update 2023-08-16 Chamonix: support nulls padding
  */
 public class ByteColumnWriter extends BaseColumnWriter
 {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/CharColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/CharColumnWriter.java
@@ -20,21 +20,19 @@
 package io.pixelsdb.pixels.core.writer;
 
 import io.pixelsdb.pixels.core.TypeDescription;
-import io.pixelsdb.pixels.core.encoding.EncodingLevel;
-
-import java.nio.ByteOrder;
 
 /**
  * pixels column writer for <code>Char</code>
  * It is the same as VarcharColumnWriter, which means it never pads zero
  * at the end when writing a value. This is for performance reasons.
+ *
  * @author guodong
  * @author hank
  */
 public class CharColumnWriter extends VarcharColumnWriter
 {
-    public CharColumnWriter(TypeDescription type, int pixelStride, EncodingLevel encodingLevel, ByteOrder byteOrder)
+    public CharColumnWriter(TypeDescription type,  PixelsWriterOption writerOption)
     {
-        super(type, pixelStride, encodingLevel, byteOrder);
+        super(type, writerOption);
     }
 }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/CharColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/CharColumnWriter.java
@@ -26,8 +26,8 @@ import io.pixelsdb.pixels.core.TypeDescription;
  * It is the same as VarcharColumnWriter, which means it never pads zero
  * at the end when writing a value. This is for performance reasons.
  *
- * @author guodong
- * @author hank
+ * @author guodong, hank
+ * @update 2023-08-16 Chamonix: support nulls padding
  */
 public class CharColumnWriter extends VarcharColumnWriter
 {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/ColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/ColumnWriter.java
@@ -31,7 +31,8 @@ import static io.pixelsdb.pixels.core.TypeDescription.MAX_SHORT_DECIMAL_PRECISIO
 /**
  * Interface for Pixels column writer.
  *
- * @author guodong
+ * @author guodong, hank
+ * @update 2023-08-16 Chamonix: support nulls padding
  */
 public interface ColumnWriter
 {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/ColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/ColumnWriter.java
@@ -21,17 +21,15 @@ package io.pixelsdb.pixels.core.writer;
 
 import io.pixelsdb.pixels.core.PixelsProto;
 import io.pixelsdb.pixels.core.TypeDescription;
-import io.pixelsdb.pixels.core.encoding.EncodingLevel;
 import io.pixelsdb.pixels.core.stats.StatsRecorder;
 import io.pixelsdb.pixels.core.vector.ColumnVector;
 
 import java.io.IOException;
-import java.nio.ByteOrder;
 
 import static io.pixelsdb.pixels.core.TypeDescription.MAX_SHORT_DECIMAL_PRECISION;
 
 /**
- * pixels
+ * Interface for Pixels column writer.
  *
  * @author guodong
  */
@@ -39,50 +37,48 @@ public interface ColumnWriter
 {
     /**
      * Create a column writer according to the data type.
-     * @param type the data type.
-     * @param pixelStride the pixel stride in the column
-     * @param encodingLevel the encoding level to be applied on the column
+     * @param type the data type
+     * @param writerOption the writer option applied on the column
      * @return
      */
-    static ColumnWriter newColumnWriter(TypeDescription type, int pixelStride,
-                                        EncodingLevel encodingLevel, ByteOrder byteOrder)
+    static ColumnWriter newColumnWriter(TypeDescription type, PixelsWriterOption writerOption)
     {
         switch (type.getCategory())
         {
             case BOOLEAN:
-                return new BooleanColumnWriter(type, pixelStride, encodingLevel, byteOrder);
+                return new BooleanColumnWriter(type, writerOption);
             case BYTE:
-                return new ByteColumnWriter(type, pixelStride, encodingLevel, byteOrder);
+                return new ByteColumnWriter(type, writerOption);
             case SHORT:
             case INT:
             case LONG:
-                return new IntegerColumnWriter(type, pixelStride, encodingLevel, byteOrder);
+                return new IntegerColumnWriter(type, writerOption);
             case FLOAT:
-                return new FloatColumnWriter(type, pixelStride, encodingLevel, byteOrder);
+                return new FloatColumnWriter(type, writerOption);
             case DOUBLE:
-                return new DoubleColumnWriter(type, pixelStride, encodingLevel, byteOrder);
+                return new DoubleColumnWriter(type, writerOption);
             case DECIMAL: // Issue #196: precision and scale are passed through type.
                 if (type.getPrecision() <= MAX_SHORT_DECIMAL_PRECISION)
-                    return new DecimalColumnWriter(type, pixelStride, encodingLevel, byteOrder);
+                    return new DecimalColumnWriter(type, writerOption);
                 else
-                    return new LongDecimalColumnWriter(type, pixelStride, encodingLevel, byteOrder);
+                    return new LongDecimalColumnWriter(type, writerOption);
             case STRING:
-                return new StringColumnWriter(type, pixelStride, encodingLevel, byteOrder);
+                return new StringColumnWriter(type, writerOption);
             // Issue #196: max length of char, varchar, binary, and varbinary, are passed through type.
             case CHAR:
-                return new CharColumnWriter(type, pixelStride, encodingLevel, byteOrder);
+                return new CharColumnWriter(type, writerOption);
             case VARCHAR:
-                return new VarcharColumnWriter(type, pixelStride, encodingLevel, byteOrder);
+                return new VarcharColumnWriter(type, writerOption);
             case BINARY:
-                return new BinaryColumnWriter(type, pixelStride, encodingLevel, byteOrder);
+                return new BinaryColumnWriter(type, writerOption);
             case VARBINARY:
-                return new VarbinaryColumnWriter(type, pixelStride, encodingLevel, byteOrder);
+                return new VarbinaryColumnWriter(type, writerOption);
             case DATE:
-                return new DateColumnWriter(type, pixelStride, encodingLevel, byteOrder);
+                return new DateColumnWriter(type, writerOption);
             case TIME:
-                return new TimeColumnWriter(type, pixelStride, encodingLevel, byteOrder);
+                return new TimeColumnWriter(type, writerOption);
             case TIMESTAMP:
-                return new TimestampColumnWriter(type, pixelStride, encodingLevel, byteOrder);
+                return new TimestampColumnWriter(type, writerOption);
             default:
                 throw new IllegalArgumentException("Bad schema type: " + type.getCategory());
         }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/ColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/ColumnWriter.java
@@ -90,6 +90,8 @@ public interface ColumnWriter
 
     int getColumnChunkSize();
 
+    boolean decideNullsPadding(PixelsWriterOption writerOption);
+
     PixelsProto.ColumnChunkIndex.Builder getColumnChunkIndex();
 
     PixelsProto.ColumnStatistic.Builder getColumnChunkStat();

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/DateColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/DateColumnWriter.java
@@ -23,23 +23,27 @@ import io.pixelsdb.pixels.core.PixelsProto;
 import io.pixelsdb.pixels.core.TypeDescription;
 import io.pixelsdb.pixels.core.encoding.EncodingLevel;
 import io.pixelsdb.pixels.core.encoding.RunLenIntEncoder;
+import io.pixelsdb.pixels.core.utils.EncodingUtils;
 import io.pixelsdb.pixels.core.vector.ColumnVector;
 import io.pixelsdb.pixels.core.vector.DateColumnVector;
 
 import java.io.IOException;
-import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 
 /**
  * Date column writer.
  * All date values are converted to the number of days from
  * UTC 1970-1-1 0:0：0 before they are stored as int values.
  *
- * 2021-04-25
  * @author hank
+ * @create 2021-04-25
+ * @update 2023-08-16 Chamonix: support nulls padding
+ * @update 2023-08-19 Zermatt: reduce memory copy and fix curPixelsVector encoding when the current pixel contains nulls
  */
 public class DateColumnWriter extends BaseColumnWriter
 {
     private final int[] curPixelVector = new int[pixelStride];
+    private final EncodingUtils encodingUtils = new EncodingUtils();
     private final boolean runlengthEncoding;
 
     public DateColumnWriter(TypeDescription type,  PixelsWriterOption writerOption)
@@ -110,20 +114,24 @@ public class DateColumnWriter extends BaseColumnWriter
             {
                 pixelStatRecorder.updateDate(curPixelVector[i]);
             }
-            outputStream.write(encoder.encode(curPixelVector));
+            outputStream.write(encoder.encode(curPixelVector, 0, curPixelVectorIndex));
         }
         else
         {
-            ByteBuffer curVecPartitionBuffer = ByteBuffer.allocate(curPixelVectorIndex * Integer.BYTES);
-            curVecPartitionBuffer.order(byteOrder);
+            boolean littleEndian = byteOrder.equals(ByteOrder.LITTLE_ENDIAN);
             for (int i = 0; i < curPixelVectorIndex; i++)
             {
-                curVecPartitionBuffer.putInt(curPixelVector[i]);
+                if (littleEndian)
+                {
+                    encodingUtils.writeIntLE(outputStream, curPixelVector[i]);
+                }
+                else
+                {
+                    encodingUtils.writeIntBE(outputStream, curPixelVector[i]);
+                }
                 pixelStatRecorder.updateDate(curPixelVector[i]);
             }
-            outputStream.write(curVecPartitionBuffer.array());
         }
-
         super.newPixel();
     }
 

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/DateColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/DateColumnWriter.java
@@ -100,7 +100,7 @@ public class DateColumnWriter extends BaseColumnWriter
             pixelStatRecorder.updateDate(curPixelVector[i]);
         }
 
-        if (encodingLevel.ge(EncodingLevel.EL1))
+        if (encodingLevel.ge(EncodingLevel.EL2))
         {
             int[] values = new int[curPixelVectorIndex];
             System.arraycopy(curPixelVector, 0, values, 0, curPixelVectorIndex);
@@ -124,7 +124,7 @@ public class DateColumnWriter extends BaseColumnWriter
     @Override
     public PixelsProto.ColumnEncoding.Builder getColumnChunkEncoding()
     {
-        if (encodingLevel.ge(EncodingLevel.EL1))
+        if (encodingLevel.ge(EncodingLevel.EL2))
         {
             return PixelsProto.ColumnEncoding.newBuilder()
                     .setKind(PixelsProto.ColumnEncoding.Kind.RUNLENGTH);

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/DateColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/DateColumnWriter.java
@@ -28,7 +28,6 @@ import io.pixelsdb.pixels.core.vector.DateColumnVector;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 
 /**
  * Date column writer.
@@ -42,9 +41,9 @@ public class DateColumnWriter extends BaseColumnWriter
 {
     private final int[] curPixelVector = new int[pixelStride];
 
-    public DateColumnWriter(TypeDescription type, int pixelStride, EncodingLevel encodingLevel, ByteOrder byteOrder)
+    public DateColumnWriter(TypeDescription type,  PixelsWriterOption writerOption)
     {
-        super(type, pixelStride, encodingLevel, byteOrder);
+        super(type, writerOption);
         // Issue #94: Date.getTime() can be negative if the date is before 1970-1-1.
         encoder = new RunLenIntEncoder(true, true);
     }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/DateColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/DateColumnWriter.java
@@ -81,6 +81,19 @@ public class DateColumnWriter extends BaseColumnWriter
             {
                 hasNull = true;
                 pixelStatRecorder.increment();
+                if (nullsPadding)
+                {
+                    // padding 0 or previous value for nulls, this is friendly for run-length encoding
+                    if (curPixelVectorIndex <= 0)
+                    {
+                        curPixelVector[curPixelVectorIndex] = 0;
+                    }
+                    else
+                    {
+                        curPixelVector[curPixelVectorIndex] = curPixelVector[curPixelVectorIndex-1];
+                    }
+                    curPixelVectorIndex ++;
+                }
             }
             else
             {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/DecimalColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/DecimalColumnWriter.java
@@ -32,6 +32,7 @@ import java.nio.ByteOrder;
  * <p><b>Note: it only supports short decimals with max precision and scale 18.</b></p>
  *
  * @author hank
+ * @update 2023-08-16 Chamonix: support nulls padding
  */
 public class DecimalColumnWriter extends BaseColumnWriter
 {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/DecimalColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/DecimalColumnWriter.java
@@ -20,7 +20,6 @@
 package io.pixelsdb.pixels.core.writer;
 
 import io.pixelsdb.pixels.core.TypeDescription;
-import io.pixelsdb.pixels.core.encoding.EncodingLevel;
 import io.pixelsdb.pixels.core.utils.EncodingUtils;
 import io.pixelsdb.pixels.core.vector.ColumnVector;
 import io.pixelsdb.pixels.core.vector.DecimalColumnVector;
@@ -38,9 +37,9 @@ public class DecimalColumnWriter extends BaseColumnWriter
 {
     private final EncodingUtils encodingUtils;
 
-    public DecimalColumnWriter(TypeDescription type, int pixelStride, EncodingLevel encodingLevel, ByteOrder byteOrder)
+    public DecimalColumnWriter(TypeDescription type,  PixelsWriterOption writerOption)
     {
-        super(type, pixelStride, encodingLevel, byteOrder);
+        super(type, writerOption);
         encodingUtils = new EncodingUtils();
     }
 

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/DecimalColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/DecimalColumnWriter.java
@@ -59,7 +59,7 @@ public class DecimalColumnWriter extends BaseColumnWriter
                 pixelStatRecorder.increment();
                 if (nullsPadding)
                 {
-                    // padding 0 for nulls, no need to update statistics
+                    // padding 0 for nulls
                     encodingUtils.writeLongLE(outputStream, 0L);
                 }
             }
@@ -82,5 +82,11 @@ public class DecimalColumnWriter extends BaseColumnWriter
             }
         }
         return outputStream.size();
+    }
+
+    @Override
+    public boolean decideNullsPadding(PixelsWriterOption writerOption)
+    {
+        return writerOption.isNullsPadding();
     }
 }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/DecimalColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/DecimalColumnWriter.java
@@ -57,6 +57,11 @@ public class DecimalColumnWriter extends BaseColumnWriter
             {
                 hasNull = true;
                 pixelStatRecorder.increment();
+                if (nullsPadding)
+                {
+                    // padding 0 for nulls, no need to update statistics
+                    encodingUtils.writeLongLE(outputStream, 0L);
+                }
             }
             else
             {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/DoubleColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/DoubleColumnWriter.java
@@ -20,7 +20,6 @@
 package io.pixelsdb.pixels.core.writer;
 
 import io.pixelsdb.pixels.core.TypeDescription;
-import io.pixelsdb.pixels.core.encoding.EncodingLevel;
 import io.pixelsdb.pixels.core.utils.EncodingUtils;
 import io.pixelsdb.pixels.core.vector.ColumnVector;
 import io.pixelsdb.pixels.core.vector.DoubleColumnVector;
@@ -37,9 +36,9 @@ public class DoubleColumnWriter extends BaseColumnWriter
 {
     private final EncodingUtils encodingUtils;
 
-    public DoubleColumnWriter(TypeDescription type, int pixelStride, EncodingLevel encodingLevel, ByteOrder byteOrder)
+    public DoubleColumnWriter(TypeDescription type,  PixelsWriterOption writerOption)
     {
-        super(type, pixelStride, encodingLevel, byteOrder);
+        super(type, writerOption);
         encodingUtils = new EncodingUtils();
     }
 

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/DoubleColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/DoubleColumnWriter.java
@@ -28,9 +28,10 @@ import java.io.IOException;
 import java.nio.ByteOrder;
 
 /**
- * pixels
+ * The column writer of double.
  *
- * @author guodong
+ * @author guodong, hank
+ * @update 2023-08-16 Chamonix: support nulls padding
  */
 public class DoubleColumnWriter extends BaseColumnWriter
 {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/DoubleColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/DoubleColumnWriter.java
@@ -56,6 +56,11 @@ public class DoubleColumnWriter extends BaseColumnWriter
             {
                 hasNull = true;
                 pixelStatRecorder.increment();
+                if (nullsPadding)
+                {
+                    // padding 0 for nulls, no need to update statistics
+                    encodingUtils.writeLongLE(outputStream, 0L);
+                }
             }
             else
             {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/DoubleColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/DoubleColumnWriter.java
@@ -58,7 +58,7 @@ public class DoubleColumnWriter extends BaseColumnWriter
                 pixelStatRecorder.increment();
                 if (nullsPadding)
                 {
-                    // padding 0 for nulls, no need to update statistics
+                    // padding 0 for nulls
                     encodingUtils.writeLongLE(outputStream, 0L);
                 }
             }
@@ -81,5 +81,11 @@ public class DoubleColumnWriter extends BaseColumnWriter
             }
         }
         return outputStream.size();
+    }
+
+    @Override
+    public boolean decideNullsPadding(PixelsWriterOption writerOption)
+    {
+        return writerOption.isNullsPadding();
     }
 }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/FloatColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/FloatColumnWriter.java
@@ -22,7 +22,7 @@ package io.pixelsdb.pixels.core.writer;
 import io.pixelsdb.pixels.core.TypeDescription;
 import io.pixelsdb.pixels.core.utils.EncodingUtils;
 import io.pixelsdb.pixels.core.vector.ColumnVector;
-import io.pixelsdb.pixels.core.vector.DoubleColumnVector;
+import io.pixelsdb.pixels.core.vector.FloatColumnVector;
 
 import java.io.IOException;
 import java.nio.ByteOrder;
@@ -32,6 +32,7 @@ import java.nio.ByteOrder;
  *
  * @author guodong, hank
  * @update 2023-08-16 Chamonix: support nulls padding
+ * @update 2023-08-20 Palezieux: use FloatColumnVector instead of DoubleColumnVector
  */
 public class FloatColumnWriter extends BaseColumnWriter
 {
@@ -46,8 +47,8 @@ public class FloatColumnWriter extends BaseColumnWriter
     @Override
     public int write(ColumnVector vector, int length) throws IOException
     {
-        DoubleColumnVector columnVector = (DoubleColumnVector) vector;
-        long[] values = columnVector.vector;
+        FloatColumnVector columnVector = (FloatColumnVector) vector;
+        int[] values = columnVector.vector;
         boolean littleEndian = this.byteOrder.equals(ByteOrder.LITTLE_ENDIAN);
         for (int i = 0; i < length; i++)
         {
@@ -65,16 +66,15 @@ public class FloatColumnWriter extends BaseColumnWriter
             }
             else
             {
-                int v = (int) values[i];
                 if (littleEndian)
                 {
-                    encodingUtils.writeIntLE(outputStream, v);
+                    encodingUtils.writeIntLE(outputStream, values[i]);
                 }
                 else
                 {
-                    encodingUtils.writeIntBE(outputStream, v);
+                    encodingUtils.writeIntBE(outputStream, values[i]);
                 }
-                pixelStatRecorder.updateFloat(Float.intBitsToFloat(v));
+                pixelStatRecorder.updateFloat(Float.intBitsToFloat(values[i]));
             }
             // if current pixel size satisfies the pixel stride, end the current pixel and start a new one
             if (curPixelEleIndex >= pixelStride)

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/FloatColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/FloatColumnWriter.java
@@ -72,7 +72,7 @@ public class FloatColumnWriter extends BaseColumnWriter
                 }
                 else
                 {
-                    encodingUtils.writeLongBE(outputStream, v);
+                    encodingUtils.writeIntBE(outputStream, v);
                 }
                 pixelStatRecorder.updateFloat(Float.intBitsToFloat(v));
             }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/FloatColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/FloatColumnWriter.java
@@ -56,6 +56,11 @@ public class FloatColumnWriter extends BaseColumnWriter
             {
                 hasNull = true;
                 pixelStatRecorder.increment();
+                if (nullsPadding)
+                {
+                    // padding 0 for nulls, no need to update statistics
+                    encodingUtils.writeIntLE(outputStream, 0);
+                }
             }
             else
             {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/FloatColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/FloatColumnWriter.java
@@ -58,7 +58,7 @@ public class FloatColumnWriter extends BaseColumnWriter
                 pixelStatRecorder.increment();
                 if (nullsPadding)
                 {
-                    // padding 0 for nulls, no need to update statistics
+                    // padding 0 for nulls
                     encodingUtils.writeIntLE(outputStream, 0);
                 }
             }
@@ -82,5 +82,11 @@ public class FloatColumnWriter extends BaseColumnWriter
             }
         }
         return outputStream.size();
+    }
+
+    @Override
+    public boolean decideNullsPadding(PixelsWriterOption writerOption)
+    {
+        return writerOption.isNullsPadding();
     }
 }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/FloatColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/FloatColumnWriter.java
@@ -28,9 +28,10 @@ import java.io.IOException;
 import java.nio.ByteOrder;
 
 /**
- * pixels
+ * The column writer of float.
  *
- * @author guodong
+ * @author guodong, hank
+ * @update 2023-08-16 Chamonix: support nulls padding
  */
 public class FloatColumnWriter extends BaseColumnWriter
 {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/FloatColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/FloatColumnWriter.java
@@ -20,7 +20,6 @@
 package io.pixelsdb.pixels.core.writer;
 
 import io.pixelsdb.pixels.core.TypeDescription;
-import io.pixelsdb.pixels.core.encoding.EncodingLevel;
 import io.pixelsdb.pixels.core.utils.EncodingUtils;
 import io.pixelsdb.pixels.core.vector.ColumnVector;
 import io.pixelsdb.pixels.core.vector.DoubleColumnVector;
@@ -37,9 +36,9 @@ public class FloatColumnWriter extends BaseColumnWriter
 {
     private final EncodingUtils encodingUtils;
 
-    public FloatColumnWriter(TypeDescription type, int pixelStride, EncodingLevel encodingLevel, ByteOrder byteOrder)
+    public FloatColumnWriter(TypeDescription type,  PixelsWriterOption writerOption)
     {
-        super(type, pixelStride, encodingLevel, byteOrder);
+        super(type, writerOption);
         encodingUtils = new EncodingUtils();
     }
 

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/IntegerColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/IntegerColumnWriter.java
@@ -30,11 +30,10 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 
 /**
- * Integer column writer.
- * If encoding, use RunLength;
- * Else isLong(1 byte) + content
+ * The column writer for integers.
  *
- * @author guodong
+ * @author guodong, hank
+ * @update 2023-08-16 Chamonix: support nulls padding
  */
 public class IntegerColumnWriter extends BaseColumnWriter
 {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/IntegerColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/IntegerColumnWriter.java
@@ -98,7 +98,7 @@ public class IntegerColumnWriter extends BaseColumnWriter
     void newPixel() throws IOException
     {
         // write out current pixel vector
-        if (encodingLevel.ge(EncodingLevel.EL1))
+        if (encodingLevel.ge(EncodingLevel.EL2))
         {
             for (int i = 0; i < curPixelVectorIndex; i++)
             {
@@ -138,7 +138,7 @@ public class IntegerColumnWriter extends BaseColumnWriter
     @Override
     public PixelsProto.ColumnEncoding.Builder getColumnChunkEncoding()
     {
-        if (encodingLevel.ge(EncodingLevel.EL1))
+        if (encodingLevel.ge(EncodingLevel.EL2))
         {
             return PixelsProto.ColumnEncoding.newBuilder()
                     .setKind(PixelsProto.ColumnEncoding.Kind.RUNLENGTH);

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/IntegerColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/IntegerColumnWriter.java
@@ -40,12 +40,17 @@ public class IntegerColumnWriter extends BaseColumnWriter
 {
     private final long[] curPixelVector = new long[pixelStride];        // current pixel value vector haven't written out yet
     private final boolean isLong;                                       // current column type is long or int, used for the first pixel
+    private final boolean runlengthEncoding;
 
     public IntegerColumnWriter(TypeDescription type,  PixelsWriterOption writerOption)
     {
         super(type, writerOption);
-        encoder = new RunLenIntEncoder();
-        this.isLong = type.getCategory() == TypeDescription.Category.LONG;
+        isLong = type.getCategory() == TypeDescription.Category.LONG;
+        runlengthEncoding = encodingLevel.ge(EncodingLevel.EL2);
+        if (runlengthEncoding)
+        {
+            encoder = new RunLenIntEncoder();
+        }
     }
 
     @Override
@@ -85,16 +90,8 @@ public class IntegerColumnWriter extends BaseColumnWriter
                 pixelStatRecorder.increment();
                 if (nullsPadding)
                 {
-                    // padding 0 or previous value for nulls, this is friendly for run-length encoding
-                    if (curPixelVectorIndex <= 0)
-                    {
-                        curPixelVector[curPixelVectorIndex] = 0L;
-                    }
-                    else
-                    {
-                        curPixelVector[curPixelVectorIndex] = curPixelVector[curPixelVectorIndex-1];
-                    }
-                    curPixelVectorIndex ++;
+                    // padding 0 for nulls
+                    curPixelVector[curPixelVectorIndex++] = 0L;
                 }
             }
             else
@@ -110,7 +107,7 @@ public class IntegerColumnWriter extends BaseColumnWriter
     void newPixel() throws IOException
     {
         // write out current pixel vector
-        if (encodingLevel.ge(EncodingLevel.EL2))
+        if (runlengthEncoding)
         {
             for (int i = 0; i < curPixelVectorIndex; i++)
             {
@@ -150,7 +147,7 @@ public class IntegerColumnWriter extends BaseColumnWriter
     @Override
     public PixelsProto.ColumnEncoding.Builder getColumnChunkEncoding()
     {
-        if (encodingLevel.ge(EncodingLevel.EL2))
+        if (runlengthEncoding)
         {
             return PixelsProto.ColumnEncoding.newBuilder()
                     .setKind(PixelsProto.ColumnEncoding.Kind.RUNLENGTH);
@@ -160,10 +157,22 @@ public class IntegerColumnWriter extends BaseColumnWriter
     }
 
     @Override
-    public void close()
-            throws IOException
+    public void close() throws IOException
     {
-        encoder.close();
+        if (runlengthEncoding)
+        {
+            encoder.close();
+        }
         super.close();
+    }
+
+    @Override
+    public boolean decideNullsPadding(PixelsWriterOption writerOption)
+    {
+        if (writerOption.getEncodingLevel().ge(EncodingLevel.EL2))
+        {
+            return false;
+        }
+        return writerOption.isNullsPadding();
     }
 }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/IntegerColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/IntegerColumnWriter.java
@@ -28,7 +28,6 @@ import io.pixelsdb.pixels.core.vector.LongColumnVector;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 
 /**
  * Integer column writer.
@@ -42,9 +41,9 @@ public class IntegerColumnWriter extends BaseColumnWriter
     private final long[] curPixelVector = new long[pixelStride];        // current pixel value vector haven't written out yet
     private final boolean isLong;                                       // current column type is long or int, used for the first pixel
 
-    public IntegerColumnWriter(TypeDescription type, int pixelStride, EncodingLevel encodingLevel, ByteOrder byteOrder)
+    public IntegerColumnWriter(TypeDescription type,  PixelsWriterOption writerOption)
     {
-        super(type, pixelStride, encodingLevel, byteOrder);
+        super(type, writerOption);
         encoder = new RunLenIntEncoder();
         this.isLong = type.getCategory() == TypeDescription.Category.LONG;
     }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/IntegerColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/IntegerColumnWriter.java
@@ -83,6 +83,19 @@ public class IntegerColumnWriter extends BaseColumnWriter
             {
                 hasNull = true;
                 pixelStatRecorder.increment();
+                if (nullsPadding)
+                {
+                    // padding 0 or previous value for nulls, this is friendly for run-length encoding
+                    if (curPixelVectorIndex <= 0)
+                    {
+                        curPixelVector[curPixelVectorIndex] = 0L;
+                    }
+                    else
+                    {
+                        curPixelVector[curPixelVectorIndex] = curPixelVector[curPixelVectorIndex-1];
+                    }
+                    curPixelVectorIndex ++;
+                }
             }
             else
             {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/LongDecimalColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/LongDecimalColumnWriter.java
@@ -31,8 +31,9 @@ import java.nio.ByteOrder;
  * The column writer of long decimals.
  * <p><b>Note: it supports decimals with max precision and scale 38.</b></p>
  *
- * @create 2022-07-01
  * @author hank
+ * @create 2022-07-01
+ * @update 2023-08-16 Chamonix: support nulls padding
  */
 public class LongDecimalColumnWriter extends BaseColumnWriter
 {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/LongDecimalColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/LongDecimalColumnWriter.java
@@ -63,21 +63,22 @@ public class LongDecimalColumnWriter extends BaseColumnWriter
                 {
                     // padding 0 for nulls
                     encodingUtils.writeLongLE(outputStream, 0L);
+                    encodingUtils.writeLongLE(outputStream, 0L);
                 }
             }
             else
             {
                 if (littleEndian)
                 {
-                    encodingUtils.writeLongLE(outputStream, values[i * 2]);
-                    encodingUtils.writeLongLE(outputStream, values[i * 2 + 1]);
+                    encodingUtils.writeLongLE(outputStream, values[i << 1]);
+                    encodingUtils.writeLongLE(outputStream, values[(i << 1) + 1]);
                 }
                 else
                 {
-                    encodingUtils.writeLongBE(outputStream, values[i * 2]);
-                    encodingUtils.writeLongBE(outputStream, values[i * 2 + 1]);
+                    encodingUtils.writeLongBE(outputStream, values[i << 1]);
+                    encodingUtils.writeLongBE(outputStream, values[(i << 1) + 1]);
                 }
-                pixelStatRecorder.updateInteger128(values[i*2], values[i*2+1], 1);
+                pixelStatRecorder.updateInteger128(values[i << 1], values[(i << 1) + 1], 1);
             }
             // if current pixel size satisfies the pixel stride, end the current pixel and start a new one
             if (curPixelEleIndex >= pixelStride)

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/LongDecimalColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/LongDecimalColumnWriter.java
@@ -60,7 +60,7 @@ public class LongDecimalColumnWriter extends BaseColumnWriter
                 pixelStatRecorder.increment();
                 if (nullsPadding)
                 {
-                    // padding 0 for nulls, no need to update statistics
+                    // padding 0 for nulls
                     encodingUtils.writeLongLE(outputStream, 0L);
                 }
             }
@@ -85,5 +85,11 @@ public class LongDecimalColumnWriter extends BaseColumnWriter
             }
         }
         return outputStream.size();
+    }
+
+    @Override
+    public boolean decideNullsPadding(PixelsWriterOption writerOption)
+    {
+        return writerOption.isNullsPadding();
     }
 }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/LongDecimalColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/LongDecimalColumnWriter.java
@@ -58,6 +58,11 @@ public class LongDecimalColumnWriter extends BaseColumnWriter
             {
                 hasNull = true;
                 pixelStatRecorder.increment();
+                if (nullsPadding)
+                {
+                    // padding 0 for nulls, no need to update statistics
+                    encodingUtils.writeLongLE(outputStream, 0L);
+                }
             }
             else
             {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/LongDecimalColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/LongDecimalColumnWriter.java
@@ -20,7 +20,6 @@
 package io.pixelsdb.pixels.core.writer;
 
 import io.pixelsdb.pixels.core.TypeDescription;
-import io.pixelsdb.pixels.core.encoding.EncodingLevel;
 import io.pixelsdb.pixels.core.utils.EncodingUtils;
 import io.pixelsdb.pixels.core.vector.ColumnVector;
 import io.pixelsdb.pixels.core.vector.LongDecimalColumnVector;
@@ -39,9 +38,9 @@ public class LongDecimalColumnWriter extends BaseColumnWriter
 {
     private final EncodingUtils encodingUtils;
 
-    public LongDecimalColumnWriter(TypeDescription type, int pixelStride, EncodingLevel encodingLevel, ByteOrder byteOrder)
+    public LongDecimalColumnWriter(TypeDescription type,  PixelsWriterOption writerOption)
     {
-        super(type, pixelStride, encodingLevel, byteOrder);
+        super(type, writerOption);
         encodingUtils = new EncodingUtils();
     }
 

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/PixelsWriterOption.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/PixelsWriterOption.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2023 PixelsDB.
+ *
+ * This file is part of Pixels.
+ *
+ * Pixels is free software: you can redistribute it and/or modify
+ * it under the terms of the Affero GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * Pixels is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Affero GNU General Public License for more details.
+ *
+ * You should have received a copy of the Affero GNU General Public
+ * License along with Pixels.  If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package io.pixelsdb.pixels.core.writer;
+
+import io.pixelsdb.pixels.core.encoding.EncodingLevel;
+
+import java.nio.ByteOrder;
+
+/**
+ * @author hank
+ * @create 2023-08-14
+ */
+public class PixelsWriterOption
+{
+    /**
+     * The number of values in each pixel.
+     */
+    private int pixelStride;
+    private EncodingLevel encodingLevel;
+    private ByteOrder byteOrder;
+    /**
+     * Whether nulls positions in column are padded by arbitrary values and occupy storage and memory space.
+     */
+    private boolean nullsPadded;
+
+    public PixelsWriterOption() { }
+
+    public int getPixelStride()
+    {
+        return pixelStride;
+    }
+
+    public PixelsWriterOption pixelStride(int pixelStride)
+    {
+        this.pixelStride = pixelStride;
+        return this;
+    }
+
+    public EncodingLevel getEncodingLevel()
+    {
+        return encodingLevel;
+    }
+
+    public PixelsWriterOption encodingLevel(EncodingLevel encodingLevel)
+    {
+        this.encodingLevel = encodingLevel;
+        return this;
+    }
+
+    public ByteOrder getByteOrder()
+    {
+        return byteOrder;
+    }
+
+    public PixelsWriterOption byteOrder(ByteOrder byteOrder)
+    {
+        this.byteOrder = byteOrder;
+        return this;
+    }
+
+    public boolean isNullsPadded()
+    {
+        return nullsPadded;
+    }
+
+    public PixelsWriterOption nullsPadded(boolean nullsPadded)
+    {
+        this.nullsPadded = nullsPadded;
+        return this;
+    }
+}

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/PixelsWriterOption.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/PixelsWriterOption.java
@@ -38,7 +38,7 @@ public class PixelsWriterOption
     /**
      * Whether nulls positions in column are padded by arbitrary values and occupy storage and memory space.
      */
-    private boolean nullsPadded;
+    private boolean nullsPadding;
 
     public PixelsWriterOption() { }
 
@@ -75,14 +75,14 @@ public class PixelsWriterOption
         return this;
     }
 
-    public boolean isNullsPadded()
+    public boolean isNullsPadding()
     {
-        return nullsPadded;
+        return nullsPadding;
     }
 
-    public PixelsWriterOption nullsPadded(boolean nullsPadded)
+    public PixelsWriterOption nullsPadding(boolean nullsPadding)
     {
-        this.nullsPadded = nullsPadded;
+        this.nullsPadding = nullsPadding;
         return this;
     }
 }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/StringColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/StringColumnWriter.java
@@ -123,8 +123,11 @@ public class StringColumnWriter extends BaseColumnWriter
         for (int i = 0; i < curPartLength; i++)
         {
             curPixelEleIndex++;
-            // add starts even if the current value is null, this is for random access
-            startsArray.add(startOffset);
+            if (nullsPadding)
+            {
+                // add starts even if the current value is null, this is for random access
+                startsArray.add(startOffset);
+            }
             if (columnVector.isNull[curPartOffset + i])
             {
                 hasNull = true;
@@ -152,6 +155,19 @@ public class StringColumnWriter extends BaseColumnWriter
             {
                 hasNull = true;
                 pixelStatRecorder.increment();
+                if (nullsPadding)
+                {
+                    // padding 0 or previous value for nulls, this is friendly for run-length encoding
+                    if (curPixelVectorIndex <= 0)
+                    {
+                        curPixelVector[curPixelVectorIndex] = 0;
+                    }
+                    else
+                    {
+                        curPixelVector[curPixelVectorIndex] = curPixelVector[curPixelVectorIndex-1];
+                    }
+                    curPixelVectorIndex ++;
+                }
             }
             else
             {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/StringColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/StringColumnWriter.java
@@ -139,19 +139,20 @@ public class StringColumnWriter extends BaseColumnWriter
         for (int i = 0; i < curPartLength; i++)
         {
             curPixelEleIndex++;
-            if (nullsPadding)
-            {
-                // add starts even if the current value is null, this is for random access
-                startsArray.add(startOffset);
-            }
             if (columnVector.isNull[curPartOffset + i])
             {
                 hasNull = true;
                 pixelStatRecorder.increment();
+                if (nullsPadding)
+                {
+                    // add starts even if the current value is null, this is for random access
+                    startsArray.add(startOffset);
+                }
             }
             else
             {
                 outputStream.write(values[curPartOffset + i], vOffsets[curPartOffset + i], vLens[curPartOffset + i]);
+                startsArray.add(startOffset);
                 startOffset += vLens[curPartOffset + i];
                 pixelStatRecorder.updateString(values[curPartOffset + i], vOffsets[curPartOffset + i],
                         vLens[curPartOffset + i], 1);

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/StringColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/StringColumnWriter.java
@@ -66,9 +66,9 @@ public class StringColumnWriter extends BaseColumnWriter
     private final EncodingUtils encodingUtils;
     private int startOffset = 0; // the start offset for the current string when un-encoded
 
-    public StringColumnWriter(TypeDescription type, int pixelStride, EncodingLevel encodingLevel, ByteOrder byteOrder)
+    public StringColumnWriter(TypeDescription type,  PixelsWriterOption writerOption)
     {
-        super(type, pixelStride, encodingLevel, byteOrder);
+        super(type, writerOption);
         this.curPixelVector = new int[pixelStride];
         this.encodingUtils = new EncodingUtils();
         encoder = new RunLenIntEncoder(false, true);

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/TimeColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/TimeColumnWriter.java
@@ -80,6 +80,19 @@ public class TimeColumnWriter extends BaseColumnWriter
             {
                 hasNull = true;
                 pixelStatRecorder.increment();
+                if (nullsPadding)
+                {
+                    // padding 0 or previous value for nulls, this is friendly for run-length encoding
+                    if (curPixelVectorIndex <= 0)
+                    {
+                        curPixelVector[curPixelVectorIndex] = 0;
+                    }
+                    else
+                    {
+                        curPixelVector[curPixelVectorIndex] = curPixelVector[curPixelVectorIndex-1];
+                    }
+                    curPixelVectorIndex ++;
+                }
             }
             else
             {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/TimeColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/TimeColumnWriter.java
@@ -23,22 +23,26 @@ import io.pixelsdb.pixels.core.PixelsProto;
 import io.pixelsdb.pixels.core.TypeDescription;
 import io.pixelsdb.pixels.core.encoding.EncodingLevel;
 import io.pixelsdb.pixels.core.encoding.RunLenIntEncoder;
+import io.pixelsdb.pixels.core.utils.EncodingUtils;
 import io.pixelsdb.pixels.core.vector.ColumnVector;
 import io.pixelsdb.pixels.core.vector.TimeColumnVector;
 
 import java.io.IOException;
-import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 
 /**
  * Time column writer.
  * All time values are converted to standard UTC time before they are stored as int values.
  *
- * 2021-04-25
  * @author hank
+ * @create 2021-04-25
+ * @update 2023-08-16 Chamonix: support nulls padding
+ * @update 2023-08-19 Zermatt: reduce memory copy and fix curPixelsVector encoding when the current pixel contains nulls
  */
 public class TimeColumnWriter extends BaseColumnWriter
 {
     private final int[] curPixelVector = new int[pixelStride];
+    private final EncodingUtils encodingUtils = new EncodingUtils();
     private final boolean runlengthEncoding;
 
     public TimeColumnWriter(TypeDescription type,  PixelsWriterOption writerOption)
@@ -109,20 +113,24 @@ public class TimeColumnWriter extends BaseColumnWriter
             {
                 pixelStatRecorder.updateTime(curPixelVector[i]);
             }
-            outputStream.write(encoder.encode(curPixelVector));
+            outputStream.write(encoder.encode(curPixelVector, 0, curPixelVectorIndex));
         }
         else
         {
-            ByteBuffer curVecPartitionBuffer = ByteBuffer.allocate(curPixelVectorIndex * Integer.BYTES);
-            curVecPartitionBuffer.order(byteOrder);
+            boolean littleEndian = byteOrder.equals(ByteOrder.LITTLE_ENDIAN);
             for (int i = 0; i < curPixelVectorIndex; i++)
             {
-                curVecPartitionBuffer.putInt(curPixelVector[i]);
+                if (littleEndian)
+                {
+                    encodingUtils.writeIntLE(outputStream, curPixelVector[i]);
+                }
+                else
+                {
+                    encodingUtils.writeIntBE(outputStream, curPixelVector[i]);
+                }
                 pixelStatRecorder.updateTime(curPixelVector[i]);
             }
-            outputStream.write(curVecPartitionBuffer.array());
         }
-
         super.newPixel();
     }
 

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/TimeColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/TimeColumnWriter.java
@@ -39,12 +39,17 @@ import java.nio.ByteBuffer;
 public class TimeColumnWriter extends BaseColumnWriter
 {
     private final int[] curPixelVector = new int[pixelStride];
+    private final boolean runlengthEncoding;
 
     public TimeColumnWriter(TypeDescription type,  PixelsWriterOption writerOption)
     {
         super(type, writerOption);
-        // time is likely to be negative according to different time zone.
-        encoder = new RunLenIntEncoder(true, true);
+        runlengthEncoding = encodingLevel.ge(EncodingLevel.EL2);
+        if (runlengthEncoding)
+        {
+            // time is likely to be negative according to different time zone.
+            encoder = new RunLenIntEncoder(true, true);
+        }
     }
 
     @Override
@@ -82,16 +87,8 @@ public class TimeColumnWriter extends BaseColumnWriter
                 pixelStatRecorder.increment();
                 if (nullsPadding)
                 {
-                    // padding 0 or previous value for nulls, this is friendly for run-length encoding
-                    if (curPixelVectorIndex <= 0)
-                    {
-                        curPixelVector[curPixelVectorIndex] = 0;
-                    }
-                    else
-                    {
-                        curPixelVector[curPixelVectorIndex] = curPixelVector[curPixelVectorIndex-1];
-                    }
-                    curPixelVectorIndex ++;
+                    // padding 0 for nulls
+                    curPixelVector[curPixelVectorIndex++] = 0;
                 }
             }
             else
@@ -106,20 +103,17 @@ public class TimeColumnWriter extends BaseColumnWriter
     @Override
     public void newPixel() throws IOException
     {
-        if (encodingLevel.ge(EncodingLevel.EL2))
+        if (runlengthEncoding)
         {
             for (int i = 0; i < curPixelVectorIndex; i++)
             {
                 pixelStatRecorder.updateTime(curPixelVector[i]);
             }
-            int[] values = new int[curPixelVectorIndex];
-            System.arraycopy(curPixelVector, 0, values, 0, curPixelVectorIndex);
-            outputStream.write(encoder.encode(values));
+            outputStream.write(encoder.encode(curPixelVector));
         }
         else
         {
-            ByteBuffer curVecPartitionBuffer =
-                    ByteBuffer.allocate(curPixelVectorIndex * Integer.BYTES);
+            ByteBuffer curVecPartitionBuffer = ByteBuffer.allocate(curPixelVectorIndex * Integer.BYTES);
             curVecPartitionBuffer.order(byteOrder);
             for (int i = 0; i < curPixelVectorIndex; i++)
             {
@@ -135,7 +129,7 @@ public class TimeColumnWriter extends BaseColumnWriter
     @Override
     public PixelsProto.ColumnEncoding.Builder getColumnChunkEncoding()
     {
-        if (encodingLevel.ge(EncodingLevel.EL2))
+        if (runlengthEncoding)
         {
             return PixelsProto.ColumnEncoding.newBuilder()
                     .setKind(PixelsProto.ColumnEncoding.Kind.RUNLENGTH);
@@ -147,7 +141,20 @@ public class TimeColumnWriter extends BaseColumnWriter
     @Override
     public void close() throws IOException
     {
-        encoder.close();
+        if (runlengthEncoding)
+        {
+            encoder.close();
+        }
         super.close();
+    }
+
+    @Override
+    public boolean decideNullsPadding(PixelsWriterOption writerOption)
+    {
+        if (writerOption.getEncodingLevel().ge(EncodingLevel.EL2))
+        {
+            return false;
+        }
+        return writerOption.isNullsPadding();
     }
 }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/TimeColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/TimeColumnWriter.java
@@ -94,7 +94,7 @@ public class TimeColumnWriter extends BaseColumnWriter
     @Override
     public void newPixel() throws IOException
     {
-        if (encodingLevel.ge(EncodingLevel.EL1))
+        if (encodingLevel.ge(EncodingLevel.EL2))
         {
             for (int i = 0; i < curPixelVectorIndex; i++)
             {
@@ -123,7 +123,7 @@ public class TimeColumnWriter extends BaseColumnWriter
     @Override
     public PixelsProto.ColumnEncoding.Builder getColumnChunkEncoding()
     {
-        if (encodingLevel.ge(EncodingLevel.EL1))
+        if (encodingLevel.ge(EncodingLevel.EL2))
         {
             return PixelsProto.ColumnEncoding.newBuilder()
                     .setKind(PixelsProto.ColumnEncoding.Kind.RUNLENGTH);

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/TimeColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/TimeColumnWriter.java
@@ -28,7 +28,6 @@ import io.pixelsdb.pixels.core.vector.TimeColumnVector;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 
 /**
  * Time column writer.
@@ -41,9 +40,9 @@ public class TimeColumnWriter extends BaseColumnWriter
 {
     private final int[] curPixelVector = new int[pixelStride];
 
-    public TimeColumnWriter(TypeDescription type, int pixelStride, EncodingLevel encodingLevel, ByteOrder byteOrder)
+    public TimeColumnWriter(TypeDescription type,  PixelsWriterOption writerOption)
     {
-        super(type, pixelStride, encodingLevel, byteOrder);
+        super(type, writerOption);
         // time is likely to be negative according to different time zone.
         encoder = new RunLenIntEncoder(true, true);
     }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/TimestampColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/TimestampColumnWriter.java
@@ -93,7 +93,7 @@ public class TimestampColumnWriter extends BaseColumnWriter
     @Override
     public void newPixel() throws IOException
     {
-        if (encodingLevel.ge(EncodingLevel.EL1))
+        if (encodingLevel.ge(EncodingLevel.EL2))
         {
             for (int i = 0; i < curPixelVectorIndex; i++)
             {
@@ -122,7 +122,7 @@ public class TimestampColumnWriter extends BaseColumnWriter
     @Override
     public PixelsProto.ColumnEncoding.Builder getColumnChunkEncoding()
     {
-        if (encodingLevel.ge(EncodingLevel.EL1))
+        if (encodingLevel.ge(EncodingLevel.EL2))
         {
             return PixelsProto.ColumnEncoding.newBuilder()
                     .setKind(PixelsProto.ColumnEncoding.Kind.RUNLENGTH);

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/TimestampColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/TimestampColumnWriter.java
@@ -28,7 +28,6 @@ import io.pixelsdb.pixels.core.vector.TimestampColumnVector;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 
 /**
  * Timestamp column writer.
@@ -40,9 +39,9 @@ public class TimestampColumnWriter extends BaseColumnWriter
 {
     private final long[] curPixelVector = new long[pixelStride];
 
-    public TimestampColumnWriter(TypeDescription type, int pixelStride, EncodingLevel encodingLevel, ByteOrder byteOrder)
+    public TimestampColumnWriter(TypeDescription type,  PixelsWriterOption writerOption)
     {
-        super(type, pixelStride, encodingLevel, byteOrder);
+        super(type, writerOption);
         // Issue #94: time can be negative if it is before 1970-1-1 0:0:0.
         encoder = new RunLenIntEncoder(true, true);
     }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/TimestampColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/TimestampColumnWriter.java
@@ -23,21 +23,26 @@ import io.pixelsdb.pixels.core.PixelsProto;
 import io.pixelsdb.pixels.core.TypeDescription;
 import io.pixelsdb.pixels.core.encoding.EncodingLevel;
 import io.pixelsdb.pixels.core.encoding.RunLenIntEncoder;
+import io.pixelsdb.pixels.core.utils.EncodingUtils;
 import io.pixelsdb.pixels.core.vector.ColumnVector;
 import io.pixelsdb.pixels.core.vector.TimestampColumnVector;
 
 import java.io.IOException;
-import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 
 /**
  * Timestamp column writer.
  * All timestamp values are converted to standard UTC time before they are stored as long values.
  *
- * @author hank
+ * @author hank, guodong
+ * @create 2017-08-06
+ * @update 2023-08-16 Chamonix: support nulls padding
+ * @update 2023-08-19 Zermatt: reduce memory copy and fix curPixelsVector encoding when the current pixel contains nulls
  */
 public class TimestampColumnWriter extends BaseColumnWriter
 {
     private final long[] curPixelVector = new long[pixelStride];
+    private final EncodingUtils encodingUtils = new EncodingUtils();
     private final boolean runlengthEncoding;
 
     public TimestampColumnWriter(TypeDescription type,  PixelsWriterOption writerOption)
@@ -109,20 +114,24 @@ public class TimestampColumnWriter extends BaseColumnWriter
             {
                 pixelStatRecorder.updateTimestamp(curPixelVector[i]);
             }
-            outputStream.write(encoder.encode(curPixelVector));
+            outputStream.write(encoder.encode(curPixelVector, 0, curPixelVectorIndex));
         }
         else
         {
-            ByteBuffer curVecPartitionBuffer = ByteBuffer.allocate(curPixelVectorIndex * Long.BYTES);
-            curVecPartitionBuffer.order(byteOrder);
+            boolean littleEndian = byteOrder.equals(ByteOrder.LITTLE_ENDIAN);
             for (int i = 0; i < curPixelVectorIndex; i++)
             {
-                curVecPartitionBuffer.putLong(curPixelVector[i]);
+                if (littleEndian)
+                {
+                    encodingUtils.writeLongLE(outputStream, curPixelVector[i]);
+                }
+                else
+                {
+                    encodingUtils.writeLongBE(outputStream, curPixelVector[i]);
+                }
                 pixelStatRecorder.updateTimestamp(curPixelVector[i]);
             }
-            outputStream.write(curVecPartitionBuffer.array());
         }
-
         super.newPixel();
     }
 

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/TimestampColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/TimestampColumnWriter.java
@@ -58,19 +58,20 @@ public class TimestampColumnWriter extends BaseColumnWriter
         while ((curPixelIsNullIndex + nextPartLength) >= pixelStride)
         {
             curPartLength = pixelStride - curPixelIsNullIndex;
-            writeCurPartTime(columnVector, times, curPartLength, curPartOffset);
+            writeCurPartTimestamp(columnVector, times, curPartLength, curPartOffset);
             newPixel();
             curPartOffset += curPartLength;
             nextPartLength = size - curPartOffset;
         }
 
         curPartLength = nextPartLength;
-        writeCurPartTime(columnVector, times, curPartLength, curPartOffset);
+        writeCurPartTimestamp(columnVector, times, curPartLength, curPartOffset);
 
         return outputStream.size();
     }
 
-    private void writeCurPartTime(TimestampColumnVector columnVector, long[] values, int curPartLength, int curPartOffset)
+    private void writeCurPartTimestamp(TimestampColumnVector columnVector,
+                                       long[] values, int curPartLength, int curPartOffset)
     {
         for (int i = 0; i < curPartLength; i++)
         {
@@ -79,6 +80,19 @@ public class TimestampColumnWriter extends BaseColumnWriter
             {
                 hasNull = true;
                 pixelStatRecorder.increment();
+                if (nullsPadding)
+                {
+                    // padding 0 or previous value for nulls, this is friendly for run-length encoding
+                    if (curPixelVectorIndex <= 0)
+                    {
+                        curPixelVector[curPixelVectorIndex] = 0L;
+                    }
+                    else
+                    {
+                        curPixelVector[curPixelVectorIndex] = curPixelVector[curPixelVectorIndex-1];
+                    }
+                    curPixelVectorIndex ++;
+                }
             }
             else
             {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/VarbinaryColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/VarbinaryColumnWriter.java
@@ -25,8 +25,8 @@ import io.pixelsdb.pixels.core.encoding.EncodingLevel;
 import java.nio.ByteOrder;
 
 /**
- * Created at: 04/03/2022
- * Author: hank
+ * @create 2022-03-04
+ * @author hank
  */
 public class VarbinaryColumnWriter extends BinaryColumnWriter
 {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/VarbinaryColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/VarbinaryColumnWriter.java
@@ -20,9 +20,6 @@
 package io.pixelsdb.pixels.core.writer;
 
 import io.pixelsdb.pixels.core.TypeDescription;
-import io.pixelsdb.pixels.core.encoding.EncodingLevel;
-
-import java.nio.ByteOrder;
 
 /**
  * @create 2022-03-04
@@ -30,8 +27,8 @@ import java.nio.ByteOrder;
  */
 public class VarbinaryColumnWriter extends BinaryColumnWriter
 {
-    public VarbinaryColumnWriter(TypeDescription type, int pixelStride, EncodingLevel encodingLevel, ByteOrder byteOrder)
+    public VarbinaryColumnWriter(TypeDescription type,  PixelsWriterOption writerOption)
     {
-        super(type, pixelStride, encodingLevel, byteOrder);
+        super(type, writerOption);
     }
 }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/VarcharColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/VarcharColumnWriter.java
@@ -20,12 +20,10 @@
 package io.pixelsdb.pixels.core.writer;
 
 import io.pixelsdb.pixels.core.TypeDescription;
-import io.pixelsdb.pixels.core.encoding.EncodingLevel;
 import io.pixelsdb.pixels.core.vector.BinaryColumnVector;
 import io.pixelsdb.pixels.core.vector.ColumnVector;
 
 import java.io.IOException;
-import java.nio.ByteOrder;
 
 /**
  * pixels column writer for <code>Varchar</code>
@@ -43,9 +41,9 @@ public class VarcharColumnWriter extends StringColumnWriter
     private final int maxLength;
     private int numTruncated;
 
-    public VarcharColumnWriter(TypeDescription type, int pixelStride, EncodingLevel encodingLevel, ByteOrder byteOrder)
+    public VarcharColumnWriter(TypeDescription type,  PixelsWriterOption writerOption)
     {
-        super(type, pixelStride, encodingLevel, byteOrder);
+        super(type, writerOption);
         this.maxLength = type.getMaxLength();
         this.numTruncated = 0;
     }

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestBooleanColumnReader.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestBooleanColumnReader.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2023 PixelsDB.
+ *
+ * This file is part of Pixels.
+ *
+ * Pixels is free software: you can redistribute it and/or modify
+ * it under the terms of the Affero GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * Pixels is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Affero GNU General Public License for more details.
+ *
+ * You should have received a copy of the Affero GNU General Public
+ * License along with Pixels.  If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package io.pixelsdb.pixels.core.reader;
+
+import io.pixelsdb.pixels.core.PixelsProto;
+import io.pixelsdb.pixels.core.TypeDescription;
+import io.pixelsdb.pixels.core.encoding.EncodingLevel;
+import io.pixelsdb.pixels.core.vector.ByteColumnVector;
+import io.pixelsdb.pixels.core.writer.BooleanColumnWriter;
+import io.pixelsdb.pixels.core.writer.PixelsWriterOption;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+/**
+ * @author hank
+ * @create 2023-08-18
+ */
+public class TestBooleanColumnReader
+{
+    @Test
+    public void test() throws IOException
+    {
+        PixelsWriterOption writerOption = new PixelsWriterOption()
+                .pixelStride(10).byteOrder(ByteOrder.LITTLE_ENDIAN)
+                .encodingLevel(EncodingLevel.EL0).nullsPadding(true);
+        BooleanColumnWriter columnWriter = new BooleanColumnWriter(TypeDescription.createBoolean(), writerOption);
+        ByteColumnVector byteColumnVector = new ByteColumnVector(22);
+        byteColumnVector.add(false);
+        byteColumnVector.add(false);
+        byteColumnVector.add(false);
+        byteColumnVector.add(true);
+        byteColumnVector.addNull();
+        byteColumnVector.add(false);
+        byteColumnVector.add(true);
+        byteColumnVector.add(true);
+        byteColumnVector.addNull();
+        byteColumnVector.add(false);
+        byteColumnVector.add(false);
+        byteColumnVector.add(false);
+        byteColumnVector.add(false);
+        byteColumnVector.add(true);
+        byteColumnVector.add(false);
+        byteColumnVector.add(false);
+        byteColumnVector.add(false);
+        byteColumnVector.add(false);
+        byteColumnVector.add(true);
+        byteColumnVector.add(false);
+        byteColumnVector.add(false);
+        byteColumnVector.add(true);
+        columnWriter.write(byteColumnVector, 22);
+        columnWriter.flush();
+        byte[] content = columnWriter.getColumnChunkContent();
+        PixelsProto.ColumnChunkIndex chunkIndex = columnWriter.getColumnChunkIndex().build();
+        PixelsProto.ColumnEncoding encoding = columnWriter.getColumnChunkEncoding().build();
+        BooleanColumnReader columnReader = new BooleanColumnReader(TypeDescription.createBoolean());
+        ByteColumnVector byteColumnVector1 = new ByteColumnVector(22);
+        columnReader.read(ByteBuffer.wrap(content), encoding, 0, 22, 10, 0, byteColumnVector1, chunkIndex);
+        for (int i = 0; i < 22; ++i)
+        {
+            if (!byteColumnVector1.noNulls && byteColumnVector1.isNull[i])
+            {
+                assert !byteColumnVector.noNulls && byteColumnVector.isNull[i];
+            }
+            else
+            {
+                assert byteColumnVector1.vector[i] == byteColumnVector.vector[i];
+            }
+        }
+    }
+}

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestBooleanColumnReader.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestBooleanColumnReader.java
@@ -43,7 +43,8 @@ public class TestBooleanColumnReader
         PixelsWriterOption writerOption = new PixelsWriterOption()
                 .pixelStride(10).byteOrder(ByteOrder.LITTLE_ENDIAN)
                 .encodingLevel(EncodingLevel.EL0).nullsPadding(true);
-        BooleanColumnWriter columnWriter = new BooleanColumnWriter(TypeDescription.createBoolean(), writerOption);
+        BooleanColumnWriter columnWriter = new BooleanColumnWriter(
+                TypeDescription.createBoolean(), writerOption);
         ByteColumnVector byteColumnVector = new ByteColumnVector(22);
         byteColumnVector.add(false);
         byteColumnVector.add(false);
@@ -74,7 +75,8 @@ public class TestBooleanColumnReader
         PixelsProto.ColumnEncoding encoding = columnWriter.getColumnChunkEncoding().build();
         BooleanColumnReader columnReader = new BooleanColumnReader(TypeDescription.createBoolean());
         ByteColumnVector byteColumnVector1 = new ByteColumnVector(22);
-        columnReader.read(ByteBuffer.wrap(content), encoding, 0, 22, 10, 0, byteColumnVector1, chunkIndex);
+        columnReader.read(ByteBuffer.wrap(content), encoding, 0, 22,
+                10, 0, byteColumnVector1, chunkIndex);
         for (int i = 0; i < 22; ++i)
         {
             if (!byteColumnVector1.noNulls && byteColumnVector1.isNull[i])

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestDateColumnReader.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestDateColumnReader.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2023 PixelsDB.
+ *
+ * This file is part of Pixels.
+ *
+ * Pixels is free software: you can redistribute it and/or modify
+ * it under the terms of the Affero GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * Pixels is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Affero GNU General Public License for more details.
+ *
+ * You should have received a copy of the Affero GNU General Public
+ * License along with Pixels.  If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package io.pixelsdb.pixels.core.reader;
+
+import io.pixelsdb.pixels.core.PixelsProto;
+import io.pixelsdb.pixels.core.TypeDescription;
+import io.pixelsdb.pixels.core.encoding.EncodingLevel;
+import io.pixelsdb.pixels.core.vector.DateColumnVector;
+import io.pixelsdb.pixels.core.writer.DateColumnWriter;
+import io.pixelsdb.pixels.core.writer.PixelsWriterOption;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+/**
+ * @author hank
+ * @create 2023-08-18 Zermatt
+ */
+public class TestDateColumnReader
+{
+    @Test
+    public void test() throws IOException
+    {
+        PixelsWriterOption writerOption = new PixelsWriterOption()
+                .pixelStride(10).byteOrder(ByteOrder.LITTLE_ENDIAN)
+                .encodingLevel(EncodingLevel.EL2).nullsPadding(false);
+        DateColumnWriter columnWriter = new DateColumnWriter(TypeDescription.createDate(), writerOption);
+        DateColumnVector dateColumnVector = new DateColumnVector(22);
+        dateColumnVector.add(100);
+        dateColumnVector.add(103);
+        dateColumnVector.add(106);
+        dateColumnVector.add(34);
+        dateColumnVector.addNull();
+        dateColumnVector.add(54);
+        dateColumnVector.add(55);
+        dateColumnVector.add(67);
+        dateColumnVector.addNull();
+        dateColumnVector.add(34);
+        dateColumnVector.add(555);
+        dateColumnVector.add(565);
+        dateColumnVector.add(234);
+        dateColumnVector.add(675);
+        dateColumnVector.add(235);
+        dateColumnVector.add(32434);
+        dateColumnVector.add(3);
+        dateColumnVector.add(6);
+        dateColumnVector.add(7);
+        dateColumnVector.add(65656565);
+        dateColumnVector.add(3434);
+        dateColumnVector.add(54578);
+        columnWriter.write(dateColumnVector, 22);
+        columnWriter.flush();
+        byte[] content = columnWriter.getColumnChunkContent();
+        PixelsProto.ColumnChunkIndex chunkIndex = columnWriter.getColumnChunkIndex().build();
+        PixelsProto.ColumnEncoding encoding = columnWriter.getColumnChunkEncoding().build();
+        DateColumnReader columnReader = new DateColumnReader(TypeDescription.createDate());
+        DateColumnVector dateColumnVector1 = new DateColumnVector(22);
+        columnReader.read(ByteBuffer.wrap(content), encoding, 0, 22, 10, 0, dateColumnVector1, chunkIndex);
+        for (int i = 0; i < 22; ++i)
+        {
+            if (!dateColumnVector1.noNulls && dateColumnVector1.isNull[i])
+            {
+                assert !dateColumnVector.noNulls && dateColumnVector.isNull[i];
+            }
+            else
+            {
+                assert dateColumnVector1.dates[i] == dateColumnVector.dates[i];
+            }
+        }
+    }
+}

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestDecimalColumnReader.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestDecimalColumnReader.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2023 PixelsDB.
+ *
+ * This file is part of Pixels.
+ *
+ * Pixels is free software: you can redistribute it and/or modify
+ * it under the terms of the Affero GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * Pixels is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Affero GNU General Public License for more details.
+ *
+ * You should have received a copy of the Affero GNU General Public
+ * License along with Pixels.  If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package io.pixelsdb.pixels.core.reader;
+
+import io.pixelsdb.pixels.core.PixelsProto;
+import io.pixelsdb.pixels.core.TypeDescription;
+import io.pixelsdb.pixels.core.encoding.EncodingLevel;
+import io.pixelsdb.pixels.core.vector.DecimalColumnVector;
+import io.pixelsdb.pixels.core.writer.DecimalColumnWriter;
+import io.pixelsdb.pixels.core.writer.PixelsWriterOption;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+/**
+ * @author hank
+ * @create 2023-08-20 Zermatt
+ */
+public class TestDecimalColumnReader
+{
+    @Test
+    public void test() throws IOException
+    {
+        PixelsWriterOption writerOption = new PixelsWriterOption()
+                .pixelStride(10).byteOrder(ByteOrder.LITTLE_ENDIAN)
+                .encodingLevel(EncodingLevel.EL0).nullsPadding(true);
+        DecimalColumnWriter columnWriter = new DecimalColumnWriter(
+                TypeDescription.createDecimal(15, 2), writerOption);
+        DecimalColumnVector decimalColumnVector = new DecimalColumnVector(22, 15, 2);
+        decimalColumnVector.add(100.22);
+        decimalColumnVector.add(103.32);
+        decimalColumnVector.add(106.43);
+        decimalColumnVector.add(34.10);
+        decimalColumnVector.addNull();
+        decimalColumnVector.add(54.09);
+        decimalColumnVector.add(55.00);
+        decimalColumnVector.add(67.23);
+        decimalColumnVector.addNull();
+        decimalColumnVector.add(34.58);
+        decimalColumnVector.add(555.98);
+        decimalColumnVector.add(565.76);
+        decimalColumnVector.add(234.11);
+        decimalColumnVector.add(675.34);
+        decimalColumnVector.add(235.58);
+        decimalColumnVector.add(32434.68);
+        decimalColumnVector.add(3.58);
+        decimalColumnVector.add(6.66);
+        decimalColumnVector.add(7.77);
+        decimalColumnVector.add(65656565.20);
+        decimalColumnVector.add(3434.11);
+        decimalColumnVector.add(54578.22);
+        columnWriter.write(decimalColumnVector, 22);
+        columnWriter.flush();
+        byte[] content = columnWriter.getColumnChunkContent();
+        PixelsProto.ColumnChunkIndex chunkIndex = columnWriter.getColumnChunkIndex().build();
+        PixelsProto.ColumnEncoding encoding = columnWriter.getColumnChunkEncoding().build();
+        DecimalColumnReader columnReader = new DecimalColumnReader(TypeDescription.createDecimal(15, 2));
+        DecimalColumnVector decimalColumnVector1 = new DecimalColumnVector(22, 15, 2);
+        columnReader.read(ByteBuffer.wrap(content), encoding, 0, 22,
+                10, 0, decimalColumnVector1, chunkIndex);
+        for (int i = 0; i < 22; ++i)
+        {
+            if (!decimalColumnVector1.noNulls && decimalColumnVector1.isNull[i])
+            {
+                assert !decimalColumnVector.noNulls && decimalColumnVector.isNull[i];
+            }
+            else
+            {
+                assert decimalColumnVector1.vector[i] == decimalColumnVector.vector[i];
+            }
+        }
+    }
+}

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestDoubleColumnReader.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestDoubleColumnReader.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2023 PixelsDB.
+ *
+ * This file is part of Pixels.
+ *
+ * Pixels is free software: you can redistribute it and/or modify
+ * it under the terms of the Affero GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * Pixels is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Affero GNU General Public License for more details.
+ *
+ * You should have received a copy of the Affero GNU General Public
+ * License along with Pixels.  If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package io.pixelsdb.pixels.core.reader;
+
+import io.pixelsdb.pixels.core.PixelsProto;
+import io.pixelsdb.pixels.core.TypeDescription;
+import io.pixelsdb.pixels.core.encoding.EncodingLevel;
+import io.pixelsdb.pixels.core.vector.DoubleColumnVector;
+import io.pixelsdb.pixels.core.writer.DoubleColumnWriter;
+import io.pixelsdb.pixels.core.writer.PixelsWriterOption;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+/**
+ * @author hank
+ * @create 2023-08-20 Zermatt
+ */
+public class TestDoubleColumnReader
+{
+    @Test
+    public void test() throws IOException
+    {
+        PixelsWriterOption writerOption = new PixelsWriterOption()
+                .pixelStride(10).byteOrder(ByteOrder.LITTLE_ENDIAN)
+                .encodingLevel(EncodingLevel.EL0).nullsPadding(true);
+        DoubleColumnWriter columnWriter = new DoubleColumnWriter(
+                TypeDescription.createDouble(), writerOption);
+        DoubleColumnVector doubleColumnVector = new DoubleColumnVector(22);
+        doubleColumnVector.add(100.22);
+        doubleColumnVector.add(103.32);
+        doubleColumnVector.add(106.43);
+        doubleColumnVector.add(34.10);
+        doubleColumnVector.addNull();
+        doubleColumnVector.add(54.09);
+        doubleColumnVector.add(55.00);
+        doubleColumnVector.add(67.23);
+        doubleColumnVector.addNull();
+        doubleColumnVector.add(34.58);
+        doubleColumnVector.add(555.98);
+        doubleColumnVector.add(565.76);
+        doubleColumnVector.add(234.11);
+        doubleColumnVector.add(675.34);
+        doubleColumnVector.add(235.58);
+        doubleColumnVector.add(32434.68);
+        doubleColumnVector.add(3.58);
+        doubleColumnVector.add(6.66);
+        doubleColumnVector.add(7.77);
+        doubleColumnVector.add(65656565.20);
+        doubleColumnVector.add(3434.11);
+        doubleColumnVector.add(54578.22);
+        columnWriter.write(doubleColumnVector, 22);
+        columnWriter.flush();
+        byte[] content = columnWriter.getColumnChunkContent();
+        PixelsProto.ColumnChunkIndex chunkIndex = columnWriter.getColumnChunkIndex().build();
+        PixelsProto.ColumnEncoding encoding = columnWriter.getColumnChunkEncoding().build();
+        DoubleColumnReader columnReader = new DoubleColumnReader(TypeDescription.createDouble());
+        DoubleColumnVector doubleColumnVector1 = new DoubleColumnVector(22);
+        columnReader.read(ByteBuffer.wrap(content), encoding, 0, 22,
+                10, 0, doubleColumnVector1, chunkIndex);
+        for (int i = 0; i < 22; ++i)
+        {
+            if (!doubleColumnVector1.noNulls && doubleColumnVector1.isNull[i])
+            {
+                assert !doubleColumnVector.noNulls && doubleColumnVector.isNull[i];
+            }
+            else
+            {
+                assert doubleColumnVector1.vector[i] == doubleColumnVector.vector[i];
+            }
+        }
+    }
+}

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestFloatColumnReader.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestFloatColumnReader.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2023 PixelsDB.
+ *
+ * This file is part of Pixels.
+ *
+ * Pixels is free software: you can redistribute it and/or modify
+ * it under the terms of the Affero GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * Pixels is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Affero GNU General Public License for more details.
+ *
+ * You should have received a copy of the Affero GNU General Public
+ * License along with Pixels.  If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package io.pixelsdb.pixels.core.reader;
+
+import io.pixelsdb.pixels.core.PixelsProto;
+import io.pixelsdb.pixels.core.TypeDescription;
+import io.pixelsdb.pixels.core.encoding.EncodingLevel;
+import io.pixelsdb.pixels.core.vector.DoubleColumnVector;
+import io.pixelsdb.pixels.core.writer.FloatColumnWriter;
+import io.pixelsdb.pixels.core.writer.PixelsWriterOption;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+/**
+ * @author hank
+ * @create 2023-08-20 Zermatt
+ */
+public class TestFloatColumnReader
+{
+    @Test
+    public void test() throws IOException
+    {
+        PixelsWriterOption writerOption = new PixelsWriterOption()
+                .pixelStride(10).byteOrder(ByteOrder.LITTLE_ENDIAN)
+                .encodingLevel(EncodingLevel.EL0).nullsPadding(true);
+        FloatColumnWriter columnWriter = new FloatColumnWriter(
+                TypeDescription.createFloat(), writerOption);
+        DoubleColumnVector doubleColumnVector = new DoubleColumnVector(22);
+        doubleColumnVector.add(100.22F);
+        doubleColumnVector.add(103.32F);
+        doubleColumnVector.add(106.43F);
+        doubleColumnVector.add(34.10F);
+        doubleColumnVector.addNull();
+        doubleColumnVector.add(54.09F);
+        doubleColumnVector.add(55.00F);
+        doubleColumnVector.add(67.23F);
+        doubleColumnVector.addNull();
+        doubleColumnVector.add(34.58F);
+        doubleColumnVector.add(555.98F);
+        doubleColumnVector.add(565.76F);
+        doubleColumnVector.add(234.11F);
+        doubleColumnVector.add(675.34F);
+        doubleColumnVector.add(235.58F);
+        doubleColumnVector.add(32434.68F);
+        doubleColumnVector.add(3.58F);
+        doubleColumnVector.add(6.66F);
+        doubleColumnVector.add(7.77F);
+        doubleColumnVector.add(65656565.20F);
+        doubleColumnVector.add(3434.11F);
+        doubleColumnVector.add(54578.22F);
+        columnWriter.write(doubleColumnVector, 22);
+        columnWriter.flush();
+        byte[] content = columnWriter.getColumnChunkContent();
+        PixelsProto.ColumnChunkIndex chunkIndex = columnWriter.getColumnChunkIndex().build();
+        PixelsProto.ColumnEncoding encoding = columnWriter.getColumnChunkEncoding().build();
+        FloatColumnReader columnReader = new FloatColumnReader(TypeDescription.createFloat());
+        DoubleColumnVector doubleColumnVector1 = new DoubleColumnVector(22);
+        columnReader.read(ByteBuffer.wrap(content), encoding, 0, 22,
+                10, 0, doubleColumnVector1, chunkIndex);
+        for (int i = 0; i < 22; ++i)
+        {
+            if (!doubleColumnVector1.noNulls && doubleColumnVector1.isNull[i])
+            {
+                assert !doubleColumnVector.noNulls && doubleColumnVector.isNull[i];
+            }
+            else
+            {
+                assert doubleColumnVector1.vector[i] == doubleColumnVector.vector[i];
+            }
+        }
+    }
+}

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestFloatColumnReader.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestFloatColumnReader.java
@@ -22,7 +22,7 @@ package io.pixelsdb.pixels.core.reader;
 import io.pixelsdb.pixels.core.PixelsProto;
 import io.pixelsdb.pixels.core.TypeDescription;
 import io.pixelsdb.pixels.core.encoding.EncodingLevel;
-import io.pixelsdb.pixels.core.vector.DoubleColumnVector;
+import io.pixelsdb.pixels.core.vector.FloatColumnVector;
 import io.pixelsdb.pixels.core.writer.FloatColumnWriter;
 import io.pixelsdb.pixels.core.writer.PixelsWriterOption;
 import org.junit.Test;
@@ -45,47 +45,47 @@ public class TestFloatColumnReader
                 .encodingLevel(EncodingLevel.EL0).nullsPadding(true);
         FloatColumnWriter columnWriter = new FloatColumnWriter(
                 TypeDescription.createFloat(), writerOption);
-        DoubleColumnVector doubleColumnVector = new DoubleColumnVector(22);
-        doubleColumnVector.add(100.22F);
-        doubleColumnVector.add(103.32F);
-        doubleColumnVector.add(106.43F);
-        doubleColumnVector.add(34.10F);
-        doubleColumnVector.addNull();
-        doubleColumnVector.add(54.09F);
-        doubleColumnVector.add(55.00F);
-        doubleColumnVector.add(67.23F);
-        doubleColumnVector.addNull();
-        doubleColumnVector.add(34.58F);
-        doubleColumnVector.add(555.98F);
-        doubleColumnVector.add(565.76F);
-        doubleColumnVector.add(234.11F);
-        doubleColumnVector.add(675.34F);
-        doubleColumnVector.add(235.58F);
-        doubleColumnVector.add(32434.68F);
-        doubleColumnVector.add(3.58F);
-        doubleColumnVector.add(6.66F);
-        doubleColumnVector.add(7.77F);
-        doubleColumnVector.add(65656565.20F);
-        doubleColumnVector.add(3434.11F);
-        doubleColumnVector.add(54578.22F);
-        columnWriter.write(doubleColumnVector, 22);
+        FloatColumnVector floatColumnVector = new FloatColumnVector(22);
+        floatColumnVector.add(100.22F);
+        floatColumnVector.add(103.32F);
+        floatColumnVector.add(106.43F);
+        floatColumnVector.add(34.10F);
+        floatColumnVector.addNull();
+        floatColumnVector.add(54.09F);
+        floatColumnVector.add(55.00F);
+        floatColumnVector.add(67.23F);
+        floatColumnVector.addNull();
+        floatColumnVector.add(34.58F);
+        floatColumnVector.add(555.98F);
+        floatColumnVector.add(565.76F);
+        floatColumnVector.add(234.11F);
+        floatColumnVector.add(675.34F);
+        floatColumnVector.add(235.58F);
+        floatColumnVector.add(32434.68F);
+        floatColumnVector.add(3.58F);
+        floatColumnVector.add(6.66F);
+        floatColumnVector.add(7.77F);
+        floatColumnVector.add(65656565.20F);
+        floatColumnVector.add(3434.11F);
+        floatColumnVector.add(54578.22F);
+        columnWriter.write(floatColumnVector, 22);
         columnWriter.flush();
         byte[] content = columnWriter.getColumnChunkContent();
         PixelsProto.ColumnChunkIndex chunkIndex = columnWriter.getColumnChunkIndex().build();
         PixelsProto.ColumnEncoding encoding = columnWriter.getColumnChunkEncoding().build();
         FloatColumnReader columnReader = new FloatColumnReader(TypeDescription.createFloat());
-        DoubleColumnVector doubleColumnVector1 = new DoubleColumnVector(22);
+        FloatColumnVector floatColumnVector1 = new FloatColumnVector(22);
         columnReader.read(ByteBuffer.wrap(content), encoding, 0, 22,
-                10, 0, doubleColumnVector1, chunkIndex);
+                10, 0, floatColumnVector1, chunkIndex);
         for (int i = 0; i < 22; ++i)
         {
-            if (!doubleColumnVector1.noNulls && doubleColumnVector1.isNull[i])
+            if (!floatColumnVector1.noNulls && floatColumnVector1.isNull[i])
             {
-                assert !doubleColumnVector.noNulls && doubleColumnVector.isNull[i];
+                assert !floatColumnVector.noNulls && floatColumnVector.isNull[i];
             }
             else
             {
-                assert doubleColumnVector1.vector[i] == doubleColumnVector.vector[i];
+                assert floatColumnVector1.vector[i] == floatColumnVector.vector[i];
             }
         }
     }

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestIntegerColumnReader.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestIntegerColumnReader.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2023 PixelsDB.
+ *
+ * This file is part of Pixels.
+ *
+ * Pixels is free software: you can redistribute it and/or modify
+ * it under the terms of the Affero GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * Pixels is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Affero GNU General Public License for more details.
+ *
+ * You should have received a copy of the Affero GNU General Public
+ * License along with Pixels.  If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package io.pixelsdb.pixels.core.reader;
+
+import io.pixelsdb.pixels.core.PixelsProto;
+import io.pixelsdb.pixels.core.TypeDescription;
+import io.pixelsdb.pixels.core.encoding.EncodingLevel;
+import io.pixelsdb.pixels.core.vector.LongColumnVector;
+import io.pixelsdb.pixels.core.writer.IntegerColumnWriter;
+import io.pixelsdb.pixels.core.writer.PixelsWriterOption;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+/**
+ * @author hank
+ * @create 2023-08-21
+ */
+public class TestIntegerColumnReader
+{
+    @Test
+    public void testInt() throws IOException
+    {
+        PixelsWriterOption writerOption = new PixelsWriterOption()
+                .pixelStride(10).byteOrder(ByteOrder.LITTLE_ENDIAN)
+                .encodingLevel(EncodingLevel.EL0).nullsPadding(true);
+        IntegerColumnWriter columnWriter = new IntegerColumnWriter(
+                TypeDescription.createInt(), writerOption);
+        LongColumnVector longColumnVector = new LongColumnVector(22);
+        longColumnVector.add(100);
+        longColumnVector.add(103);
+        longColumnVector.add(106);
+        longColumnVector.add(34);
+        longColumnVector.addNull();
+        longColumnVector.add(54);
+        longColumnVector.add(55);
+        longColumnVector.add(67);
+        longColumnVector.addNull();
+        longColumnVector.add(34);
+        longColumnVector.add(555);
+        longColumnVector.add(565);
+        longColumnVector.add(234);
+        longColumnVector.add(675);
+        longColumnVector.add(235);
+        longColumnVector.add(32434);
+        longColumnVector.add(3);
+        longColumnVector.add(6);
+        longColumnVector.add(7);
+        longColumnVector.add(65656565);
+        longColumnVector.add(3434);
+        longColumnVector.add(54578);
+        columnWriter.write(longColumnVector, 22);
+        columnWriter.flush();
+        byte[] content = columnWriter.getColumnChunkContent();
+        PixelsProto.ColumnChunkIndex chunkIndex = columnWriter.getColumnChunkIndex().build();
+        PixelsProto.ColumnEncoding encoding = columnWriter.getColumnChunkEncoding().build();
+        IntegerColumnReader columnReader = new IntegerColumnReader(TypeDescription.createInt());
+        LongColumnVector longColumnVector1 = new LongColumnVector(22);
+        columnReader.read(ByteBuffer.wrap(content), encoding, 0, 22,
+                10, 0, longColumnVector1, chunkIndex);
+        for (int i = 0; i < 22; ++i)
+        {
+            if (!longColumnVector1.noNulls && longColumnVector1.isNull[i])
+            {
+                assert !longColumnVector.noNulls && longColumnVector.isNull[i];
+            }
+            else
+            {
+                assert longColumnVector1.vector[i] == longColumnVector.vector[i];
+            }
+        }
+    }
+
+    @Test
+    public void testLong() throws IOException
+    {
+        PixelsWriterOption writerOption = new PixelsWriterOption()
+                .pixelStride(10).byteOrder(ByteOrder.LITTLE_ENDIAN)
+                .encodingLevel(EncodingLevel.EL0).nullsPadding(true);
+        IntegerColumnWriter columnWriter = new IntegerColumnWriter(
+                TypeDescription.createLong(), writerOption);
+        LongColumnVector longColumnVector = new LongColumnVector(22);
+        longColumnVector.add(100);
+        longColumnVector.add(103);
+        longColumnVector.add(106);
+        longColumnVector.add(34);
+        longColumnVector.addNull();
+        longColumnVector.add(54);
+        longColumnVector.add(55);
+        longColumnVector.add(67);
+        longColumnVector.addNull();
+        longColumnVector.add(34);
+        longColumnVector.add(555);
+        longColumnVector.add(565);
+        longColumnVector.add(234);
+        longColumnVector.add(675);
+        longColumnVector.add(235);
+        longColumnVector.add(32434);
+        longColumnVector.add(3);
+        longColumnVector.add(6);
+        longColumnVector.add(7);
+        longColumnVector.add(65656565);
+        longColumnVector.add(3434);
+        longColumnVector.add(54578);
+        columnWriter.write(longColumnVector, 22);
+        columnWriter.flush();
+        byte[] content = columnWriter.getColumnChunkContent();
+        PixelsProto.ColumnChunkIndex chunkIndex = columnWriter.getColumnChunkIndex().build();
+        PixelsProto.ColumnEncoding encoding = columnWriter.getColumnChunkEncoding().build();
+        IntegerColumnReader columnReader = new IntegerColumnReader(TypeDescription.createLong());
+        LongColumnVector longColumnVector1 = new LongColumnVector(22);
+        columnReader.read(ByteBuffer.wrap(content), encoding, 0, 22,
+                10, 0, longColumnVector1, chunkIndex);
+        for (int i = 0; i < 22; ++i)
+        {
+            if (!longColumnVector1.noNulls && longColumnVector1.isNull[i])
+            {
+                assert !longColumnVector.noNulls && longColumnVector.isNull[i];
+            }
+            else
+            {
+                assert longColumnVector1.vector[i] == longColumnVector.vector[i];
+            }
+        }
+    }
+}

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestLongDecimalColumnReader.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestLongDecimalColumnReader.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2023 PixelsDB.
+ *
+ * This file is part of Pixels.
+ *
+ * Pixels is free software: you can redistribute it and/or modify
+ * it under the terms of the Affero GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * Pixels is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Affero GNU General Public License for more details.
+ *
+ * You should have received a copy of the Affero GNU General Public
+ * License along with Pixels.  If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package io.pixelsdb.pixels.core.reader;
+
+import io.pixelsdb.pixels.core.PixelsProto;
+import io.pixelsdb.pixels.core.TypeDescription;
+import io.pixelsdb.pixels.core.encoding.EncodingLevel;
+import io.pixelsdb.pixels.core.vector.LongDecimalColumnVector;
+import io.pixelsdb.pixels.core.writer.LongDecimalColumnWriter;
+import io.pixelsdb.pixels.core.writer.PixelsWriterOption;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+/**
+ * @author hank
+ * @create 2023-08-20 Zermatt
+ */
+public class TestLongDecimalColumnReader
+{
+    @Test
+    public void test() throws IOException
+    {
+        PixelsWriterOption writerOption = new PixelsWriterOption()
+                .pixelStride(10).byteOrder(ByteOrder.LITTLE_ENDIAN)
+                .encodingLevel(EncodingLevel.EL0).nullsPadding(true);
+        LongDecimalColumnWriter columnWriter = new LongDecimalColumnWriter(
+                TypeDescription.createDecimal(38, 2), writerOption);
+        LongDecimalColumnVector decimalColumnVector = new LongDecimalColumnVector(22, 38, 2);
+        decimalColumnVector.add(100.22);
+        decimalColumnVector.add(103.32);
+        decimalColumnVector.add(106.43);
+        decimalColumnVector.add(34.10);
+        decimalColumnVector.addNull();
+        decimalColumnVector.add(54.09);
+        decimalColumnVector.add(55.00);
+        decimalColumnVector.add(67.23);
+        decimalColumnVector.addNull();
+        decimalColumnVector.add(34.58);
+        decimalColumnVector.add(555.98);
+        decimalColumnVector.add(565.76);
+        decimalColumnVector.add(234.11);
+        decimalColumnVector.add(675.34);
+        decimalColumnVector.add(235.58);
+        decimalColumnVector.add(32434.68);
+        decimalColumnVector.add(3.58);
+        decimalColumnVector.add(6.66);
+        decimalColumnVector.add(7.77);
+        decimalColumnVector.add(65656565.20);
+        decimalColumnVector.add(3434.11);
+        decimalColumnVector.add(54578.22);
+        columnWriter.write(decimalColumnVector, 22);
+        columnWriter.flush();
+        byte[] content = columnWriter.getColumnChunkContent();
+        PixelsProto.ColumnChunkIndex chunkIndex = columnWriter.getColumnChunkIndex().build();
+        PixelsProto.ColumnEncoding encoding = columnWriter.getColumnChunkEncoding().build();
+        LongDecimalColumnReader columnReader = new LongDecimalColumnReader(TypeDescription.createDecimal(38, 2));
+        LongDecimalColumnVector decimalColumnVector1 = new LongDecimalColumnVector(22, 38, 2);
+        columnReader.read(ByteBuffer.wrap(content), encoding, 0, 22,
+                10, 0, decimalColumnVector1, chunkIndex);
+        for (int i = 0; i < 22; ++i)
+        {
+            if (!decimalColumnVector1.noNulls && decimalColumnVector1.isNull[i])
+            {
+                assert !decimalColumnVector.noNulls && decimalColumnVector.isNull[i];
+            }
+            else
+            {
+                assert decimalColumnVector1.vector[i * 2] == decimalColumnVector.vector[i * 2];
+                assert decimalColumnVector1.vector[i * 2 + 1] == decimalColumnVector.vector[i * 2 + 1];
+            }
+        }
+    }
+}

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestStringColumnReader.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestStringColumnReader.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2023 PixelsDB.
+ *
+ * This file is part of Pixels.
+ *
+ * Pixels is free software: you can redistribute it and/or modify
+ * it under the terms of the Affero GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * Pixels is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Affero GNU General Public License for more details.
+ *
+ * You should have received a copy of the Affero GNU General Public
+ * License along with Pixels.  If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package io.pixelsdb.pixels.core.reader;
+
+import io.pixelsdb.pixels.core.PixelsProto;
+import io.pixelsdb.pixels.core.TypeDescription;
+import io.pixelsdb.pixels.core.encoding.EncodingLevel;
+import io.pixelsdb.pixels.core.vector.BinaryColumnVector;
+import io.pixelsdb.pixels.core.writer.PixelsWriterOption;
+import io.pixelsdb.pixels.core.writer.StringColumnWriter;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+/**
+ * @author hank
+ * @create 2023-08-21
+ */
+public class TestStringColumnReader
+{
+    @Test
+    public void test() throws IOException
+    {
+        PixelsWriterOption writerOption = new PixelsWriterOption()
+                .pixelStride(10).byteOrder(ByteOrder.LITTLE_ENDIAN)
+                .encodingLevel(EncodingLevel.EL0).nullsPadding(true);
+        StringColumnWriter columnWriter = new StringColumnWriter(
+                TypeDescription.createString(), writerOption);
+        BinaryColumnVector binaryColumnVector = new BinaryColumnVector(22);
+        binaryColumnVector.add("100");
+        binaryColumnVector.add("103");
+        binaryColumnVector.add("106");
+        binaryColumnVector.add("34");
+        binaryColumnVector.addNull();
+        binaryColumnVector.add("54");
+        binaryColumnVector.add("55");
+        binaryColumnVector.add("67");
+        binaryColumnVector.addNull();
+        binaryColumnVector.add("34");
+        binaryColumnVector.add("555");
+        binaryColumnVector.add("565");
+        binaryColumnVector.add("234");
+        binaryColumnVector.add("675");
+        binaryColumnVector.add("235");
+        binaryColumnVector.add("32434");
+        binaryColumnVector.add("3");
+        binaryColumnVector.add("6");
+        binaryColumnVector.add("7");
+        binaryColumnVector.add("65656565");
+        binaryColumnVector.add("3434");
+        binaryColumnVector.add("54578");
+        columnWriter.write(binaryColumnVector, 22);
+        columnWriter.flush();
+        byte[] content = columnWriter.getColumnChunkContent();
+        PixelsProto.ColumnChunkIndex chunkIndex = columnWriter.getColumnChunkIndex().build();
+        PixelsProto.ColumnEncoding encoding = columnWriter.getColumnChunkEncoding().build();
+        StringColumnReader columnReader = new StringColumnReader(TypeDescription.createString());
+        BinaryColumnVector binaryColumnVector1 = new BinaryColumnVector(22);
+        columnReader.read(ByteBuffer.wrap(content), encoding, 0, 22,
+                10, 0, binaryColumnVector1, chunkIndex);
+        for (int i = 0; i < 22; ++i)
+        {
+            if (!binaryColumnVector1.noNulls && binaryColumnVector1.isNull[i])
+            {
+                assert !binaryColumnVector.noNulls && binaryColumnVector.isNull[i];
+            }
+            else
+            {
+                String s1 = new String(binaryColumnVector1.vector[i], binaryColumnVector1.start[i], binaryColumnVector1.lens[i]);
+                String s = new String(binaryColumnVector.vector[i], binaryColumnVector.start[i], binaryColumnVector.lens[i]);
+                assert s1.equals(s);
+            }
+        }
+    }
+}

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestTimeColumnReader.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestTimeColumnReader.java
@@ -22,9 +22,9 @@ package io.pixelsdb.pixels.core.reader;
 import io.pixelsdb.pixels.core.PixelsProto;
 import io.pixelsdb.pixels.core.TypeDescription;
 import io.pixelsdb.pixels.core.encoding.EncodingLevel;
-import io.pixelsdb.pixels.core.vector.DateColumnVector;
-import io.pixelsdb.pixels.core.writer.DateColumnWriter;
+import io.pixelsdb.pixels.core.vector.TimeColumnVector;
 import io.pixelsdb.pixels.core.writer.PixelsWriterOption;
+import io.pixelsdb.pixels.core.writer.TimeColumnWriter;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -33,9 +33,9 @@ import java.nio.ByteOrder;
 
 /**
  * @author hank
- * @create 2023-08-19 Zermatt
+ * @create 2023-08-20 Zermatt
  */
-public class TestDateColumnReader
+public class TestTimeColumnReader
 {
     @Test
     public void test() throws IOException
@@ -43,49 +43,49 @@ public class TestDateColumnReader
         PixelsWriterOption writerOption = new PixelsWriterOption()
                 .pixelStride(10).byteOrder(ByteOrder.LITTLE_ENDIAN)
                 .encodingLevel(EncodingLevel.EL0).nullsPadding(true);
-        DateColumnWriter columnWriter = new DateColumnWriter(
-                TypeDescription.createDate(), writerOption);
-        DateColumnVector dateColumnVector = new DateColumnVector(22);
-        dateColumnVector.add(100);
-        dateColumnVector.add(103);
-        dateColumnVector.add(106);
-        dateColumnVector.add(34);
-        dateColumnVector.addNull();
-        dateColumnVector.add(54);
-        dateColumnVector.add(55);
-        dateColumnVector.add(67);
-        dateColumnVector.addNull();
-        dateColumnVector.add(34);
-        dateColumnVector.add(555);
-        dateColumnVector.add(565);
-        dateColumnVector.add(234);
-        dateColumnVector.add(675);
-        dateColumnVector.add(235);
-        dateColumnVector.add(32434);
-        dateColumnVector.add(3);
-        dateColumnVector.add(6);
-        dateColumnVector.add(7);
-        dateColumnVector.add(65656565);
-        dateColumnVector.add(3434);
-        dateColumnVector.add(54578);
-        columnWriter.write(dateColumnVector, 22);
+        TimeColumnWriter columnWriter = new TimeColumnWriter(
+                TypeDescription.createTime(3), writerOption);
+        TimeColumnVector timeColumnVector = new TimeColumnVector(22, 3);
+        timeColumnVector.add(100);
+        timeColumnVector.add(103);
+        timeColumnVector.add(106);
+        timeColumnVector.add(34);
+        timeColumnVector.addNull();
+        timeColumnVector.add(54);
+        timeColumnVector.add(55);
+        timeColumnVector.add(67);
+        timeColumnVector.addNull();
+        timeColumnVector.add(34);
+        timeColumnVector.add(555);
+        timeColumnVector.add(565);
+        timeColumnVector.add(234);
+        timeColumnVector.add(675);
+        timeColumnVector.add(235);
+        timeColumnVector.add(32434);
+        timeColumnVector.add(3);
+        timeColumnVector.add(6);
+        timeColumnVector.add(7);
+        timeColumnVector.add(65656565);
+        timeColumnVector.add(3434);
+        timeColumnVector.add(54578);
+        columnWriter.write(timeColumnVector, 22);
         columnWriter.flush();
         byte[] content = columnWriter.getColumnChunkContent();
         PixelsProto.ColumnChunkIndex chunkIndex = columnWriter.getColumnChunkIndex().build();
         PixelsProto.ColumnEncoding encoding = columnWriter.getColumnChunkEncoding().build();
-        DateColumnReader columnReader = new DateColumnReader(TypeDescription.createDate());
-        DateColumnVector dateColumnVector1 = new DateColumnVector(22);
+        TimeColumnReader columnReader = new TimeColumnReader(TypeDescription.createTime(3));
+        TimeColumnVector timeColumnVector1 = new TimeColumnVector(22, 3);
         columnReader.read(ByteBuffer.wrap(content), encoding, 0, 22,
-                10, 0, dateColumnVector1, chunkIndex);
+                10, 0, timeColumnVector1, chunkIndex);
         for (int i = 0; i < 22; ++i)
         {
-            if (!dateColumnVector1.noNulls && dateColumnVector1.isNull[i])
+            if (!timeColumnVector1.noNulls && timeColumnVector1.isNull[i])
             {
-                assert !dateColumnVector.noNulls && dateColumnVector.isNull[i];
+                assert !timeColumnVector.noNulls && timeColumnVector.isNull[i];
             }
             else
             {
-                assert dateColumnVector1.dates[i] == dateColumnVector.dates[i];
+                assert timeColumnVector1.times[i] == timeColumnVector.times[i];
             }
         }
     }

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestTimestampColumnReader.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestTimestampColumnReader.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2023 PixelsDB.
+ *
+ * This file is part of Pixels.
+ *
+ * Pixels is free software: you can redistribute it and/or modify
+ * it under the terms of the Affero GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * Pixels is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Affero GNU General Public License for more details.
+ *
+ * You should have received a copy of the Affero GNU General Public
+ * License along with Pixels.  If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package io.pixelsdb.pixels.core.reader;
+
+import io.pixelsdb.pixels.core.PixelsProto;
+import io.pixelsdb.pixels.core.TypeDescription;
+import io.pixelsdb.pixels.core.encoding.EncodingLevel;
+import io.pixelsdb.pixels.core.vector.TimestampColumnVector;
+import io.pixelsdb.pixels.core.writer.PixelsWriterOption;
+import io.pixelsdb.pixels.core.writer.TimestampColumnWriter;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+/**
+ * @author hank
+ * @create 2023-08-20 Zermatt
+ */
+public class TestTimestampColumnReader
+{
+    @Test
+    public void test() throws IOException
+    {
+        PixelsWriterOption writerOption = new PixelsWriterOption()
+                .pixelStride(10).byteOrder(ByteOrder.LITTLE_ENDIAN)
+                .encodingLevel(EncodingLevel.EL0).nullsPadding(true);
+        TimestampColumnWriter columnWriter = new TimestampColumnWriter(
+                TypeDescription.createTimestamp(6), writerOption);
+        TimestampColumnVector timestampColumnVector = new TimestampColumnVector(22, 6);
+        timestampColumnVector.add(100L);
+        timestampColumnVector.add(103L);
+        timestampColumnVector.add(106L);
+        timestampColumnVector.add(34L);
+        timestampColumnVector.addNull();
+        timestampColumnVector.add(54L);
+        timestampColumnVector.add(55L);
+        timestampColumnVector.add(67L);
+        timestampColumnVector.addNull();
+        timestampColumnVector.add(34L);
+        timestampColumnVector.add(555L);
+        timestampColumnVector.add(565L);
+        timestampColumnVector.add(234L);
+        timestampColumnVector.add(675L);
+        timestampColumnVector.add(235L);
+        timestampColumnVector.add(32434L);
+        timestampColumnVector.add(3L);
+        timestampColumnVector.add(6L);
+        timestampColumnVector.add(7L);
+        timestampColumnVector.add(65656565L);
+        timestampColumnVector.add(3434L);
+        timestampColumnVector.add(54578L);
+        columnWriter.write(timestampColumnVector, 22);
+        columnWriter.flush();
+        byte[] content = columnWriter.getColumnChunkContent();
+        PixelsProto.ColumnChunkIndex chunkIndex = columnWriter.getColumnChunkIndex().build();
+        PixelsProto.ColumnEncoding encoding = columnWriter.getColumnChunkEncoding().build();
+        TimestampColumnReader columnReader = new TimestampColumnReader(TypeDescription.createTimestamp(6));
+        TimestampColumnVector timestampColumnVector1 = new TimestampColumnVector(22, 6);
+        columnReader.read(ByteBuffer.wrap(content), encoding, 0, 22,
+                10, 0, timestampColumnVector1, chunkIndex);
+        for (int i = 0; i < 22; ++i)
+        {
+            if (!timestampColumnVector1.noNulls && timestampColumnVector1.isNull[i])
+            {
+                assert !timestampColumnVector.noNulls && timestampColumnVector.isNull[i];
+            }
+            else
+            {
+                assert timestampColumnVector1.times[i] == timestampColumnVector.times[i];
+            }
+        }
+    }
+}

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/writer/TestPixelsWriter.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/writer/TestPixelsWriter.java
@@ -372,13 +372,12 @@ public class TestPixelsWriter
                     PixelsProto.RowGroupFooter rowGroupFooter = pixelsPhysicalReader.readRowGroupFooter(cacheRGId);
                     PixelsProto.ColumnChunkIndex chunkIndex =
                             rowGroupFooter.getRowGroupIndexEntry().getColumnChunkIndexEntries(cacheColId);
-                    int chunkLen = (int) chunkIndex.getChunkLength();
+                    int chunkLen = chunkIndex.getChunkLength();
                     long chunkOffset = chunkIndex.getChunkOffset();
                     cacheLength += chunkLen;
-                    byte[] columnlet = pixelsPhysicalReader.read(chunkOffset, chunkLen);
-//                  byte[] columnlet = new byte[0];
+                    byte[] columnChunk = pixelsPhysicalReader.read(chunkOffset, chunkLen);
                     PixelsCacheKey cacheKey = new PixelsCacheKey(pixelsPhysicalReader.getCurrentBlockId(), cacheRGId, cacheColId);
-                    cacheWriter.write(cacheKey, columnlet);
+                    cacheWriter.write(cacheKey, columnChunk);
                 }
             }
             long endNano = System.nanoTime();

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/writer/TestStringColumnWriter.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/writer/TestStringColumnWriter.java
@@ -30,7 +30,7 @@ import java.util.UUID;
 
 /**
  * @author hank
- * @date 8/13/22
+ * @create 2022-08-13
  */
 public class TestStringColumnWriter
 {
@@ -44,8 +44,10 @@ public class TestStringColumnWriter
         {
             stringColumnVector.add(UUID.randomUUID().toString());
         }
+        PixelsWriterOption pixelsWriterOption = new PixelsWriterOption()
+                .pixelStride(10000).encodingLevel(EncodingLevel.EL2).byteOrder(ByteOrder.BIG_ENDIAN);
         StringColumnWriter stringColumnWriter = new StringColumnWriter(
-                TypeDescription.createString(), 10000, EncodingLevel.EL2, ByteOrder.BIG_ENDIAN);
+                TypeDescription.createString(), pixelsWriterOption);
         long startTime = System.currentTimeMillis();
         for (int i = 0; i < 1000; ++i)
         {

--- a/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/predicate/ColumnFilter.java
+++ b/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/predicate/ColumnFilter.java
@@ -337,6 +337,9 @@ public class ColumnFilter<T extends Comparable<T>>
                 doFilter(decv.vector, decv.noNulls ? null : decv.isNull, start, length, result);
                 return;
             case FLOAT:
+                FloatColumnVector fcv = (FloatColumnVector) columnVector;
+                doFilter(fcv.vector, fcv.noNulls ? null : fcv.isNull, start, length, result);
+                return;
             case DOUBLE:
                 DoubleColumnVector dcv = (DoubleColumnVector) columnVector;
                 doFilter(dcv.vector, dcv.noNulls ? null : dcv.isNull, start, length, result);

--- a/proto/pixels.proto
+++ b/proto/pixels.proto
@@ -236,7 +236,7 @@ message ColumnChunkIndex {
     // whether this column chunk is stored in little endian
     optional bool littleEndian = 6;
     // whether the null positions are padded with arbitrary value, only valid non-encoded column chunks
-    optional bool nullsPadded = 7;
+    optional bool nullsPadding = 7;
 }
 
 message RowGroupIndex {

--- a/proto/pixels.proto
+++ b/proto/pixels.proto
@@ -263,6 +263,7 @@ message ColumnEncoding {
     }
 
     required Kind kind = 1;
+    // the number of distinct elements in the dictionary, only valid when dictionary encoding is in use
     optional uint32 dictionarySize = 2;
     // the explicit cascade encoding scheme specified by pixels writer
     optional ColumnEncoding cascadeEncoding = 3;

--- a/proto/pixels.proto
+++ b/proto/pixels.proto
@@ -235,7 +235,8 @@ message ColumnChunkIndex {
     repeated PixelStatistic pixelStatistics = 5;
     // whether this column chunk is stored in little endian
     optional bool littleEndian = 6;
-    // whether the null positions are padded with arbitrary value, only valid non-encoded column chunks
+    // whether the null positions are padded with arbitrary value,
+    // only take effects if non-random-accessible encoding (i.e., run-length) is not used
     optional bool nullsPadding = 7;
 }
 

--- a/proto/pixels.proto
+++ b/proto/pixels.proto
@@ -228,10 +228,13 @@ message PixelStatistic {
 // ColumnChunk index
 message ColumnChunkIndex {
     optional uint64 chunkOffset = 1;
-    optional uint64 chunkLength = 2;
-    optional uint64 isNullOffset = 3;
+    // the number of bytes of this column chunk (including the isNull bitmap) in the storage
+    optional uint32 chunkLength = 2;
+    // the offset of the isNull bitmap within this column chunk
+    optional uint32 isNullOffset = 3;
     // starting offsets of each pixel in this column chunk
-    repeated uint64 pixelPositions = 4 [packed=true];
+    repeated uint32 pixelPositions = 4 [packed=true];
+    // the statistics of the pixels in this column chunk
     repeated PixelStatistic pixelStatistics = 5;
     // whether this column chunk is stored in little endian
     optional bool littleEndian = 6;

--- a/proto/pixels.proto
+++ b/proto/pixels.proto
@@ -255,7 +255,7 @@ message RowGroupFooter {
 message ColumnEncoding {
     enum Kind {
         NONE = 0;
-        // pixels cascades delta encoding adaptively on run-length encoding, so there is no explicit delta encoding
+        // pixels adaptively cascades delta encoding on run-length encoding, so there is no explicit delta encoding
         RUNLENGTH = 1;
         // since v0.2.0, dictionary encoding does not cascade other encoding schemes such as run-length by default
         DICTIONARY = 2;


### PR DESCRIPTION
Add a writer option for column writers.
Handle nulls padding in the column writers and readers.
Add a -p parameter to the LOAD command of pixels-cli to specify whether nulls padding is enabled.
Optimize the de-compaction of the isNull bitmap in the column readers, single-table query performance on TPCH.orders is improved by 15%-20%.
Fix a bug related to null records reading in the column writers of Date, Time, and Timestamp.
