### PR TITLE
[Issue #548] support endianness in bit compact and decompact

### DIFF
--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/BooleanColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/BooleanColumnReader.java
@@ -97,7 +97,7 @@ public class BooleanColumnReader extends ColumnReader
                 // Issue #545: de-compact the byte before isNullOffset instead of the whole chunk
                 bytesToDeCompact = chunkIndex.getIsNullOffset();
                 bits = new byte[bytesToDeCompact * 8];
-                BitUtils.bitWiseDeCompact(bits, input, input.position(), bytesToDeCompact);
+                BitUtils.bitWiseDeCompactBE(bits, input, input.position(), bytesToDeCompact);
             }
             else
             {
@@ -131,7 +131,7 @@ public class BooleanColumnReader extends ColumnReader
             hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
             if (hasNull)
             {
-                BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset);
+                BitUtils.bitWiseDeCompactBE(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset);
                 isNullOffset += bytesToDeCompact;
                 columnVector.noNulls = false;
             }
@@ -142,7 +142,7 @@ public class BooleanColumnReader extends ColumnReader
             // read content
             if (nullsPadding)
             {
-                BitUtils.bitWiseDeCompact(columnVector.vector, i, numToRead, inputBuffer, bitsOrInputIndex);
+                BitUtils.bitWiseDeCompactBE(columnVector.vector, i, numToRead, inputBuffer, bitsOrInputIndex);
                 bitsOrInputIndex += bytesToDeCompact;
             }
             else

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/BooleanColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/BooleanColumnReader.java
@@ -88,6 +88,7 @@ public class BooleanColumnReader extends ColumnReader
         ByteColumnVector columnVector = (ByteColumnVector) vector;
         int bytesToDeCompact;
         boolean nullsPadding = chunkIndex.hasNullsPadding() && chunkIndex.getNullsPadding();
+        boolean littleEndian = chunkIndex.hasLittleEndian() && chunkIndex.getLittleEndian();
         if (offset == 0)
         {
             // read content
@@ -97,7 +98,7 @@ public class BooleanColumnReader extends ColumnReader
                 // Issue #545: de-compact the byte before isNullOffset instead of the whole chunk
                 bytesToDeCompact = chunkIndex.getIsNullOffset();
                 bits = new byte[bytesToDeCompact * 8];
-                BitUtils.bitWiseDeCompactBE(bits, input, input.position(), bytesToDeCompact);
+                BitUtils.bitWiseDeCompact(bits, input, input.position(), bytesToDeCompact, littleEndian);
             }
             else
             {
@@ -131,7 +132,7 @@ public class BooleanColumnReader extends ColumnReader
             hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
             if (hasNull)
             {
-                BitUtils.bitWiseDeCompactBE(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset);
+                BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset, littleEndian);
                 isNullOffset += bytesToDeCompact;
                 columnVector.noNulls = false;
             }
@@ -142,7 +143,7 @@ public class BooleanColumnReader extends ColumnReader
             // read content
             if (nullsPadding)
             {
-                BitUtils.bitWiseDeCompactBE(columnVector.vector, i, numToRead, inputBuffer, bitsOrInputIndex);
+                BitUtils.bitWiseDeCompact(columnVector.vector, i, numToRead, inputBuffer, bitsOrInputIndex, littleEndian);
                 bitsOrInputIndex += bytesToDeCompact;
             }
             else

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/DateColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/DateColumnReader.java
@@ -131,7 +131,7 @@ public class DateColumnReader extends ColumnReader
             hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
             if (hasNull)
             {
-                BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset);
+                BitUtils.bitWiseDeCompactBE(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset);
                 isNullOffset += bytesToDeCompact;
                 columnVector.noNulls = false;
             }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/DateColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/DateColumnReader.java
@@ -95,6 +95,7 @@ public class DateColumnReader extends ColumnReader
     {
         DateColumnVector columnVector = (DateColumnVector) vector;
         boolean nullsPadding = chunkIndex.hasNullsPadding() && chunkIndex.getNullsPadding();
+        boolean littleEndian = chunkIndex.hasLittleEndian() && chunkIndex.getLittleEndian();
         if (offset == 0)
         {
             if (inputStream != null)
@@ -102,7 +103,6 @@ public class DateColumnReader extends ColumnReader
                 inputStream.close();
             }
             this.inputBuffer = input;
-            boolean littleEndian = chunkIndex.hasLittleEndian() && chunkIndex.getLittleEndian();
             this.inputBuffer.order(littleEndian ? ByteOrder.LITTLE_ENDIAN : ByteOrder.BIG_ENDIAN);
             inputStream = new ByteBufferInputStream(inputBuffer, inputBuffer.position(), inputBuffer.limit());
             decoder = new RunLenIntDecoder(inputStream, true);
@@ -131,7 +131,7 @@ public class DateColumnReader extends ColumnReader
             hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
             if (hasNull)
             {
-                BitUtils.bitWiseDeCompactBE(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset);
+                BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset, littleEndian);
                 isNullOffset += bytesToDeCompact;
                 columnVector.noNulls = false;
             }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/DecimalColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/DecimalColumnReader.java
@@ -125,7 +125,7 @@ public class DecimalColumnReader extends ColumnReader
             hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
             if (hasNull)
             {
-                BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset);
+                BitUtils.bitWiseDeCompactBE(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset);
                 isNullOffset += bytesToDeCompact;
                 columnVector.noNulls = false;
             } else

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/DecimalColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/DecimalColumnReader.java
@@ -94,10 +94,11 @@ public class DecimalColumnReader extends ColumnReader
                     ") does not match the column vector of decimal(" + columnVector.getPrecision() + "," +
                     columnVector.getScale() + ")");
         }
+        boolean nullsPadding = chunkIndex.hasNullsPadding() && chunkIndex.getNullsPadding();
+        boolean littleEndian = chunkIndex.hasLittleEndian() && chunkIndex.getLittleEndian();
         if (offset == 0)
         {
             this.inputBuffer = input;
-            boolean littleEndian = chunkIndex.hasLittleEndian() && chunkIndex.getLittleEndian();
             this.inputBuffer.order(littleEndian ? ByteOrder.LITTLE_ENDIAN : ByteOrder.BIG_ENDIAN);
             inputIndex = this.inputBuffer.position();
             // isNull
@@ -106,7 +107,7 @@ public class DecimalColumnReader extends ColumnReader
             hasNull = true;
             elementIndex = 0;
         }
-        boolean nullsPadding = chunkIndex.hasNullsPadding() && chunkIndex.getNullsPadding();
+
         // read without copying the de-compacted content and isNull
         int numLeft = size, numToRead, bytesToDeCompact;
         for (int i = vectorIndex; numLeft > 0; )
