### PR TITLE
[Issue #548] support alignment for isNull bitmap

### DIFF
--- a/pixels-common/src/main/resources/pixels.properties
+++ b/pixels-common/src/main/resources/pixels.properties
@@ -59,8 +59,12 @@ cache.read.direct=false
 pixel.stride=10000
 # the row group size in bytes for pixels writer, should not exceed 2GB
 row.group.size=268435456
-# the chunk alignment for pixels writer, it is for SIMD and its unit is byte
+# the alignment of the start offset of a column chunk in the file, it is for SIMD and its unit is byte
 column.chunk.alignment=32
+# the alignment of the start offset of the isnull bitmap in a column chunk,
+# it is for the compatibility of DuckDB and its unit is byte.
+# for DuckDB, it is only effective when column.chunk.alignment also meets the alignment of the isNull bitmap
+isnull.bitmap.alignment=8
 # whether column chunks are encoded in pixels writer
 column.chunk.encoding=true
 # the little-endian is used on the column chunks in pixels writer

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/PixelsReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/PixelsReader.java
@@ -28,14 +28,12 @@ import java.io.IOException;
 import java.util.List;
 
 /**
- * Pixels file reader.
- * This interface is for reading pixels content as
- * {@link VectorizedRowBatch}.
+ * The interface of Pixels file reader.
+ * It is for reading pixels content into {@link VectorizedRowBatch}.
  *
- * @author guodong
+ * @author guodong, hank
  */
-public interface PixelsReader
-        extends Closeable
+public interface PixelsReader extends Closeable
 {
     /**
      * Get a <code>PixelsRecordReader</code>

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/PixelsReaderImpl.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/PixelsReaderImpl.java
@@ -48,8 +48,7 @@ import static java.util.Objects.requireNonNull;
 /**
  * Pixels file reader default implementation
  *
- * @author guodong
- * @author hank
+ * @author guodong, hank
  */
 @NotThreadSafe
 public class PixelsReaderImpl implements PixelsReader

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/PixelsWriter.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/PixelsWriter.java
@@ -25,9 +25,9 @@ import java.io.Closeable;
 import java.io.IOException;
 
 /**
- * pixels
+ * The interface of Pixels file writer.
  *
- * @author guodong
+ * @author guodong, hank
  */
 public interface PixelsWriter extends Closeable
 {
@@ -37,8 +37,7 @@ public interface PixelsWriter extends Closeable
      * @param rowBatch the row batch to be written.
      * @return if the file adds a new row group, returns false. Otherwise, returns true.
      */
-    boolean addRowBatch(VectorizedRowBatch rowBatch)
-            throws IOException;
+    boolean addRowBatch(VectorizedRowBatch rowBatch) throws IOException;
 
     /**
      * Add row batch into the file that is hash partitioned.
@@ -46,9 +45,7 @@ public interface PixelsWriter extends Closeable
      * @param rowBatch the row batch to be written.
      * @param hashValue the hashValue of the partition that the row batch is belong to.
      */
-    void addRowBatch(VectorizedRowBatch rowBatch, int hashValue)
-            throws IOException;
-
+    void addRowBatch(VectorizedRowBatch rowBatch, int hashValue) throws IOException;
 
     /**
      * Get schema of this file.

--- a/proto/pixels.proto
+++ b/proto/pixels.proto
@@ -241,6 +241,8 @@ message ColumnChunkIndex {
     // whether the null positions are padded with arbitrary value,
     // only take effects if non-random-accessible encoding (i.e., run-length) is not used
     optional bool nullsPadding = 7;
+    // the number of bytes the isNullOffset is align to
+    optional uint32 isNullAlignment = 8;
 }
 
 message RowGroupIndex {


### PR DESCRIPTION
Add the following property in pixels.properties to control the alignment of the isNull bitmap:
```properties
# the alignment of the start offset of the isnull bitmap in a column chunk,
# it is for the compatibility of DuckDB and its unit is byte.
# for DuckDB, it is only effective when column.chunk.alignment also meets the alignment of the isNull bitmap
isnull.bitmap.alignment=8
```