### PR TITLE
[Issue #572] rename columnlet to column chunk and fix dependency and comments

### DIFF
--- a/pixels-cache/README.md
+++ b/pixels-cache/README.md
@@ -10,7 +10,10 @@ Main interfaces of pixels cache includes:
 - **MappedBusReader** and **MappedBusWriter** provides message queues on top of shared memory.
 - **PixelsMetaHolder** is the metadata cache for pixels.
 
-In our previous design, the pixels cache are managed independently by the cache manager on each worker node. In the query planning phase, cache location is not considered for improving I/O performance. The location of a split/task is only determined by which node the corresponding HDFS block is located in. The cache manager on each node works in a passive manner - waiting for a split/task been assigned to this node and managing a cache for the columnlet accessed by that task.
+In our previous design, the pixels cache are managed independently by the cache manager on each worker node. 
+In the query planning phase, cache location is not considered for improving I/O performance. 
+The location of a split/task is only determined by which node the corresponding HDFS block is located in. 
+The cache manager on each node works in a passive manner - waiting for a split/task been assigned to this node and managing a cache for the column chunks accessed by that task.
 
 This is not an efficient manner, for that 
 1) pre-caching and global cache scheduling is not possible; 

--- a/pixels-cache/pom.xml
+++ b/pixels-cache/pom.xml
@@ -42,6 +42,23 @@
             <artifactId>guava</artifactId>
             <optional>true</optional>
         </dependency>
+
+        <!-- grpc -->
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-netty-shaded</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-protobuf</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-stub</artifactId>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/ColumnChunkId.java
+++ b/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/ColumnChunkId.java
@@ -25,7 +25,6 @@ import static com.google.common.base.MoreObjects.toStringHelper;
 
 /**
  * This is used to represent the cached column chunk inside a file.
- * In Pixels, columnlet = column chunk.
  *
  * @author guodong
  * @author hank

--- a/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsCacheReader.java
+++ b/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsCacheReader.java
@@ -119,20 +119,20 @@ public class PixelsCacheReader
     }
 
     /**
-     * Read specified columnlet from cache.
+     * Read specified column chunk from cache.
      * If cache is not hit, empty byte array is returned, and an access message is sent to the mq.
-     * If cache is hit, columnlet content is returned as byte array.
+     * If cache is hit, the column chunk content is returned as byte array.
      * This method may return NULL value. Be careful dealing with null!!!
      *
      * @param blockId    block id
      * @param rowGroupId row group id
      * @param columnId   column id
      * @param direct get direct byte buffer if true
-     * @return columnlet content, null if failed to read cache.
+     * @return the column chunk content, or null if failed to read the cache
      */
     public ByteBuffer get(long blockId, short rowGroupId, short columnId, boolean direct)
     {
-        // search index file for columnlet id
+        // search index file for column chunk id
         PixelsCacheKey.getBytes(keyBuffer, blockId, rowGroupId, columnId);
 
         // check the rwFlag and increase readCount.

--- a/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsPhysicalReader.java
+++ b/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsPhysicalReader.java
@@ -99,18 +99,18 @@ public class PixelsPhysicalReader
 
     }
 
-    public int read(short rowGroupId, short columnId, byte[] columnlet) throws IOException
+    public int read(short rowGroupId, short columnId, byte[] columnChunk) throws IOException
     {
         PixelsProto.RowGroupFooter rowGroupFooter = readRowGroupFooter(rowGroupId);
         PixelsProto.ColumnChunkIndex chunkIndex =
                 rowGroupFooter.getRowGroupIndexEntry().getColumnChunkIndexEntries(columnId);
-        int physicalLen = (int) chunkIndex.getChunkLength();
-        if (physicalLen > columnlet.length) {
+        int physicalLen = chunkIndex.getChunkLength();
+        if (physicalLen > columnChunk.length) {
             return physicalLen;
         }
         long physicalOffset = chunkIndex.getChunkOffset();
         physicalReader.seek(physicalOffset);
-        physicalReader.readFully(columnlet);
+        physicalReader.readFully(columnChunk);
         return physicalLen;
 
     }

--- a/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsRadix.java
+++ b/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsRadix.java
@@ -209,9 +209,9 @@ public class PixelsRadix
     }
 
     /**
-     * @Deprecated DO NOT USE THIS
      * This method currently is only used in tests
      */