@@ -125,7 +126,7 @@ public class DecimalColumnReader extends ColumnReader
             hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
             if (hasNull)
             {
-                BitUtils.bitWiseDeCompactBE(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset);
+                BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset, littleEndian);
                 isNullOffset += bytesToDeCompact;
                 columnVector.noNulls = false;
             } else

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/DoubleColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/DoubleColumnReader.java
@@ -116,7 +116,7 @@ public class DoubleColumnReader extends ColumnReader
             hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
             if (hasNull)
             {
-                BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset);
+                BitUtils.bitWiseDeCompactBE(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset);
                 isNullOffset += bytesToDeCompact;
                 columnVector.noNulls = false;
             } else

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/DoubleColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/DoubleColumnReader.java
@@ -85,10 +85,11 @@ public class DoubleColumnReader extends ColumnReader
                      ColumnVector vector, PixelsProto.ColumnChunkIndex chunkIndex)
     {
         DoubleColumnVector columnVector = (DoubleColumnVector) vector;
+        boolean nullsPadding = chunkIndex.hasNullsPadding() && chunkIndex.getNullsPadding();
+        boolean littleEndian = chunkIndex.hasLittleEndian() && chunkIndex.getLittleEndian();
         if (offset == 0)
         {
             this.inputBuffer = input;
-            boolean littleEndian = chunkIndex.hasLittleEndian() && chunkIndex.getLittleEndian();
             this.inputBuffer.order(littleEndian ? ByteOrder.LITTLE_ENDIAN : ByteOrder.BIG_ENDIAN);
             inputIndex = inputBuffer.position();
             // isNull
@@ -97,7 +98,7 @@ public class DoubleColumnReader extends ColumnReader
             hasNull = true;
             elementIndex = 0;
         }
-        boolean nullsPadding = chunkIndex.hasNullsPadding() && chunkIndex.getNullsPadding();
+
         // read without copying the de-compacted content and isNull
         int numLeft = size, numToRead, bytesToDeCompact;
         for (int i = vectorIndex; numLeft > 0; )
@@ -116,7 +117,7 @@ public class DoubleColumnReader extends ColumnReader
             hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
             if (hasNull)
             {
-                BitUtils.bitWiseDeCompactBE(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset);
+                BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset, littleEndian);
                 isNullOffset += bytesToDeCompact;
                 columnVector.noNulls = false;
             } else

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/FloatColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/FloatColumnReader.java
@@ -84,17 +84,18 @@ public class FloatColumnReader extends ColumnReader
                      ColumnVector vector, PixelsProto.ColumnChunkIndex chunkIndex)
     {
         FloatColumnVector columnVector = (FloatColumnVector) vector;
+        boolean nullsPadding = chunkIndex.hasNullsPadding() && chunkIndex.getNullsPadding();
+        boolean littleEndian = chunkIndex.hasLittleEndian() && chunkIndex.getLittleEndian();
         if (offset == 0)
         {
             this.inputBuffer = input;
-            boolean littleEndian = chunkIndex.hasLittleEndian() && chunkIndex.getLittleEndian();
             this.inputBuffer.order(littleEndian ? ByteOrder.LITTLE_ENDIAN : ByteOrder.BIG_ENDIAN);
             inputIndex = inputBuffer.position();
             isNullOffset = inputIndex + chunkIndex.getIsNullOffset();
             hasNull = true;
             elementIndex = 0;
         }
-        boolean nullsPadding = chunkIndex.hasNullsPadding() && chunkIndex.getNullsPadding();
+
         // read without copying the de-compacted content and isNull
         int numLeft = size, numToRead, bytesToDeCompact;
         for (int i = vectorIndex; numLeft > 0; )
@@ -113,7 +114,7 @@ public class FloatColumnReader extends ColumnReader
             hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
             if (hasNull)
             {
-                BitUtils.bitWiseDeCompactBE(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset);
+                BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset, littleEndian);
                 isNullOffset += bytesToDeCompact;
                 columnVector.noNulls = false;
             } else

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/FloatColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/FloatColumnReader.java
@@ -113,7 +113,7 @@ public class FloatColumnReader extends ColumnReader
             hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
             if (hasNull)
             {
-                BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset);
+                BitUtils.bitWiseDeCompactBE(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset);
                 isNullOffset += bytesToDeCompact;
                 columnVector.noNulls = false;
             } else

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/IntegerColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/IntegerColumnReader.java
@@ -141,7 +141,7 @@ public class IntegerColumnReader extends ColumnReader
             hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
             if (hasNull)
             {
-                BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset);
+                BitUtils.bitWiseDeCompactBE(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset);
                 isNullOffset += bytesToDeCompact;
                 columnVector.noNulls = false;
             } else

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/IntegerColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/IntegerColumnReader.java
@@ -98,6 +98,9 @@ public class IntegerColumnReader extends ColumnReader
                      ColumnVector vector, PixelsProto.ColumnChunkIndex chunkIndex) throws IOException
     {
         LongColumnVector columnVector = (LongColumnVector) vector;
+        boolean decoding = encoding.getKind().equals(PixelsProto.ColumnEncoding.Kind.RUNLENGTH);
+        boolean nullsPadding = chunkIndex.hasNullsPadding() && chunkIndex.getNullsPadding();
+        boolean littleEndian = chunkIndex.hasLittleEndian() && chunkIndex.getLittleEndian();
         // if read from start, init the stream and decoder
         if (offset == 0)
         {
@@ -106,7 +109,6 @@ public class IntegerColumnReader extends ColumnReader
                 inputStream.close();
             }
             this.inputBuffer = input;
-            boolean littleEndian = chunkIndex.hasLittleEndian() && chunkIndex.getLittleEndian();
             this.inputBuffer.order(littleEndian ? ByteOrder.LITTLE_ENDIAN : ByteOrder.BIG_ENDIAN);
             inputStream = new ByteBufferInputStream(inputBuffer, inputBuffer.position(), inputBuffer.limit());
             decoder = new RunLenIntDecoder(inputStream, true);
@@ -121,8 +123,6 @@ public class IntegerColumnReader extends ColumnReader
             }
         }
 
-        boolean decoding = encoding.getKind().equals(PixelsProto.ColumnEncoding.Kind.RUNLENGTH);
-        boolean nullsPadding = chunkIndex.hasNullsPadding() && chunkIndex.getNullsPadding();
         // read without copying the de-compacted content and isNull
         int numLeft = size, numToRead, bytesToDeCompact;
         for (int i = vectorIndex; numLeft > 0; )
@@ -141,7 +141,7 @@ public class IntegerColumnReader extends ColumnReader
             hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
             if (hasNull)
             {
-                BitUtils.bitWiseDeCompactBE(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset);
+                BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset, littleEndian);
                 isNullOffset += bytesToDeCompact;
                 columnVector.noNulls = false;
             } else

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/LongDecimalColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/LongDecimalColumnReader.java
@@ -92,10 +92,11 @@ public class LongDecimalColumnReader extends ColumnReader
                     ") does not match the column vector of long_decimal(" + columnVector.getPrecision() + "," +
                     columnVector.getScale() + ")");
         }
+        boolean nullsPadding = chunkIndex.hasNullsPadding() && chunkIndex.getNullsPadding();
+        boolean littleEndian = chunkIndex.hasLittleEndian() && chunkIndex.getLittleEndian();
         if (offset == 0)
         {
             this.inputBuffer = input;
-            boolean littleEndian = chunkIndex.hasLittleEndian() && chunkIndex.getLittleEndian();
             this.inputBuffer.order(littleEndian ? ByteOrder.LITTLE_ENDIAN : ByteOrder.BIG_ENDIAN);
             inputIndex = inputBuffer.position();
             // isNull
@@ -104,7 +105,7 @@ public class LongDecimalColumnReader extends ColumnReader
             hasNull = true;
             elementIndex = 0;
         }
-        boolean nullsPadding = chunkIndex.hasNullsPadding() && chunkIndex.getNullsPadding();
+
         // read without copying the de-compacted content and isNull
         int numLeft = size, numToRead, bytesToDeCompact;
         for (int i = vectorIndex; numLeft > 0; )
@@ -123,7 +124,7 @@ public class LongDecimalColumnReader extends ColumnReader
             hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
             if (hasNull)
             {
-                BitUtils.bitWiseDeCompactBE(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset);
+                BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset, littleEndian);
                 isNullOffset += bytesToDeCompact;
                 columnVector.noNulls = false;
             } else

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/LongDecimalColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/LongDecimalColumnReader.java
@@ -123,7 +123,7 @@ public class LongDecimalColumnReader extends ColumnReader
             hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
             if (hasNull)
             {
-                BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset);
+                BitUtils.bitWiseDeCompactBE(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset);
                 isNullOffset += bytesToDeCompact;
                 columnVector.noNulls = false;
             } else

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/StringColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/StringColumnReader.java
@@ -204,7 +204,7 @@ public class StringColumnReader extends ColumnReader
                     hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
                     if (hasNull)
                     {
-                        BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset);
+                        BitUtils.bitWiseDeCompactBE(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset);
                         isNullOffset += bytesToDeCompact;
                         columnVector.noNulls = false;
                     } else
@@ -262,7 +262,7 @@ public class StringColumnReader extends ColumnReader
                     hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
                     if (hasNull)
                     {
-                        BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset);
+                        BitUtils.bitWiseDeCompactBE(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset);
                         isNullOffset += bytesToDeCompact;
                         columnVector.noNulls = false;
                     } else
@@ -319,7 +319,7 @@ public class StringColumnReader extends ColumnReader
                 hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
                 if (hasNull)
                 {
-                    BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset);
+                    BitUtils.bitWiseDeCompactBE(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset);
                     isNullOffset += bytesToDeCompact;
                     columnVector.noNulls = false;
                 } else

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/StringColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/StringColumnReader.java
@@ -155,6 +155,8 @@ public class StringColumnReader extends ColumnReader
                      ColumnVector vector, PixelsProto.ColumnChunkIndex chunkIndex)
             throws IOException
     {
+        boolean nullsPadding = chunkIndex.hasNullsPadding() && chunkIndex.getNullsPadding();
+        boolean littleEndian = chunkIndex.hasLittleEndian() && chunkIndex.getLittleEndian();
         if (offset == 0)
         {
             if (inputBuffer != null)
@@ -162,7 +164,7 @@ public class StringColumnReader extends ColumnReader
                 inputBuffer.release();
             }
             // no memory copy
-            boolean littleEndian = chunkIndex.hasLittleEndian() && chunkIndex.getLittleEndian();
+
             ByteOrder byteOrder = littleEndian ? ByteOrder.LITTLE_ENDIAN : ByteOrder.BIG_ENDIAN;
             inputBuffer = Unpooled.wrappedBuffer(input).order(byteOrder);
             readContent(input.remaining(), encoding, byteOrder);
@@ -171,7 +173,7 @@ public class StringColumnReader extends ColumnReader
             hasNull = true;
             elementIndex = 0;
         }
-        boolean nullsPadding = chunkIndex.hasNullsPadding() && chunkIndex.getNullsPadding();
+
         // if dictionary encoded
         if (encoding.getKind().equals(PixelsProto.ColumnEncoding.Kind.DICTIONARY))
         {
@@ -204,7 +206,7 @@ public class StringColumnReader extends ColumnReader
                     hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
                     if (hasNull)
                     {
-                        BitUtils.bitWiseDeCompactBE(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset);
+                        BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset, littleEndian);
                         isNullOffset += bytesToDeCompact;
                         columnVector.noNulls = false;
                     } else
@@ -262,7 +264,7 @@ public class StringColumnReader extends ColumnReader
                     hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
                     if (hasNull)
                     {
-                        BitUtils.bitWiseDeCompactBE(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset);
+                        BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset, littleEndian);
                         isNullOffset += bytesToDeCompact;
                         columnVector.noNulls = false;
                     } else
@@ -319,7 +321,7 @@ public class StringColumnReader extends ColumnReader
                 hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
                 if (hasNull)
                 {
-                    BitUtils.bitWiseDeCompactBE(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset);
+                    BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset, littleEndian);
                     isNullOffset += bytesToDeCompact;
                     columnVector.noNulls = false;
                 } else

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/TimeColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/TimeColumnReader.java
@@ -131,7 +131,7 @@ public class TimeColumnReader extends ColumnReader
             hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
             if (hasNull)
             {
-                BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset);
+                BitUtils.bitWiseDeCompactBE(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset);
                 isNullOffset += bytesToDeCompact;
                 columnVector.noNulls = false;
             }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/TimestampColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/TimestampColumnReader.java
@@ -95,6 +95,8 @@ public class TimestampColumnReader extends ColumnReader
     {
         TimestampColumnVector columnVector = (TimestampColumnVector) vector;
         boolean nullsPadding = chunkIndex.hasNullsPadding() && chunkIndex.getNullsPadding();
+        boolean decoding = encoding.getKind().equals(PixelsProto.ColumnEncoding.Kind.RUNLENGTH);
+        boolean littleEndian = chunkIndex.hasLittleEndian() && chunkIndex.getLittleEndian();
         if (offset == 0)
         {
             if (inputStream != null)
@@ -102,7 +104,6 @@ public class TimestampColumnReader extends ColumnReader
                 inputStream.close();
             }
             this.inputBuffer = input;
-            boolean littleEndian = chunkIndex.hasLittleEndian() && chunkIndex.getLittleEndian();
             this.inputBuffer.order(littleEndian ? ByteOrder.LITTLE_ENDIAN : ByteOrder.BIG_ENDIAN);
             inputStream = new ByteBufferInputStream(inputBuffer, inputBuffer.position(), inputBuffer.limit());
             decoder = new RunLenIntDecoder(inputStream, true);
@@ -111,7 +112,6 @@ public class TimestampColumnReader extends ColumnReader
             elementIndex = 0;
         }
 
-        boolean decoding = encoding.getKind().equals(PixelsProto.ColumnEncoding.Kind.RUNLENGTH);
         // read without copying the de-compacted content and isNull
         int numLeft = size, numToRead, bytesToDeCompact;
         for (int i = vectorIndex; numLeft > 0;)
@@ -131,7 +131,7 @@ public class TimestampColumnReader extends ColumnReader
             hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
             if (hasNull)
             {
-                BitUtils.bitWiseDeCompactBE(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset);
+                BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset, littleEndian);
                 isNullOffset += bytesToDeCompact;
                 columnVector.noNulls = false;
             }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/TimestampColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/TimestampColumnReader.java
@@ -131,7 +131,7 @@ public class TimestampColumnReader extends ColumnReader
             hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
             if (hasNull)
             {
-                BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset);
+                BitUtils.bitWiseDeCompactBE(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset);
                 isNullOffset += bytesToDeCompact;
                 columnVector.noNulls = false;
             }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/utils/BitUtils.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/utils/BitUtils.java
@@ -25,7 +25,7 @@ import java.io.ByteArrayOutputStream;
 import java.nio.ByteBuffer;
 
 /**
- * pixels
+ * The bit compaction and de-compaction utils.
  *
  * @author guodong
  * @author hank
@@ -36,7 +36,14 @@ public class BitUtils
     {
     }
 
-    public static byte[] bitWiseCompact(boolean[] values, int length)
+    /**
+     * Compact the values into bytes in big endian. The elements with low indexes in values
+     * are compacted into the high bits in each byte.
+     * @param values the boolean values to compact into bytes
+     * @param length the number of elements in values to compact
+     * @return the compact result
+     */
+    public static byte[] bitWiseCompactBE(boolean[] values, int length)
     {
         ByteArrayOutputStream bitWiseOutput = new ByteArrayOutputStream();
         // Issue #99: remove to improve performance.
@@ -65,35 +72,48 @@ public class BitUtils
         return bitWiseOutput.toByteArray();
     }
 
-//    public static byte[] bitWiseCompact(long[] values, int length)
-//    {
-//        ByteArrayOutputStream bitWiseOutput = new ByteArrayOutputStream();
-//        int bitsToWrite = 1;
-//        int bitsLeft = 8;
-//        byte current = 0;
-//
-//        for (int i = 0; i < length; i++)
-//        {
-//            long v = values[i];
-//            bitsLeft -= bitsToWrite;
-//            current |= v << bitsLeft;
-//            if (bitsLeft == 0)
-//            {
-//                bitWiseOutput.write(current);
-//                current = 0;
-//                bitsLeft = 8;
-//            }
-//        }
-//
-//        if (bitsLeft != 8)
-//        {
-//            bitWiseOutput.write(current);
-//        }
-//
-//        return bitWiseOutput.toByteArray();
-//    }
+    /**
+     * Compact the values into bytes in little endian. The elements with low indexes in values
+     * are compacted into the low bits in each byte.
+     * @param values the boolean values to compact into bytes
+     * @param length the number of elements in values to compact
+     * @return the compact result
+     */
+    public static byte[] bitWiseCompactLE(boolean[] values, int length)
+    {
+        ByteArrayOutputStream bitWiseOutput = new ByteArrayOutputStream();
+        int currBit = 0;
+        byte current = 0;
 
-    public static byte[] bitWiseCompact(byte[] values, int length)
+        for (int i = 0; i < length; i++)
+        {
+            byte v = values[i] ? (byte) 1 : (byte) 0;
+            current |= v << currBit;
+            currBit ++;
+            if (currBit == 8)
+            {
+                bitWiseOutput.write(current);
+                current = 0;
+                currBit = 0;
+            }
+        }
+
+        if (currBit != 0)
+        {
+            bitWiseOutput.write(current);
+        }
+
+        return bitWiseOutput.toByteArray();
+    }
+
+    /**
+     * Compact the values into bytes in big endian. The elements with low indexes in values
+     * are compacted into the high bits in each byte.
+     * @param values the boolean values to compact into bytes, each element should be 0 (false) or 1 (true)
+     * @param length the number of elements in values to compact
+     * @return the compact result
+     */
+    public static byte[] bitWiseCompactBE(byte[] values, int length)
     {
         ByteArrayOutputStream bitWiseOutput = new ByteArrayOutputStream();
         // Issue #99: remove to improve performance.
@@ -123,12 +143,46 @@ public class BitUtils
     }
 
     /**
-     * Bit de-compaction
+     * Compact the values into bytes in little endian. The elements with low indexes in values
+     * are compacted into the low bits in each byte.
+     * @param values the boolean values to compact into bytes, each element should be 0 (false) or 1 (true)
+     * @param length the number of elements in values to compact
+     * @return the compact result
+     */
+    public static byte[] bitWiseCompactLE(byte[] values, int length)
+    {
+        ByteArrayOutputStream bitWiseOutput = new ByteArrayOutputStream();
+        int currBit = 0;
+        byte current = 0;
+
+        for (int i = 0; i < length; i++)
+        {
+            byte v = values[i];
+            current |= v << currBit;
+            currBit ++;
+            if (currBit == 8)
+            {
+                bitWiseOutput.write(current);
+                current = 0;
+                currBit = 0;
+            }
+        }
+
+        if (currBit != 0)
+        {
+            bitWiseOutput.write(current);
+        }
+
+        return bitWiseOutput.toByteArray();
+    }
+
+    /**
+     * Bit de-compaction in big endian.
      *
      * @param input input byte array
      * @return de-compacted bits
      */