+    @Deprecated
     public PixelsCacheIdx get(long blockId, short rowGroupId, short columnId)
     {
         RadixNode root = nodes.get(0);

--- a/pixels-cache/src/test/java/io/pixelsdb/pixels/cache/BenchmarkCacheReader.java
+++ b/pixels-cache/src/test/java/io/pixelsdb/pixels/cache/BenchmarkCacheReader.java
@@ -712,10 +712,10 @@ public class BenchmarkCacheReader {
 
         // build files
         Set<String> files = pixelsCacheKeys.stream().map(key -> String.valueOf(key.blockId)).collect(Collectors.toSet());
-        // build cacheColumnletOrders
-        Set<String> cacheColumnletOrders = pixelsCacheKeys.stream().map(key -> key.rowGroupId + ":" + key.columnId).collect(Collectors.toSet());
+        // build cacheColumnChunkOrders
+        Set<String> cacheColumnChunkOrders = pixelsCacheKeys.stream().map(key -> key.rowGroupId + ":" + key.columnId).collect(Collectors.toSet());
         long startWrite = System.currentTimeMillis();
-        assert (writer.incrementalLoad(623, new ArrayList<>(cacheColumnletOrders), files.toArray(new String[0])) == 0);
+        assert (writer.incrementalLoad(623, new ArrayList<>(cacheColumnChunkOrders), files.toArray(new String[0])) == 0);
 
         finish.set(1);
         finish.set(1);
@@ -808,13 +808,13 @@ public class BenchmarkCacheReader {
 
         // build files
         Set<String> files = pixelsCacheKeys.stream().map(key -> String.valueOf(key.blockId)).collect(Collectors.toSet());
-        // build cacheColumnletOrders
-        Set<String> cacheColumnletOrders = pixelsCacheKeys.stream().map(key -> key.rowGroupId + ":" + key.columnId).collect(Collectors.toSet());
+        // build cacheColumnChunkOrders
+        Set<String> cacheColumnChunkOrders = pixelsCacheKeys.stream().map(key -> key.rowGroupId + ":" + key.columnId).collect(Collectors.toSet());
         long startWrite = System.currentTimeMillis();
 
-        assert (writer.incrementalLoad(900, new ArrayList<>(cacheColumnletOrders), files.toArray(new String[0])) == 0);
-//        assert (writer.incrementalLoad(800, new ArrayList<>(cacheColumnletOrders), files.toArray(new String[0])) == 0);
-//        assert (writer.incrementalLoad(801, new ArrayList<>(cacheColumnletOrders), files.toArray(new String[0])) == 0);
+        assert (writer.incrementalLoad(900, new ArrayList<>(cacheColumnChunkOrders), files.toArray(new String[0])) == 0);
+//        assert (writer.incrementalLoad(800, new ArrayList<>(cacheColumnChunkOrders), files.toArray(new String[0])) == 0);
+//        assert (writer.incrementalLoad(801, new ArrayList<>(cacheColumnChunkOrders), files.toArray(new String[0])) == 0);
 
 
         finish.set(1);
@@ -906,10 +906,10 @@ public class BenchmarkCacheReader {
 
         // build files
         Set<String> files = pixelsCacheKeys.stream().map(key -> String.valueOf(key.blockId)).collect(Collectors.toSet());
-        // build cacheColumnletOrders
-        Set<String> cacheColumnletOrders = pixelsCacheKeys.stream().map(key -> key.rowGroupId + ":" + key.columnId).collect(Collectors.toSet());
+        // build cacheColumnChunkOrders
+        Set<String> cacheColumnChunkOrders = pixelsCacheKeys.stream().map(key -> key.rowGroupId + ":" + key.columnId).collect(Collectors.toSet());
         long startWrite = System.currentTimeMillis();
-        assert (writer.incrementalLoad(800, new ArrayList<>(cacheColumnletOrders), files.toArray(new String[0])) == 0);
+        assert (writer.incrementalLoad(800, new ArrayList<>(cacheColumnChunkOrders), files.toArray(new String[0])) == 0);
 
         finish.set(1);
         List<BenchmarkResult> results = new ArrayList<>(nReaders);

--- a/pixels-cache/src/test/java/io/pixelsdb/pixels/cache/TestPartitionCacheWriter.java
+++ b/pixels-cache/src/test/java/io/pixelsdb/pixels/cache/TestPartitionCacheWriter.java
@@ -157,9 +157,9 @@ public class TestPartitionCacheWriter {
         // construct the layout and files
         // build files
         Set<String> files = pixelsCacheKeys.stream().map(key -> String.valueOf(key.blockId)).collect(Collectors.toSet());
-        // build cacheColumnletOrders
-        Set<String> cacheColumnletOrders = pixelsCacheKeys.stream().map(key -> key.rowGroupId + ":" + key.columnId).collect(Collectors.toSet());
-        assert(writer.bulkLoad(623, new ArrayList<>(cacheColumnletOrders), files.toArray(new String[0])) == 0);
+        // build cacheColumnChunkOrders
+        Set<String> cacheColumnChunkOrders = pixelsCacheKeys.stream().map(key -> key.rowGroupId + ":" + key.columnId).collect(Collectors.toSet());
+        assert(writer.bulkLoad(623, new ArrayList<>(cacheColumnChunkOrders), files.toArray(new String[0])) == 0);
 
         long realIndexSize = cacheConfig.getIndexSize() / (cacheConfig.getPartitions()) * (cacheConfig.getPartitions() + 1) + PixelsCacheUtil.PARTITION_INDEX_META_SIZE;
         long realCacheSize = cacheConfig.getCacheSize() / (cacheConfig.getPartitions()) * (cacheConfig.getPartitions() + 1) + PixelsCacheUtil.CACHE_DATA_OFFSET;
@@ -212,9 +212,9 @@ public class TestPartitionCacheWriter {
         // construct the layout and files
         // build files
         Set<String> files = pixelsCacheKeys.stream().map(key -> String.valueOf(key.blockId)).collect(Collectors.toSet());
-        // build cacheColumnletOrders
-        Set<String> cacheColumnletOrders = pixelsCacheKeys.stream().map(key -> key.rowGroupId + ":" + key.columnId).collect(Collectors.toSet());
-        assert(writer.bulkLoad(623, new ArrayList<>(cacheColumnletOrders), files.toArray(new String[0])) == 0);
+        // build cacheColumnChunkOrders
+        Set<String> cacheColumnChunkOrders = pixelsCacheKeys.stream().map(key -> key.rowGroupId + ":" + key.columnId).collect(Collectors.toSet());
+        assert(writer.bulkLoad(623, new ArrayList<>(cacheColumnChunkOrders), files.toArray(new String[0])) == 0);
 
         PartitionCacheReader reader = PartitionCacheReader.newBuilder().setIndexType(indexType)
                 .setCacheLocation(cacheConfig.getCacheLocation()).setIndexLocation(cacheConfig.getIndexLocation()).build2();
@@ -260,9 +260,9 @@ public class TestPartitionCacheWriter {
         // construct the layout and files
         // build files
         Set<String> files = pixelsCacheKeys.stream().map(key -> String.valueOf(key.blockId)).collect(Collectors.toSet());
-        // build cacheColumnletOrders
-        Set<String> cacheColumnletOrders = pixelsCacheKeys.stream().map(key -> key.rowGroupId + ":" + key.columnId).collect(Collectors.toSet());
-        assert(writer.bulkLoad(623, new ArrayList<>(cacheColumnletOrders), files.toArray(new String[0])) == 0);
+        // build cacheColumnChunkOrders
+        Set<String> cacheColumnChunkOrders = pixelsCacheKeys.stream().map(key -> key.rowGroupId + ":" + key.columnId).collect(Collectors.toSet());
+        assert(writer.bulkLoad(623, new ArrayList<>(cacheColumnChunkOrders), files.toArray(new String[0])) == 0);
 
         long realIndexSize = cacheConfig.getIndexSize() / (cacheConfig.getPartitions()) * (cacheConfig.getPartitions() + 1) + PixelsCacheUtil.PARTITION_INDEX_META_SIZE;
         long realCacheSize = cacheConfig.getCacheSize() / (cacheConfig.getPartitions()) * (cacheConfig.getPartitions() + 1) + PixelsCacheUtil.CACHE_DATA_OFFSET;
@@ -330,9 +330,9 @@ public class TestPartitionCacheWriter {
         // construct the layout and files
         // build files
         Set<String> files = pixelsCacheKeys.stream().map(key -> String.valueOf(key.blockId)).collect(Collectors.toSet());
-        // build cacheColumnletOrders
-        Set<String> cacheColumnletOrders = pixelsCacheKeys.stream().map(key -> key.rowGroupId + ":" + key.columnId).collect(Collectors.toSet());
-        assert(writer.bulkLoad(623, new ArrayList<>(cacheColumnletOrders), files.toArray(new String[0])) == 0);
+        // build cacheColumnChunkOrders
+        Set<String> cacheColumnChunkOrders = pixelsCacheKeys.stream().map(key -> key.rowGroupId + ":" + key.columnId).collect(Collectors.toSet());
+        assert(writer.bulkLoad(623, new ArrayList<>(cacheColumnChunkOrders), files.toArray(new String[0])) == 0);
 
         PartitionCacheReader reader = PartitionCacheReader.newBuilder().setCacheLocation(cacheConfig.getCacheLocation())
                 .setIndexLocation(cacheConfig.getIndexLocation()).setIndexType(indexType).build2();
@@ -391,10 +391,10 @@ public class TestPartitionCacheWriter {
         // construct the layout and files
         // build files
         Set<String> files = pixelsCacheKeys.stream().map(key -> String.valueOf(key.blockId)).collect(Collectors.toSet());
-        // build cacheColumnletOrders
-        Set<String> cacheColumnletOrders = pixelsCacheKeys.stream().map(key -> key.rowGroupId + ":" + key.columnId).collect(Collectors.toSet());
-//        writer.bulkLoad(623, new ArrayList<>(cacheColumnletOrders), files.toArray(new String[0]));
-        assert(writer.incrementalLoad(623, new ArrayList<>(cacheColumnletOrders), files.toArray(new String[0])) == 0);
+        // build cacheColumnChunkOrders
+        Set<String> cacheColumnChunkOrders = pixelsCacheKeys.stream().map(key -> key.rowGroupId + ":" + key.columnId).collect(Collectors.toSet());
+//        writer.bulkLoad(623, new ArrayList<>(cacheColumnChunkOrders), files.toArray(new String[0]));
+        assert(writer.incrementalLoad(623, new ArrayList<>(cacheColumnChunkOrders), files.toArray(new String[0])) == 0);
 
         long realIndexSize = cacheConfig.getIndexSize() / (cacheConfig.getPartitions()) * (cacheConfig.getPartitions() + 1) + PixelsCacheUtil.PARTITION_INDEX_META_SIZE;
         long realCacheSize = cacheConfig.getCacheSize() / (cacheConfig.getPartitions()) * (cacheConfig.getPartitions() + 1) + PixelsCacheUtil.CACHE_DATA_OFFSET;
@@ -491,9 +491,9 @@ public class TestPartitionCacheWriter {
 
         // build files
         Set<String> files = pixelsCacheKeys.stream().map(key -> String.valueOf(key.blockId)).collect(Collectors.toSet());
-        // build cacheColumnletOrders
-        Set<String> cacheColumnletOrders = pixelsCacheKeys.stream().map(key -> key.rowGroupId + ":" + key.columnId).collect(Collectors.toSet());
-        assert (writer.incrementalLoad(623, new ArrayList<>(cacheColumnletOrders), files.toArray(new String[0])) == 0);
+        // build cacheColumnChunkOrders
+        Set<String> cacheColumnChunkOrders = pixelsCacheKeys.stream().map(key -> key.rowGroupId + ":" + key.columnId).collect(Collectors.toSet());
+        assert (writer.incrementalLoad(623, new ArrayList<>(cacheColumnChunkOrders), files.toArray(new String[0])) == 0);
 
         finish.set(1);
     }
@@ -670,9 +670,9 @@ public class TestPartitionCacheWriter {
 
         // build files
         Set<String> files = pixelsCacheKeys.stream().map(key -> String.valueOf(key.blockId)).collect(Collectors.toSet());
-        // build cacheColumnletOrders
-        Set<String> cacheColumnletOrders = pixelsCacheKeys.stream().map(key -> key.rowGroupId + ":" + key.columnId).collect(Collectors.toSet());
-        assert (writer.incrementalLoad(623, new ArrayList<>(cacheColumnletOrders), files.toArray(new String[0])) == 0);
+        // build cacheColumnChunkOrders
+        Set<String> cacheColumnChunkOrders = pixelsCacheKeys.stream().map(key -> key.rowGroupId + ":" + key.columnId).collect(Collectors.toSet());
+        assert (writer.incrementalLoad(623, new ArrayList<>(cacheColumnChunkOrders), files.toArray(new String[0])) == 0);
 
         finish.set(1);
     }
@@ -755,9 +755,9 @@ public class TestPartitionCacheWriter {
 
         // build files
         Set<String> files = pixelsCacheKeys.stream().map(key -> String.valueOf(key.blockId)).collect(Collectors.toSet());
-        // build cacheColumnletOrders
-        Set<String> cacheColumnletOrders = pixelsCacheKeys.stream().map(key -> key.rowGroupId + ":" + key.columnId).collect(Collectors.toSet());
-        assert (writer.incrementalLoad(623, new ArrayList<>(cacheColumnletOrders), files.toArray(new String[0])) == 0);
+        // build cacheColumnChunkOrders
+        Set<String> cacheColumnChunkOrders = pixelsCacheKeys.stream().map(key -> key.rowGroupId + ":" + key.columnId).collect(Collectors.toSet());
+        assert (writer.incrementalLoad(623, new ArrayList<>(cacheColumnChunkOrders), files.toArray(new String[0])) == 0);
 
         finish.set(1);
     }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/PixelsRecordReaderImpl.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/PixelsRecordReaderImpl.java
@@ -593,7 +593,7 @@ public class PixelsRecordReaderImpl implements PixelsRecordReader
                      */
                     // int rgId = rgIdx + RGStart;
                     int rgId = targetRGs[rgIdx];
-                    // TODO: not only columnlets in cacheOrder are cached.
+                    // TODO: not only the column chunks in cacheOrder are cached.
                     String cacheIdentifier = rgId + ":" + colId;
                     // if cached, read from cache files
                     if (cacheOrder.contains(cacheIdentifier))
@@ -628,18 +628,18 @@ public class PixelsRecordReaderImpl implements PixelsRecordReader
                 short rgId = columnChunkId.rowGroupId;
                 short colId = columnChunkId.columnId;
 //                long getBegin = System.nanoTime();
-                ByteBuffer columnlet = cacheReader.get(blockId, rgId, colId, columnChunkId.direct);
-                memoryUsage += columnChunkId.direct ? 0 : columnlet.capacity();
+                ByteBuffer columnChunk = cacheReader.get(blockId, rgId, colId, columnChunkId.direct);
+                memoryUsage += columnChunkId.direct ? 0 : columnChunk.capacity();
 //                long getEnd = System.nanoTime();
-//                logger.debug("[cache get]: " + columnlet.length + "," + (getEnd - getBegin));
-                chunkBuffers[(rgId - RGStart) * includedColumns.length + colId] = columnlet;
-                if (columnlet == null || columnlet.capacity() == 0)
+//                logger.debug("[cache get]: " + columnChunk.length + "," + (getEnd - getBegin));
+                chunkBuffers[(rgId - RGStart) * includedColumns.length + colId] = columnChunk;
+                if (columnChunk == null || columnChunk.capacity() == 0)
                 {
                     /**
                      * Issue #67 (patch):
                      * Deal with null or empty cache chunk.
-                     * If cache read failed (e.g. cache read timeout), column chunk (columnlet) will be null.
-                     * In this condition, we have to read the column chunk (columnlet) from disk.
+                     * If cache read failed (e.g. cache read timeout), column chunk will be null.
+                     * In this condition, we have to read the column chunk from disk.
                      */
                     int rgIdx = rgId - RGStart;
                     PixelsProto.RowGroupIndex rowGroupIndex =
@@ -652,7 +652,7 @@ public class PixelsRecordReaderImpl implements PixelsRecordReader
                 }
                 else
                 {
-                    this.cacheReadBytes += columnlet.capacity();
+                    this.cacheReadBytes += columnChunk.capacity();
                 }
             }
         }

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/writer/TestPixelsWriter.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/writer/TestPixelsWriter.java
@@ -366,9 +366,9 @@ public class TestPixelsWriter
                 PixelsPhysicalReader pixelsPhysicalReader = new PixelsPhysicalReader(storage, file);
                 for (int i = 0; i < cacheBorder; i++)
                 {
-                    String[] cacheColumnletIdParts = cacheOrders.get(i).split(":");
-                    short cacheRGId = Short.parseShort(cacheColumnletIdParts[0]);
-                    short cacheColId = Short.parseShort(cacheColumnletIdParts[1]);
+                    String[] cacheColumnChunkIdParts = cacheOrders.get(i).split(":");
+                    short cacheRGId = Short.parseShort(cacheColumnChunkIdParts[0]);
+                    short cacheColId = Short.parseShort(cacheColumnChunkIdParts[1]);
                     PixelsProto.RowGroupFooter rowGroupFooter = pixelsPhysicalReader.readRowGroupFooter(cacheRGId);
                     PixelsProto.ColumnChunkIndex chunkIndex =
                             rowGroupFooter.getRowGroupIndexEntry().getColumnChunkIndexEntries(cacheColId);

--- a/pixels-daemon/src/main/resources/layout_compact.json
+++ b/pixels-daemon/src/main/resources/layout_compact.json
@@ -1,8 +1,8 @@
 {
-  "numRowGroupInBlock" : 3,
+  "numRowGroupInFile" : 3,
   "numColumn": 5,
   "cacheBorder": 8,
-  "columnletOrder":
+  "columnChunkOrder":
   [
     "0:2",
     "1:4",

--- a/pixels-daemon/src/main/resources/layout_splits.json
+++ b/pixels-daemon/src/main/resources/layout_splits.json
@@ -1,5 +1,5 @@
 {
-  "numRowGroupInBlock":4,
+  "numRowGroupInFile":4,
   "splitPatterns":
   [
     {


### PR DESCRIPTION
1. Columnlet was used to reference the column chunk in a row group. However, these two terms are confusing in the code and comments. As column chunk is widely used in other literature, we rename all occurrences of columnlet to column chunk.
2. grpc is needed by the unit tests in pixels-cache, we add it back to the pom.