-    public static void bitWiseDeCompact(byte[] bits, byte[] input)
+    public static void bitWiseDeCompactBE(byte[] bits, byte[] input)
     {
         /*
          * Issue #99:
@@ -149,7 +203,7 @@ public class BitUtils
     }
 
     /**
-     * Bit de-compaction
+     * Bit de-compaction in big endian.
      *
      * @param bits the de-compact (decode) result, each element is either 0 (false) or 1 (true)
      * @param input  input byte array
@@ -157,7 +211,7 @@ public class BitUtils
      * @param length byte length of the input
      * @return de-compacted bits
      */
-    public static void bitWiseDeCompact(byte[] bits, byte[] input, int offset, int length)
+    public static void bitWiseDeCompactBE(byte[] bits, byte[] input, int offset, int length)
     {
         /*
          * Issue #99:
@@ -178,7 +232,7 @@ public class BitUtils
     }
 
     /**
-     * Bit de-compaction, this method does not modify the current position in input byte buffer.
+     * Bit de-compaction in big endian, this method does not modify the current position in input byte buffer.
      *
      * @param bits the de-compact (decode) result, each element is either 0 (false) or 1 (true)
      * @param input input byte buffer, which can be direct
@@ -186,7 +240,7 @@ public class BitUtils
      * @param length byte length of the input
      * @return de-compacted bits
      */
-    public static void bitWiseDeCompact(byte[] bits, ByteBuffer input, int offset, int length)
+    public static void bitWiseDeCompactBE(byte[] bits, ByteBuffer input, int offset, int length)
     {
         /*
          * Issue #99:
@@ -209,7 +263,7 @@ public class BitUtils
     }
 
     /**
-     * Bit de-compaction, this method does not modify the current position in input byte buffer.
+     * Bit de-compaction in big endian, this method does not modify the current position in input byte buffer.
      *
      * @param bits the de-compact (decode) result, each element is either 0 (false) or 1 (true)
      * @param input input byte buffer, which can be direct.
@@ -217,7 +271,7 @@ public class BitUtils
      * @param length byte length of the input
      * @return de-compacted bits
      */
-    public static void bitWiseDeCompact(byte[] bits, ByteBuf input, int offset, int length)
+    public static void bitWiseDeCompactBE(byte[] bits, ByteBuf input, int offset, int length)
     {
         /*
          * Issue #99:
@@ -240,7 +294,7 @@ public class BitUtils
     }
 
     /**
-     * Bit de-compaction, this method does not modify the current position in input byte buffer.
+     * Bit de-compaction in big endian, this method does not modify the current position in input byte buffer.
      * It always starts from the first bit of a byte in the input.
      *
      * @param bits the de-compact (decode) result, each element is either 0 (false) or 1 (true)
@@ -250,7 +304,7 @@ public class BitUtils
      * @param offset starting offset of the input
      * @return de-compacted bits
      */
-    public static void bitWiseDeCompact(byte[] bits, int bitsOffset, int bitsLength, ByteBuffer input, int offset)
+    public static void bitWiseDeCompactBE(byte[] bits, int bitsOffset, int bitsLength, ByteBuffer input, int offset)
     {
         byte bitsLeft = 8, b;
         int bitsEnd = bitsOffset + bitsLength;
@@ -267,7 +321,7 @@ public class BitUtils
     }
 
     /**
-     * Bit de-compaction, this method does not modify the current position in input byte buffer.
+     * Bit de-compaction in big endian, this method does not modify the current position in input byte buffer.
      * It always starts from the first bit of a byte in the input.
      *
      * @param bits the de-compact (decode) result, each element is true if the corresponding bit is 1
@@ -277,7 +331,7 @@ public class BitUtils
      * @param offset starting offset of the input
      * @return de-compacted bits
      */
-    public static void bitWiseDeCompact(boolean[] bits, int bitsOffset, int bitsLength, ByteBuffer input, int offset)
+    public static void bitWiseDeCompactBE(boolean[] bits, int bitsOffset, int bitsLength, ByteBuffer input, int offset)
     {
         byte bitsLeft = 8, b;
         int bitsEnd = bitsOffset + bitsLength;
@@ -294,7 +348,7 @@ public class BitUtils
     }
 
     /**
-     * Bit de-compaction, this method does not modify the current position in input byte buffer.
+     * Bit de-compaction in big endian, this method does not modify the current position in input byte buffer.
      * It always starts from the first bit of a byte in the input.
      *
      * @param bits the de-compact (decode) result, each element is true if the corresponding bit is 1
@@ -304,7 +358,7 @@ public class BitUtils
      * @param offset starting offset of the input
      * @return de-compacted bits
      */
-    public static void bitWiseDeCompact(boolean[] bits, int bitsOffset, int bitsLength, ByteBuf input, int offset)
+    public static void bitWiseDeCompactBE(boolean[] bits, int bitsOffset, int bitsLength, ByteBuf input, int offset)
     {
         byte bitsLeft = 8, b;
         int bitsEnd = bitsOffset + bitsLength;
@@ -317,6 +371,182 @@ public class BitUtils
                 bits[bitsIndex++] = (0x01 & (b >> bitsLeft)) == 1;
             }
             bitsLeft = 8;
+        }
+    }
+
+    /**
+     * Bit de-compaction in little endian.
+     *
+     * @param input input byte array
+     * @return de-compacted bits
+     */
+    public static void bitWiseDeCompactLE(byte[] bits, byte[] input)
+    {
+        byte currBit = 0;
+        int index = 0;
+        for (byte b : input)
+        {
+            while (currBit < 8)
+            {
+                bits[index++] = (byte) (0x01 & (b >> currBit));
+                currBit ++;
+            }
+            currBit = 0;
+        }
+    }
+
+    /**
+     * Bit de-compaction in little endian.
+     *
+     * @param bits the de-compact (decode) result, each element is either 0 (false) or 1 (true)
+     * @param input  input byte array
+     * @param offset starting offset of the input
+     * @param length byte length of the input
+     * @return de-compacted bits
+     */
+    public static void bitWiseDeCompactLE(byte[] bits, byte[] input, int offset, int length)
+    {
+        byte currBit = 0;
+        int index = 0;
+        for (int i = offset; i < offset + length; i++)
+        {
+            while (currBit < 8)
+            {
+                bits[index++] = (byte)(0x01 & (input[i] >> currBit));
+                currBit ++;
+            }
+            currBit = 0;
+        }
+    }
+
+    /**
+     * Bit de-compaction in little endian, this method does not modify the current position in input byte buffer.
+     *
+     * @param bits the de-compact (decode) result, each element is either 0 (false) or 1 (true)
+     * @param input input byte buffer, which can be direct
+     * @param offset starting offset of the input
+     * @param length byte length of the input
+     * @return de-compacted bits
+     */
+    public static void bitWiseDeCompactLE(byte[] bits, ByteBuffer input, int offset, int length)
+    {
+        byte currBit = 0, b;
+        int index = 0;
+        for (int i = offset; i < offset + length; ++i)
+        {
+            b = input.get(i);
+            while (currBit < 8)
+            {
+                bits[index++] = (byte) (0x01 & (b >> currBit));
+                currBit ++;
+            }
+            currBit = 0;
+        }
+    }
+
+    /**
+     * Bit de-compaction in little endian, this method does not modify the current position in input byte buffer.
+     *
+     * @param bits the de-compact (decode) result, each element is either 0 (false) or 1 (true)
+     * @param input input byte buffer, which can be direct.
+     * @param offset starting offset of the input
+     * @param length byte length of the input
+     * @return de-compacted bits
+     */
+    public static void bitWiseDeCompactLE(byte[] bits, ByteBuf input, int offset, int length)
+    {
+        byte currBit = 0, b;
+        int index = 0;
+        for (int i = offset; i < offset + length; ++i)
+        {
+            b = input.getByte(i);
+            while (currBit < 8)
+            {
+                bits[index++] = (byte) (0x01 & (b >> currBit));
+                currBit ++;
+            }
+            currBit = 0;
+        }
+    }
+
+    /**
+     * Bit de-compaction in little endian, this method does not modify the current position in input byte buffer.
+     * It always starts from the first bit of a byte in the input.
+     *
+     * @param bits the de-compact (decode) result, each element is either 0 (false) or 1 (true)
+     * @param bitsOffset the index in bits to start de-compact into
+     * @param bitsLength the number of bits to de-compact
+     * @param input input byte buffer, which can be direct
+     * @param offset starting offset of the input
+     * @return de-compacted bits
+     */
+    public static void bitWiseDeCompactLE(byte[] bits, int bitsOffset, int bitsLength, ByteBuffer input, int offset)
+    {
+        byte currBit = 0, b;
+        int bitsEnd = bitsOffset + bitsLength;
+        for (int i = offset, bitsIndex = bitsOffset; bitsIndex < bitsEnd; ++i)
+        {
+            b = input.get(i);
+            while (currBit < 8 && bitsIndex < bitsEnd)
+            {
+                bits[bitsIndex++] = (byte) (0x01 & (b >> currBit));
+                currBit ++;
+            }
+            currBit = 0;
+        }
+    }
+
+    /**
+     * Bit de-compaction in little endian, this method does not modify the current position in input byte buffer.
+     * It always starts from the first bit of a byte in the input.
+     *
+     * @param bits the de-compact (decode) result, each element is true if the corresponding bit is 1
+     * @param bitsOffset the index in bits to start de-compact into
+     * @param bitsLength the number of bits to de-compact
+     * @param input input byte buffer, which can be direct
+     * @param offset starting offset of the input
+     * @return de-compacted bits
+     */
+    public static void bitWiseDeCompactLE(boolean[] bits, int bitsOffset, int bitsLength, ByteBuffer input, int offset)
+    {
+        byte currBit = 0, b;
+        int bitsEnd = bitsOffset + bitsLength;
+        for (int i = offset, bitsIndex = bitsOffset; bitsIndex < bitsEnd; ++i)
+        {
+            b = input.get(i);
+            while (currBit < 8 && bitsIndex < bitsEnd)
+            {
+                bits[bitsIndex++] = (0x01 & (b >> currBit)) == 1;
+                currBit ++;
+            }
+            currBit = 0;
+        }
+    }
+
+    /**
+     * Bit de-compaction in little endian, this method does not modify the current position in input byte buffer.
+     * It always starts from the first bit of a byte in the input.
+     *
+     * @param bits the de-compact (decode) result, each element is true if the corresponding bit is 1
+     * @param bitsOffset the index in bits to start de-compact into
+     * @param bitsLength the number of bits to de-compact
+     * @param input input byte buffer, which can be direct
+     * @param offset starting offset of the input
+     * @return de-compacted bits
+     */
+    public static void bitWiseDeCompactLE(boolean[] bits, int bitsOffset, int bitsLength, ByteBuf input, int offset)
+    {
+        byte currBit = 0, b;
+        int bitsEnd = bitsOffset + bitsLength;
+        for (int i = offset, bitsIndex = bitsOffset; bitsIndex < bitsEnd; ++i)
+        {
+            b = input.getByte(i);
+            while (currBit < 8 && bitsIndex < bitsEnd)
+            {
+                bits[bitsIndex++] = (0x01 & (b >> currBit)) == 1;
+                currBit ++;
+            }
+            currBit = 0;
         }
     }
 

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/utils/BitUtils.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/utils/BitUtils.java
@@ -23,27 +23,40 @@ import io.netty.buffer.ByteBuf;
 
 import java.io.ByteArrayOutputStream;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 
 /**
  * The bit compaction and de-compaction utils.
  *
  * @author guodong
  * @author hank
+ * @update 2023-08-26 Beijing: support endianness
  */
 public class BitUtils
 {
-    private BitUtils()
-    {
-    }
+    private BitUtils() { }
 
     /**
-     * Compact the values into bytes in big endian. The elements with low indexes in values
-     * are compacted into the high bits in each byte.
+     * Compact the values into bytes in the byte order. For big endian, the elements with low indexes in values
+     * are compacted into the high bits in each byte, and vice versa.
      * @param values the boolean values to compact into bytes
      * @param length the number of elements in values to compact
+     * @param byteOrder the byte order of the compact result
      * @return the compact result
      */
-    public static byte[] bitWiseCompactBE(boolean[] values, int length)
+    public static byte[] bitWiseCompact(boolean[] values, int length, ByteOrder byteOrder)
+    {
+        if (byteOrder.equals(ByteOrder.LITTLE_ENDIAN))
+        {
+            return bitWiseCompactLE(values, length);
+        }
+        else
+        {
+            return bitWiseCompactBE(values, length);
+        }
+    }
+
+    private static byte[] bitWiseCompactBE(boolean[] values, int length)
     {
         ByteArrayOutputStream bitWiseOutput = new ByteArrayOutputStream();
         // Issue #99: remove to improve performance.
@@ -72,14 +85,7 @@ public class BitUtils
         return bitWiseOutput.toByteArray();
     }
 
-    /**
-     * Compact the values into bytes in little endian. The elements with low indexes in values
-     * are compacted into the low bits in each byte.
-     * @param values the boolean values to compact into bytes
-     * @param length the number of elements in values to compact
-     * @return the compact result
-     */
-    public static byte[] bitWiseCompactLE(boolean[] values, int length)
+    private static byte[] bitWiseCompactLE(boolean[] values, int length)
     {
         ByteArrayOutputStream bitWiseOutput = new ByteArrayOutputStream();
         int currBit = 0;
@@ -107,13 +113,26 @@ public class BitUtils
     }
 
     /**
-     * Compact the values into bytes in big endian. The elements with low indexes in values
-     * are compacted into the high bits in each byte.
+     * Compact the values into bytes in the byte order. For big endian, the elements with low indexes in values
+     * are compacted into the high bits in each byte, and vice versa.
      * @param values the boolean values to compact into bytes, each element should be 0 (false) or 1 (true)
      * @param length the number of elements in values to compact
+     * @param byteOrder the byte order of the compact result
      * @return the compact result
      */
-    public static byte[] bitWiseCompactBE(byte[] values, int length)
+    public static byte[] bitWiseCompact(byte[] values, int length, ByteOrder byteOrder)
+    {
+        if (byteOrder.equals(ByteOrder.LITTLE_ENDIAN))
+        {
+            return bitWiseCompactLE(values, length);
+        }
+        else
+        {
+            return bitWiseCompactBE(values, length);
+        }
+    }
+
+    private static byte[] bitWiseCompactBE(byte[] values, int length)
     {
         ByteArrayOutputStream bitWiseOutput = new ByteArrayOutputStream();
         // Issue #99: remove to improve performance.
@@ -142,14 +161,7 @@ public class BitUtils
         return bitWiseOutput.toByteArray();
     }
 
-    /**
-     * Compact the values into bytes in little endian. The elements with low indexes in values
-     * are compacted into the low bits in each byte.
-     * @param values the boolean values to compact into bytes, each element should be 0 (false) or 1 (true)
-     * @param length the number of elements in values to compact
-     * @return the compact result
-     */
-    public static byte[] bitWiseCompactLE(byte[] values, int length)
+    private static byte[] bitWiseCompactLE(byte[] values, int length)
     {
         ByteArrayOutputStream bitWiseOutput = new ByteArrayOutputStream();
         int currBit = 0;
@@ -177,12 +189,26 @@ public class BitUtils
     }
 
     /**
-     * Bit de-compaction in big endian.
+     * Bit de-compaction.
      *
+     * @param bits de-compacted bits
      * @param input input byte array
-     * @return de-compacted bits
+     * @param littleEndian whether the byte order of input is little endian
      */
-    public static void bitWiseDeCompactBE(byte[] bits, byte[] input)
+    public static void bitWiseDeCompact(byte[] bits, byte[] input, boolean littleEndian)
+    {
+        if (littleEndian)
+        {
+            bitWiseDeCompactLE(bits, input);
+        }
+        else
+        {
+            bitWiseDeCompactBE(bits, input);
+        }
+    }
+
+
+    private static void bitWiseDeCompactBE(byte[] bits, byte[] input)
     {
         /*
          * Issue #99:
@@ -202,16 +228,43 @@ public class BitUtils
         }
     }
 
+    private static void bitWiseDeCompactLE(byte[] bits, byte[] input)
+    {
+        byte currBit = 0;
+        int index = 0;
+        for (byte b : input)
+        {
+            while (currBit < 8)
+            {
+                bits[index++] = (byte) (0x01 & (b >> currBit));
+                currBit ++;
+            }
+            currBit = 0;
+        }
+    }
+
     /**
-     * Bit de-compaction in big endian.
+     * Bit de-compaction.
      *
      * @param bits the de-compact (decode) result, each element is either 0 (false) or 1 (true)
      * @param input  input byte array
      * @param offset starting offset of the input
      * @param length byte length of the input
-     * @return de-compacted bits
+     * @param littleEndian whether the byte order of input is little endian
      */
-    public static void bitWiseDeCompactBE(byte[] bits, byte[] input, int offset, int length)
+    public static void bitWiseDeCompact(byte[] bits, byte[] input, int offset, int length, boolean littleEndian)
+    {
+        if (littleEndian)
+        {
+            bitWiseDeCompactLE(bits, input, offset, length);
+        }
+        else
+        {
+            bitWiseDeCompactBE(bits, input, offset, length);
+        }
+    }
+
+    private static void bitWiseDeCompactBE(byte[] bits, byte[] input, int offset, int length)
     {
         /*
          * Issue #99:
@@ -231,180 +284,7 @@ public class BitUtils
         }
     }
 
-    /**
-     * Bit de-compaction in big endian, this method does not modify the current position in input byte buffer.
-     *
-     * @param bits the de-compact (decode) result, each element is either 0 (false) or 1 (true)
-     * @param input input byte buffer, which can be direct
-     * @param offset starting offset of the input
-     * @param length byte length of the input
-     * @return de-compacted bits
-     */
-    public static void bitWiseDeCompactBE(byte[] bits, ByteBuffer input, int offset, int length)
-    {
-        /*
-         * Issue #99:
-         * Use as fewer variables as possible to reduce stack footprint
-         * and thus improve performance.
-         */
-        byte bitsLeft = 8, b;
-        int index = 0;
-        // loop condition fixed in Issue #99.
-        for (int i = offset; i < offset + length; ++i)
-        {
-            b = input.get(i);
-            while (bitsLeft > 0)
-            {
-                bitsLeft --;
-                bits[index++] = (byte) (0x01 & (b >> bitsLeft));
-            }
-            bitsLeft = 8;
-        }
-    }
-
-    /**
-     * Bit de-compaction in big endian, this method does not modify the current position in input byte buffer.
-     *
-     * @param bits the de-compact (decode) result, each element is either 0 (false) or 1 (true)
-     * @param input input byte buffer, which can be direct.
-     * @param offset starting offset of the input
-     * @param length byte length of the input
-     * @return de-compacted bits
-     */
-    public static void bitWiseDeCompactBE(byte[] bits, ByteBuf input, int offset, int length)
-    {
-        /*
-         * Issue #99:
-         * Use as fewer variables as possible to reduce stack footprint
-         * and thus improve performance.
-         */
-        byte bitsLeft = 8, b;
-        int index = 0;
-        // loop condition fixed in Issue #99.
-        for (int i = offset; i < offset + length; ++i)
-        {
-            b = input.getByte(i);
-            while (bitsLeft > 0)
-            {
-                bitsLeft --;
-                bits[index++] = (byte) (0x01 & (b >> bitsLeft));
-            }
-            bitsLeft = 8;
-        }
-    }
-
-    /**
-     * Bit de-compaction in big endian, this method does not modify the current position in input byte buffer.
-     * It always starts from the first bit of a byte in the input.
-     *
-     * @param bits the de-compact (decode) result, each element is either 0 (false) or 1 (true)
-     * @param bitsOffset the index in bits to start de-compact into
-     * @param bitsLength the number of bits to de-compact
-     * @param input input byte buffer, which can be direct
-     * @param offset starting offset of the input
-     * @return de-compacted bits
-     */
-    public static void bitWiseDeCompactBE(byte[] bits, int bitsOffset, int bitsLength, ByteBuffer input, int offset)
-    {
-        byte bitsLeft = 8, b;
-        int bitsEnd = bitsOffset + bitsLength;
-        for (int i = offset, bitsIndex = bitsOffset; bitsIndex < bitsEnd; ++i)
-        {
-            b = input.get(i);
-            while (bitsLeft > 0 && bitsIndex < bitsEnd)
-            {
-                bitsLeft --;
-                bits[bitsIndex++] = (byte) (0x01 & (b >> bitsLeft));
-            }
-            bitsLeft = 8;
-        }
-    }
-
-    /**
-     * Bit de-compaction in big endian, this method does not modify the current position in input byte buffer.
-     * It always starts from the first bit of a byte in the input.
-     *
-     * @param bits the de-compact (decode) result, each element is true if the corresponding bit is 1
-     * @param bitsOffset the index in bits to start de-compact into
-     * @param bitsLength the number of bits to de-compact
-     * @param input input byte buffer, which can be direct
-     * @param offset starting offset of the input
-     * @return de-compacted bits
-     */
-    public static void bitWiseDeCompactBE(boolean[] bits, int bitsOffset, int bitsLength, ByteBuffer input, int offset)
-    {
-        byte bitsLeft = 8, b;
-        int bitsEnd = bitsOffset + bitsLength;
-        for (int i = offset, bitsIndex = bitsOffset; bitsIndex < bitsEnd; ++i)
-        {
-            b = input.get(i);
-            while (bitsLeft > 0 && bitsIndex < bitsEnd)
-            {
-                bitsLeft --;
-                bits[bitsIndex++] = (0x01 & (b >> bitsLeft)) == 1;
-            }
-            bitsLeft = 8;
-        }
-    }
-
-    /**
-     * Bit de-compaction in big endian, this method does not modify the current position in input byte buffer.
-     * It always starts from the first bit of a byte in the input.
-     *
-     * @param bits the de-compact (decode) result, each element is true if the corresponding bit is 1
-     * @param bitsOffset the index in bits to start de-compact into
-     * @param bitsLength the number of bits to de-compact
-     * @param input input byte buffer, which can be direct
-     * @param offset starting offset of the input
-     * @return de-compacted bits
-     */
-    public static void bitWiseDeCompactBE(boolean[] bits, int bitsOffset, int bitsLength, ByteBuf input, int offset)
-    {
-        byte bitsLeft = 8, b;
-        int bitsEnd = bitsOffset + bitsLength;
-        for (int i = offset, bitsIndex = bitsOffset; bitsIndex < bitsEnd; ++i)
-        {
-            b = input.getByte(i);
-            while (bitsLeft > 0 && bitsIndex < bitsEnd)
-            {
-                bitsLeft --;
-                bits[bitsIndex++] = (0x01 & (b >> bitsLeft)) == 1;
-            }
-            bitsLeft = 8;
-        }
-    }
-
-    /**
-     * Bit de-compaction in little endian.
-     *
-     * @param input input byte array
-     * @return de-compacted bits
-     */
-    public static void bitWiseDeCompactLE(byte[] bits, byte[] input)
-    {
-        byte currBit = 0;
-        int index = 0;
-        for (byte b : input)
-        {
-            while (currBit < 8)
-            {
-                bits[index++] = (byte) (0x01 & (b >> currBit));
-                currBit ++;
-            }
-            currBit = 0;
-        }
-    }
-
-    /**
-     * Bit de-compaction in little endian.
-     *
-     * @param bits the de-compact (decode) result, each element is either 0 (false) or 1 (true)
-     * @param input  input byte array
-     * @param offset starting offset of the input
-     * @param length byte length of the input
-     * @return de-compacted bits
-     */
-    public static void bitWiseDeCompactLE(byte[] bits, byte[] input, int offset, int length)
+    private static void bitWiseDeCompactLE(byte[] bits, byte[] input, int offset, int length)
     {
         byte currBit = 0;
         int index = 0;
@@ -420,15 +300,49 @@ public class BitUtils
     }
 
     /**
-     * Bit de-compaction in little endian, this method does not modify the current position in input byte buffer.
+     * Bit de-compaction, this method does not modify the current position in input byte buffer.
      *
      * @param bits the de-compact (decode) result, each element is either 0 (false) or 1 (true)
      * @param input input byte buffer, which can be direct
      * @param offset starting offset of the input
      * @param length byte length of the input
-     * @return de-compacted bits
+     * @param littleEndian whether the byte order of input is little endian
      */
-    public static void bitWiseDeCompactLE(byte[] bits, ByteBuffer input, int offset, int length)
+    public static void bitWiseDeCompact(byte[] bits, ByteBuffer input, int offset, int length, boolean littleEndian)
+    {
+        if (littleEndian)
+        {
+            bitWiseDeCompactLE(bits, input, offset, length);
+        }
+        else
+        {
+            bitWiseDeCompactBE(bits, input, offset, length);
+        }
+    }
+
+    private static void bitWiseDeCompactBE(byte[] bits, ByteBuffer input, int offset, int length)
+    {
+        /*
+         * Issue #99:
+         * Use as fewer variables as possible to reduce stack footprint
+         * and thus improve performance.
+         */
+        byte bitsLeft = 8, b;
+        int index = 0;
+        // loop condition fixed in Issue #99.
+        for (int i = offset; i < offset + length; ++i)
+        {
+            b = input.get(i);
+            while (bitsLeft > 0)
+            {
+                bitsLeft --;
+                bits[index++] = (byte) (0x01 & (b >> bitsLeft));
+            }
+            bitsLeft = 8;
+        }
+    }
+
+    private static void bitWiseDeCompactLE(byte[] bits, ByteBuffer input, int offset, int length)
     {
         byte currBit = 0, b;
         int index = 0;
@@ -445,15 +359,49 @@ public class BitUtils
     }
 
     /**
-     * Bit de-compaction in little endian, this method does not modify the current position in input byte buffer.
+     * Bit de-compaction, this method does not modify the current position in input byte buffer.
      *
      * @param bits the de-compact (decode) result, each element is either 0 (false) or 1 (true)
-     * @param input input byte buffer, which can be direct.
+     * @param input input byte buffer, which can be direct
      * @param offset starting offset of the input
      * @param length byte length of the input
-     * @return de-compacted bits
+     * @param littleEndian whether the byte order of input is little endian
      */
-    public static void bitWiseDeCompactLE(byte[] bits, ByteBuf input, int offset, int length)
+    public static void bitWiseDeCompact(byte[] bits, ByteBuf input, int offset, int length, boolean littleEndian)
+    {
+        if (littleEndian)
+        {
+            bitWiseDeCompactLE(bits, input, offset, length);
+        }
+        else
+        {
+            bitWiseDeCompactBE(bits, input, offset, length);
+        }
+    }
+
+    private static void bitWiseDeCompactBE(byte[] bits, ByteBuf input, int offset, int length)
+    {
+        /*
+         * Issue #99:
+         * Use as fewer variables as possible to reduce stack footprint
+         * and thus improve performance.
+         */
+        byte bitsLeft = 8, b;
+        int index = 0;
+        // loop condition fixed in Issue #99.
+        for (int i = offset; i < offset + length; ++i)
+        {
+            b = input.getByte(i);
+            while (bitsLeft > 0)
+            {
+                bitsLeft --;
+                bits[index++] = (byte) (0x01 & (b >> bitsLeft));
+            }
+            bitsLeft = 8;
+        }
+    }
+
+    private static void bitWiseDeCompactLE(byte[] bits, ByteBuf input, int offset, int length)
     {
         byte currBit = 0, b;
         int index = 0;
@@ -470,7 +418,7 @@ public class BitUtils
     }
 
     /**
-     * Bit de-compaction in little endian, this method does not modify the current position in input byte buffer.
+     * Bit de-compaction, this method does not modify the current position in input byte buffer.
      * It always starts from the first bit of a byte in the input.
      *
      * @param bits the de-compact (decode) result, each element is either 0 (false) or 1 (true)
@@ -478,9 +426,38 @@ public class BitUtils
      * @param bitsLength the number of bits to de-compact
      * @param input input byte buffer, which can be direct
      * @param offset starting offset of the input
-     * @return de-compacted bits
+     * @param littleEndian whether the byte order of input is little endian
      */
-    public static void bitWiseDeCompactLE(byte[] bits, int bitsOffset, int bitsLength, ByteBuffer input, int offset)
+    public static void bitWiseDeCompact(byte[] bits, int bitsOffset, int bitsLength,
+                                        ByteBuffer input, int offset, boolean littleEndian)
+    {
+        if (littleEndian)
+        {
+            bitWiseDeCompactLE(bits, bitsOffset, bitsLength, input, offset);
+        }
+        else
+        {
+            bitWiseDeCompactBE(bits, bitsOffset, bitsLength, input, offset);
+        }
+    }
+
+    private static void bitWiseDeCompactBE(byte[] bits, int bitsOffset, int bitsLength, ByteBuffer input, int offset)
+    {
+        byte bitsLeft = 8, b;
+        int bitsEnd = bitsOffset + bitsLength;
+        for (int i = offset, bitsIndex = bitsOffset; bitsIndex < bitsEnd; ++i)
+        {
+            b = input.get(i);
+            while (bitsLeft > 0 && bitsIndex < bitsEnd)
+            {
+                bitsLeft --;
+                bits[bitsIndex++] = (byte) (0x01 & (b >> bitsLeft));
+            }
+            bitsLeft = 8;
+        }
+    }
+
+    private static void bitWiseDeCompactLE(byte[] bits, int bitsOffset, int bitsLength, ByteBuffer input, int offset)
     {
         byte currBit = 0, b;
         int bitsEnd = bitsOffset + bitsLength;
@@ -497,17 +474,46 @@ public class BitUtils
     }
 
     /**
-     * Bit de-compaction in little endian, this method does not modify the current position in input byte buffer.
+     * Bit de-compaction, this method does not modify the current position in input byte buffer.
      * It always starts from the first bit of a byte in the input.
      *
-     * @param bits the de-compact (decode) result, each element is true if the corresponding bit is 1
+     * @param bits the de-compact (decode) result, each element is either 0 (false) or 1 (true)
      * @param bitsOffset the index in bits to start de-compact into
      * @param bitsLength the number of bits to de-compact
      * @param input input byte buffer, which can be direct
      * @param offset starting offset of the input
-     * @return de-compacted bits
+     * @param littleEndian whether the byte order of input is little endian
      */
-    public static void bitWiseDeCompactLE(boolean[] bits, int bitsOffset, int bitsLength, ByteBuffer input, int offset)
+    public static void bitWiseDeCompact(boolean[] bits, int bitsOffset, int bitsLength,
+                                        ByteBuffer input, int offset, boolean littleEndian)
+    {
+        if (littleEndian)
+        {
+            bitWiseDeCompactLE(bits, bitsOffset, bitsLength, input, offset);
+        }
+        else
+        {
+            bitWiseDeCompactBE(bits, bitsOffset, bitsLength, input, offset);
+        }
+    }
+
+    private static void bitWiseDeCompactBE(boolean[] bits, int bitsOffset, int bitsLength, ByteBuffer input, int offset)
+    {
+        byte bitsLeft = 8, b;
+        int bitsEnd = bitsOffset + bitsLength;
+        for (int i = offset, bitsIndex = bitsOffset; bitsIndex < bitsEnd; ++i)
+        {
+            b = input.get(i);
+            while (bitsLeft > 0 && bitsIndex < bitsEnd)
+            {
+                bitsLeft --;
+                bits[bitsIndex++] = (0x01 & (b >> bitsLeft)) == 1;
+            }
+            bitsLeft = 8;
+        }
+    }
+
+    private static void bitWiseDeCompactLE(boolean[] bits, int bitsOffset, int bitsLength, ByteBuffer input, int offset)
     {
         byte currBit = 0, b;
         int bitsEnd = bitsOffset + bitsLength;
@@ -524,17 +530,46 @@ public class BitUtils
     }
 
     /**
-     * Bit de-compaction in little endian, this method does not modify the current position in input byte buffer.
+     * Bit de-compaction, this method does not modify the current position in input byte buffer.
      * It always starts from the first bit of a byte in the input.
      *
-     * @param bits the de-compact (decode) result, each element is true if the corresponding bit is 1
+     * @param bits the de-compact (decode) result, each element is either 0 (false) or 1 (true)
      * @param bitsOffset the index in bits to start de-compact into
      * @param bitsLength the number of bits to de-compact
      * @param input input byte buffer, which can be direct
      * @param offset starting offset of the input
-     * @return de-compacted bits
+     * @param littleEndian whether the byte order of input is little endian
      */
-    public static void bitWiseDeCompactLE(boolean[] bits, int bitsOffset, int bitsLength, ByteBuf input, int offset)
+    public static void bitWiseDeCompact(boolean[] bits, int bitsOffset, int bitsLength,
+                                        ByteBuf input, int offset, boolean littleEndian)
+    {
+        if (littleEndian)
+        {
+            bitWiseDeCompactLE(bits, bitsOffset, bitsLength, input, offset);
+        }
+        else
+        {
+            bitWiseDeCompactBE(bits, bitsOffset, bitsLength, input, offset);
+        }
+    }
+
+    private static void bitWiseDeCompactBE(boolean[] bits, int bitsOffset, int bitsLength, ByteBuf input, int offset)
+    {
+        byte bitsLeft = 8, b;
+        int bitsEnd = bitsOffset + bitsLength;
+        for (int i = offset, bitsIndex = bitsOffset; bitsIndex < bitsEnd; ++i)
+        {
+            b = input.getByte(i);
+            while (bitsLeft > 0 && bitsIndex < bitsEnd)
+            {
+                bitsLeft --;
+                bits[bitsIndex++] = (0x01 & (b >> bitsLeft)) == 1;
+            }
+            bitsLeft = 8;
+        }
+    }
+
+    private static void bitWiseDeCompactLE(boolean[] bits, int bitsOffset, int bitsLength, ByteBuf input, int offset)
     {
         byte currBit = 0, b;
         int bitsEnd = bitsOffset + bitsLength;

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/BaseColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/BaseColumnWriter.java
@@ -160,7 +160,7 @@ public abstract class BaseColumnWriter implements ColumnWriter
         // isNull
         if (hasNull)
         {
-            isNullStream.write(BitUtils.bitWiseCompactBE(isNull, curPixelIsNullIndex));
+            isNullStream.write(BitUtils.bitWiseCompact(isNull, curPixelIsNullIndex, byteOrder));
             pixelStatRecorder.setHasNull();
         }
         // update position of current pixel

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/BaseColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/BaseColumnWriter.java
@@ -160,7 +160,7 @@ public abstract class BaseColumnWriter implements ColumnWriter
         // isNull
         if (hasNull)
         {
-            isNullStream.write(BitUtils.bitWiseCompact(isNull, curPixelIsNullIndex));
+            isNullStream.write(BitUtils.bitWiseCompactBE(isNull, curPixelIsNullIndex));
             pixelStatRecorder.setHasNull();
         }
         // update position of current pixel

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/BooleanColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/BooleanColumnWriter.java
@@ -98,7 +98,7 @@ public class BooleanColumnWriter extends BaseColumnWriter
             pixelStatRecorder.updateBoolean(curPixelVector[i] != 0, 1);
         }
 
-        outputStream.write(BitUtils.bitWiseCompact(curPixelVector, curPixelVectorIndex));
+        outputStream.write(BitUtils.bitWiseCompactBE(curPixelVector, curPixelVectorIndex));
 
         super.newPixel();
     }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/BooleanColumnWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/writer/BooleanColumnWriter.java
@@ -98,7 +98,7 @@ public class BooleanColumnWriter extends BaseColumnWriter
             pixelStatRecorder.updateBoolean(curPixelVector[i] != 0, 1);
         }
 
-        outputStream.write(BitUtils.bitWiseCompactBE(curPixelVector, curPixelVectorIndex));
+        outputStream.write(BitUtils.bitWiseCompact(curPixelVector, curPixelVectorIndex, byteOrder));
 
         super.newPixel();
     }

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/encoding/TestEncoding.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/encoding/TestEncoding.java
@@ -115,11 +115,11 @@ public class TestEncoding
             cur[i] = i > 25;
             exp[i] = i > 25;
         }
-        byte[] input = BitUtils.bitWiseCompact(cur, TestParams.rowNum);
+        byte[] input = BitUtils.bitWiseCompactBE(cur, TestParams.rowNum);
 
         boolean[] res = new boolean[TestParams.rowNum];
         byte[] bytesRes = new byte[input.length * 8];
-        BitUtils.bitWiseDeCompact(bytesRes, input);
+        BitUtils.bitWiseDeCompactBE(bytesRes, input);
         for (int i = 0; i < TestParams.rowNum; i++)
         {
             res[i] = bytesRes[i] == 1;
@@ -128,7 +128,7 @@ public class TestEncoding
 
         bytesRes = new byte[8];
         res = new boolean[8];
-        BitUtils.bitWiseDeCompact(bytesRes, input, 3, 1);
+        BitUtils.bitWiseDeCompactBE(bytesRes, input, 3, 1);
         for (int i = 0; i < 8; i++)
         {
             res[i] = bytesRes[i] == 1;
@@ -149,9 +149,9 @@ public class TestEncoding
             exp[i] = i > 25 ? (byte)1  : (byte) 0;
         }
 
-        byte[] compactedBytes = BitUtils.bitWiseCompact(cur, TestParams.rowNum);
+        byte[] compactedBytes = BitUtils.bitWiseCompactBE(cur, TestParams.rowNum);
         byte[] bytesRes = new byte[compactedBytes.length * 8];
-        BitUtils.bitWiseDeCompact(bytesRes, compactedBytes);
+        BitUtils.bitWiseDeCompactBE(bytesRes, compactedBytes);
         byte[] bytes = new byte[TestParams.rowNum];
         System.arraycopy(bytesRes, 0, bytes, 0, TestParams.rowNum);
         assertArrayEquals(exp, bytes);

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/encoding/TestEncoding.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/encoding/TestEncoding.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.nio.ByteOrder;
 import java.util.Random;
 
 import static org.junit.Assert.assertArrayEquals;
@@ -115,11 +116,11 @@ public class TestEncoding
             cur[i] = i > 25;
             exp[i] = i > 25;
         }
-        byte[] input = BitUtils.bitWiseCompactBE(cur, TestParams.rowNum);
+        byte[] input = BitUtils.bitWiseCompact(cur, TestParams.rowNum, ByteOrder.BIG_ENDIAN);
 
         boolean[] res = new boolean[TestParams.rowNum];
         byte[] bytesRes = new byte[input.length * 8];
-        BitUtils.bitWiseDeCompactBE(bytesRes, input);
+        BitUtils.bitWiseDeCompact(bytesRes, input, false);
         for (int i = 0; i < TestParams.rowNum; i++)
         {
             res[i] = bytesRes[i] == 1;
@@ -128,7 +129,7 @@ public class TestEncoding
 
         bytesRes = new byte[8];
         res = new boolean[8];
-        BitUtils.bitWiseDeCompactBE(bytesRes, input, 3, 1);
+        BitUtils.bitWiseDeCompact(bytesRes, input, 3, 1, false);
         for (int i = 0; i < 8; i++)
         {
             res[i] = bytesRes[i] == 1;
@@ -149,9 +150,9 @@ public class TestEncoding
             exp[i] = i > 25 ? (byte)1  : (byte) 0;
         }
 
-        byte[] compactedBytes = BitUtils.bitWiseCompactBE(cur, TestParams.rowNum);
+        byte[] compactedBytes = BitUtils.bitWiseCompact(cur, TestParams.rowNum, ByteOrder.BIG_ENDIAN);
         byte[] bytesRes = new byte[compactedBytes.length * 8];
-        BitUtils.bitWiseDeCompactBE(bytesRes, compactedBytes);
+        BitUtils.bitWiseDeCompact(bytesRes, compactedBytes, false);
         byte[] bytes = new byte[TestParams.rowNum];
         System.arraycopy(bytesRes, 0, bytes, 0, TestParams.rowNum);
         assertArrayEquals(exp, bytes);

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/utils/TestBitUtils.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/utils/TestBitUtils.java
@@ -80,7 +80,7 @@ public class TestBitUtils
         {
             for (int j = 0; j < 100; ++j)
             {
-                BitUtils.bitWiseDeCompactBE(bits, buffer, j, 1);
+                BitUtils.bitWiseDeCompact(bits, buffer, j, 1, false);
             }
         }
 

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/utils/TestBitUtils.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/utils/TestBitUtils.java
@@ -80,7 +80,7 @@ public class TestBitUtils
         {
             for (int j = 0; j < 100; ++j)
             {
-                BitUtils.bitWiseDeCompact(bits, buffer, j, 1);
+                BitUtils.bitWiseDeCompactBE(bits, buffer, j, 1);
             }
         }
 


### PR DESCRIPTION
In bit compact, big endian means the first element in the input array is compacted as the highest bit of the first byte in the result, and vice versa.
In bit de-compact, big endian means the highest bit of the first byte in the input buffer is de-compacted as the first element in the result, and vice versa.