### PR TITLE
[Issue #491] implement plan coordinator initialization

### DIFF
--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/task/Task.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/task/Task.java
@@ -34,12 +34,11 @@ public class Task
 {
     public enum Status
     {
-        PENDING, RUNNING, TIMEOUT, COMPLETE, ABORT
+        PENDING, RUNNING, TIMEOUT, COMPLETE, ABORT, FAILED
     }
 
     private final String taskId;
     private final String payload;
-    private String output;
     private Status status;
     private Worker<? extends WorkerInfo> worker;
 
@@ -71,7 +70,7 @@ public class Task
         }
     }
 
-    protected boolean complete(String output)
+    protected boolean complete(boolean success)
     {
         synchronized (this.taskId)
         {
@@ -79,8 +78,14 @@ public class Task
             {
                 return false;
             }
-            this.status = Status.COMPLETE;
-            this.output = output;
+            if (success)
+            {
+                this.status = Status.COMPLETE;
+            }
+            else
+            {
+                this.status = Status.FAILED;
+            }
             return true;
         }
     }
@@ -129,11 +134,6 @@ public class Task
     public String getPayload()
     {
         return payload;
-    }
-
-    public String getOutput()
-    {
-        return output;
     }
 
     @Override

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/task/Task.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/task/Task.java
@@ -37,12 +37,12 @@ public class Task
         PENDING, RUNNING, TIMEOUT, COMPLETE, ABORT, FAILED
     }
 
-    private final String taskId;
+    private final Integer taskId;
     private final String payload;
     private Status status;
     private Worker<? extends WorkerInfo> worker;
 
-    public Task(String taskId, String payload)
+    public Task(int taskId, String payload)
     {
         this.taskId = taskId;
         this.payload = payload;
@@ -126,7 +126,7 @@ public class Task
         return true;
     }
 
-    public String getTaskId()
+    public int getTaskId()
     {
         return taskId;
     }

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/task/TaskQueue.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/task/TaskQueue.java
@@ -112,15 +112,15 @@ public class TaskQueue<E extends Task>
     /**
      * Retrieve a running task and set its status to complete.
      * @param taskId the task id
-     * @param output the output (json) of the completed task
+     * @param success true if the task completes successfully
      * @return the task that is completed, or null if no such task
      */
-    public E complete(String taskId, String output)
+    public E complete(String taskId, boolean success)
     {
         E task = this.runningTasks.remove(taskId);
         if (task != null)
         {
-            task.complete(output);
+            task.complete(success);
             return task;
         }
         else

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/task/TaskQueue.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/task/TaskQueue.java
@@ -35,7 +35,7 @@ public class TaskQueue<E extends Task>
 {
     private final LinkedList<E> allTasks;
     private final ConcurrentLinkedQueue<E> pendingQueue;
-    private final ConcurrentHashMap<String, E> runningTasks;
+    private final ConcurrentHashMap<Integer, E> runningTasks;
 
     public TaskQueue()
     {
@@ -115,7 +115,7 @@ public class TaskQueue<E extends Task>
      * @param success true if the task completes successfully
      * @return the task that is completed, or null if no such task
      */
-    public E complete(String taskId, boolean success)
+    public E complete(int taskId, boolean success)
     {
         E task = this.runningTasks.remove(taskId);
         if (task != null)
@@ -135,7 +135,7 @@ public class TaskQueue<E extends Task>
      */
     public E removeNextExpired()
     {
-        Iterator<Map.Entry<String, E>> iterator = this.runningTasks.entrySet().iterator();
+        Iterator<Map.Entry<Integer, E>> iterator = this.runningTasks.entrySet().iterator();
         while (iterator.hasNext())
         {
             E task = iterator.next().getValue();

--- a/pixels-common/src/test/java/io/pixelsdb/pixels/common/task/TestQueue.java
+++ b/pixels-common/src/test/java/io/pixelsdb/pixels/common/task/TestQueue.java
@@ -30,7 +30,7 @@ public class TestQueue
     @Test
     public void testTaskConstruction()
     {
-        Task task = new Task("123", "{\"id\":456}");
+        Task task = new Task(123, "{\"id\":456}");
         System.out.println(task.getTaskId());
         System.out.println(task.getPayload());
     }

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/coordinate/PlanCoordinator.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/coordinate/PlanCoordinator.java
@@ -19,8 +19,9 @@
  */
 package io.pixelsdb.pixels.planner.coordinate;
 
+import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
@@ -32,14 +33,22 @@ import static java.util.Objects.requireNonNull;
 public class PlanCoordinator
 {
     private final long transId;
-    private final Map<Integer, StageCoordinator> stageCoordinators;
-    private final Map<Integer, StageDependency> stageDependencies;
+    /**
+     * It is only modified during coordinator initialization, thus there is no read-write conflict.
+     */
+    private final Map<Integer, StageCoordinator> stageCoordinators = new HashMap<>();
+    /**
+     * It is only modified during coordinator initialization, thus there is no read-write conflict.
+     */
+    private final Map<Integer, StageDependency> stageDependencies = new HashMap<>();
+    /**
+     * The assigner of stage id.
+     */
+    private final AtomicInteger stageIdAssigner = new AtomicInteger(0);
 
     public PlanCoordinator(long transId)
     {
         this.transId = transId;
-        this.stageCoordinators = new ConcurrentHashMap<>();
-        this.stageDependencies = new ConcurrentHashMap<>();
     }
 
     public void addStageCoordinator(StageCoordinator stageCoordinator, StageDependency stageDependency)
@@ -66,5 +75,10 @@ public class PlanCoordinator
     public long getTransId()
     {
         return transId;
+    }
+
+    public int assignStageId()
+    {
+        return this.stageIdAssigner.getAndIncrement();
     }
 }

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/coordinate/PlanCoordinator.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/coordinate/PlanCoordinator.java
@@ -51,7 +51,7 @@ public class PlanCoordinator
         this.transId = transId;
     }
 
-    public void addStageCoordinator(StageCoordinator stageCoordinator, StageDependency stageDependency)
+    protected void addStageCoordinator(StageCoordinator stageCoordinator, StageDependency stageDependency)
     {
         int stageId = requireNonNull(stageCoordinator, "stageCoordinator is null").getStageId();
         requireNonNull(stageDependency, "stageDependency is null");

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/coordinate/PlanCoordinator.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/coordinate/PlanCoordinator.java
@@ -51,7 +51,7 @@ public class PlanCoordinator
         this.transId = transId;
     }
 
-    protected void addStageCoordinator(StageCoordinator stageCoordinator, StageDependency stageDependency)
+    public void addStageCoordinator(StageCoordinator stageCoordinator, StageDependency stageDependency)
     {
         int stageId = requireNonNull(stageCoordinator, "stageCoordinator is null").getStageId();
         requireNonNull(stageDependency, "stageDependency is null");

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/coordinate/PlanCoordinatorFactory.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/coordinate/PlanCoordinatorFactory.java
@@ -47,7 +47,7 @@ public class PlanCoordinatorFactory
     public void createPlanCoordinator(long transId, Operator planRootOperator)
     {
         PlanCoordinator planCoordinator = new PlanCoordinator(transId);
-        planRootOperator.initPlanCoordinator(planCoordinator);
+        planRootOperator.initPlanCoordinator(planCoordinator, -1);
         this.transIdToPlanCoordinator.put(transId, planCoordinator);
     }
 

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/coordinate/PlanCoordinatorFactory.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/coordinate/PlanCoordinatorFactory.java
@@ -47,7 +47,7 @@ public class PlanCoordinatorFactory
     public void createPlanCoordinator(long transId, Operator planRootOperator)
     {
         PlanCoordinator planCoordinator = new PlanCoordinator(transId);
-        planRootOperator.initPlanCoordinator(planCoordinator, -1);
+        planRootOperator.initPlanCoordinator(planCoordinator, -1, false);
         this.transIdToPlanCoordinator.put(transId, planCoordinator);
     }
 

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/coordinate/PlanCoordinatorFactory.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/coordinate/PlanCoordinatorFactory.java
@@ -19,6 +19,8 @@
  */
 package io.pixelsdb.pixels.planner.coordinate;
 
+import io.pixelsdb.pixels.planner.plan.physical.Operator;
+
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -42,7 +44,12 @@ public class PlanCoordinatorFactory
         this.transIdToPlanCoordinator = new ConcurrentHashMap<>();
     }
 
-    // TODO: create plan coordinator given a query plan and add it into transIdToPlanCoordinator.
+    public void createPlanCoordinator(long transId, Operator planRootOperator)
+    {
+        PlanCoordinator planCoordinator = new PlanCoordinator(transId);
+        planRootOperator.initPlanCoordinator(planCoordinator);
+        this.transIdToPlanCoordinator.put(transId, planCoordinator);
+    }
 
     public PlanCoordinator getPlanCoordinator(long transId)
     {

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/coordinate/StageCoordinator.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/coordinate/StageCoordinator.java
@@ -118,7 +118,7 @@ public class StageCoordinator
         }
     }
 
-    public void completeTask(String taskId, boolean success)
+    public void completeTask(int taskId, boolean success)
     {
         checkArgument(this.isQueued && this.taskQueue != null,
                 "can not complete task on a non-queued stage");

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/coordinate/StageCoordinator.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/coordinate/StageCoordinator.java
@@ -58,7 +58,7 @@ public class StageCoordinator
     // this.workers is used for dependency checking, no concurrent reads and writes
     private final List<Worker<CFWorkerInfo>> workers = new ArrayList<>();
     private final Map<Long, Integer> workerIdToWorkerIndex = new ConcurrentHashMap<>();
-    private final AtomicInteger workerIndex = new AtomicInteger(0);
+    private final AtomicInteger workerIndexAssigner = new AtomicInteger(0);
     private final Object lock = new Object();
 
     public StageCoordinator(int stageId, int workerNum)
@@ -80,7 +80,7 @@ public class StageCoordinator
     public void addWorker(Worker<CFWorkerInfo> worker)
     {
         this.workerIdToWorkers.put(worker.getWorkerId(), worker);
-        this.workerIdToWorkerIndex.put(worker.getWorkerId(), this.workerIndex.getAndIncrement());
+        this.workerIdToWorkerIndex.put(worker.getWorkerId(), this.workerIndexAssigner.getAndIncrement());
         if (!this.isQueued && this.workers.size() == this.fixedWorkerNum)
         {
             this.lock.notifyAll();
@@ -118,11 +118,11 @@ public class StageCoordinator
         }
     }
 
-    public void completeTask(String taskId, String output)
+    public void completeTask(String taskId, boolean success)
     {
         checkArgument(this.isQueued && this.taskQueue != null,
                 "can not complete task on a non-queued stage");
-        this.taskQueue.complete(taskId, output);
+        this.taskQueue.complete(taskId, success);
     }
 
     public int getStageId()

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/coordinate/StageDependency.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/coordinate/StageDependency.java
@@ -19,6 +19,8 @@
  */
 package io.pixelsdb.pixels.planner.coordinate;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 /**
  * @author hank
  * @create 2023-09-24
@@ -26,11 +28,15 @@ package io.pixelsdb.pixels.planner.coordinate;
 public class StageDependency
 {
     private final int currentStageId;
+    /**
+     * {@link #downStreamStageId} can be negative if there is no valid downstream stage
+     */
     private final int downStreamStageId;
     private final boolean isWide;
 
     public StageDependency(int currentStageId, int downStreamStageId, boolean isWide)
     {
+        checkArgument(currentStageId >= 0, "currentStageId must be non-negative");
         this.currentStageId = currentStageId;
         this.downStreamStageId = downStreamStageId;
         this.isWide = isWide;
@@ -44,6 +50,11 @@ public class StageDependency
     public int getDownStreamStageId()
     {
         return downStreamStageId;
+    }
+
+    public boolean hasDownstreamStage()
+    {
+        return this.downStreamStageId >= 0;
     }
 
     /**

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/coordinate/TaskInfo.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/coordinate/TaskInfo.java
@@ -29,7 +29,7 @@ public class TaskInfo
 {
     private final String taskId;
     private final String payload;
-    private String output;
+    private boolean success;
 
     public TaskInfo(String taskId, String payload)
     {
@@ -53,18 +53,18 @@ public class TaskInfo
         return payload;
     }
 
-    public String getOutput()
+    public boolean isSuccess()
     {
-        return output;
+        return success;
     }
 
-    public void setOutput(String output)
+    public void setSuccess(boolean success)
     {
-        this.output = output;
+        this.success = success;
     }
 
-    public TurboProto.TaskOutput toTaskOutputProto()
+    public TurboProto.TaskResult toTaskResultProto()
     {
-        return TurboProto.TaskOutput.newBuilder().setTaskId(this.taskId).setOutput(this.output).build();
+        return TurboProto.TaskResult.newBuilder().setTaskId(this.taskId).setSuccess(this.success).build();
     }
 }

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/coordinate/TaskInfo.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/coordinate/TaskInfo.java
@@ -27,11 +27,11 @@ import io.pixelsdb.pixels.turbo.TurboProto;
  */
 public class TaskInfo
 {
-    private final String taskId;
+    private final int taskId;
     private final String payload;
     private boolean success;
 
-    public TaskInfo(String taskId, String payload)
+    public TaskInfo(int taskId, String payload)
     {
         this.taskId = taskId;
         this.payload = payload;
@@ -43,7 +43,7 @@ public class TaskInfo
         this.payload = taskInput.getPayload();
     }
 
-    public String getTaskId()
+    public int getTaskId()
     {
         return taskId;
     }

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/coordinate/WorkerCoordinateService.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/coordinate/WorkerCoordinateService.java
@@ -149,7 +149,7 @@ public class WorkerCoordinateService
                 TurboProto.CompleteTasksRequest.newBuilder().setWorkerId(workerId);
         for (TaskInfo taskInfo : tasks)
         {
-            request.addTaskOutputs(taskInfo.toTaskOutputProto());
+            request.addTaskResults(taskInfo.toTaskResultProto());
         }
         TurboProto.CompleteTasksResponse response = this.stub.completeTasks(request.build());
         if (response.getErrorCode() != SUCCESS)

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/coordinate/WorkerCoordinateService.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/coordinate/WorkerCoordinateService.java
@@ -28,11 +28,11 @@ import io.pixelsdb.pixels.common.task.Worker;
 import io.pixelsdb.pixels.turbo.TurboProto;
 import io.pixelsdb.pixels.turbo.WorkerCoordinateServiceGrpc;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import static io.pixelsdb.pixels.common.error.ErrorCode.SUCCESS;
-import static io.pixelsdb.pixels.common.error.ErrorCode.WORKER_COORDINATE_END_OF_TASKS;
+import static io.pixelsdb.pixels.common.error.ErrorCode.*;
 
 /**
  * The coordinate service for the cloud function workers that are involved in pipelining query execution.
@@ -83,8 +83,8 @@ public class WorkerCoordinateService
      * If this worker is not the end of the execution pipeline (i.e., belongs to the root of the query plan),
      * it must get the downstream worker or workers where it should send the intermediate results to.
      * @param workerId the id of this worker
-     * @return the basic information of the downstream workers
-     * @throws WorkerCoordinateException
+     * @return the basic information of the downstream worker(s), or empty list if there is no downstream worker(s)
+     * @throws WorkerCoordinateException if there are any other errors
      */
     public List<CFWorkerInfo> getDownstreamWorkers(long workerId) throws WorkerCoordinateException
     {
@@ -93,6 +93,10 @@ public class WorkerCoordinateService
         TurboProto.GetDownstreamWorkersResponse response = this.stub.getDownstreamWorkers(request);
         if (response.getErrorCode() != SUCCESS)
         {
+            if (response.getErrorCode() == WORKER_COORDINATE_NO_DOWNSTREAM)
+            {
+                return Collections.emptyList();
+            }
             throw new WorkerCoordinateException("failed to get downstream workers, error code=" + response.getErrorCode());
         }
         ImmutableList.Builder<CFWorkerInfo> builder = ImmutableList.builder();

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/coordinate/WorkerCoordinateServiceImpl.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/coordinate/WorkerCoordinateServiceImpl.java
@@ -161,15 +161,15 @@ public class WorkerCoordinateServiceImpl extends WorkerCoordinateServiceGrpc.Wor
                               StreamObserver<TurboProto.CompleteTasksResponse> responseObserver)
     {
         long workerId = request.getWorkerId();
-        List<TurboProto.TaskOutput> taskOutputs = request.getTaskOutputsList();
+        List<TurboProto.TaskResult> taskResults = request.getTaskResultsList();
         Worker<CFWorkerInfo> worker = CFWorkerManager.Instance().getCFWorker(workerId);
         CFWorkerInfo workerInfo = worker.getWorkerInfo();
         PlanCoordinator planCoordinator = PlanCoordinatorFactory.Instance().getPlanCoordinator(workerInfo.getTransId());
         StageCoordinator stageCoordinator = planCoordinator.getStageCoordinator(workerInfo.getStageId());
         TurboProto.CompleteTasksResponse.Builder builder = TurboProto.CompleteTasksResponse.newBuilder();
-        for (TurboProto.TaskOutput taskOutput : taskOutputs)
+        for (TurboProto.TaskResult taskOutput : taskResults)
         {
-            stageCoordinator.completeTask(taskOutput.getTaskId(), taskOutput.getOutput());
+            stageCoordinator.completeTask(taskOutput.getTaskId(), taskOutput.getSuccess());
         }
         builder.setErrorCode(SUCCESS);
         responseObserver.onNext(builder.build());

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/coordinate/WorkerCoordinateServiceImpl.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/coordinate/WorkerCoordinateServiceImpl.java
@@ -78,7 +78,7 @@ public class WorkerCoordinateServiceImpl extends WorkerCoordinateServiceGrpc.Wor
         PlanCoordinator planCoordinator = PlanCoordinatorFactory.Instance().getPlanCoordinator(workerInfo.getTransId());
         StageDependency dependency = planCoordinator.getStageDependency(workerInfo.getStageId());
         TurboProto.GetDownstreamWorkersResponse.Builder builder = TurboProto.GetDownstreamWorkersResponse.newBuilder();
-        if (dependency != null)
+        if (dependency.hasDownstreamStage())
         {
             boolean isWide = dependency.isWide();
             StageCoordinator dependentStage = planCoordinator.getStageCoordinator(dependency.getDownStreamStageId());

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/AggregationOperator.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/AggregationOperator.java
@@ -22,6 +22,7 @@ package io.pixelsdb.pixels.planner.plan.physical;
 import com.google.common.collect.ImmutableList;
 import io.pixelsdb.pixels.common.turbo.Output;
 import io.pixelsdb.pixels.planner.coordinate.PlanCoordinator;
+import io.pixelsdb.pixels.planner.coordinate.StageDependency;
 import io.pixelsdb.pixels.planner.plan.physical.input.AggregationInput;
 import io.pixelsdb.pixels.planner.plan.physical.input.ScanInput;
 
@@ -114,8 +115,11 @@ public abstract class AggregationOperator extends Operator
     }
 
     @Override
-    public void initPlanCoordinator(PlanCoordinator planCoordinator)
+    public void initPlanCoordinator(PlanCoordinator planCoordinator, int parentStageId)
     {
+        int stageId = planCoordinator.assignStageId();
+        StageDependency dependency = new StageDependency(stageId, parentStageId, true);
+        // StageCoordinator coordinator = new StageCoordinator();
         // TODO: implement
     }
 

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/AggregationOperator.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/AggregationOperator.java
@@ -21,6 +21,7 @@ package io.pixelsdb.pixels.planner.plan.physical;
 
 import com.google.common.collect.ImmutableList;
 import io.pixelsdb.pixels.common.turbo.Output;
+import io.pixelsdb.pixels.planner.coordinate.PlanCoordinator;
 import io.pixelsdb.pixels.planner.plan.physical.input.AggregationInput;
 import io.pixelsdb.pixels.planner.plan.physical.input.ScanInput;
 
@@ -110,6 +111,12 @@ public abstract class AggregationOperator extends Operator
                     "scanInputs must be empty if child is set to non-null");
             this.child = child;
         }
+    }
+
+    @Override
+    public void initPlanCoordinator(PlanCoordinator planCoordinator)
+    {
+        // TODO: implement
     }
 
     @Override

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/JoinOperator.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/JoinOperator.java
@@ -94,9 +94,7 @@ public abstract class JoinOperator extends Operator
 
         public JoinOutputCollection() { }
 
-        public JoinOutputCollection(JoinAlgorithm joinAlgo,
-                                OutputCollection smallChild,
-                                OutputCollection largeChild)
+        public JoinOutputCollection(JoinAlgorithm joinAlgo, OutputCollection smallChild, OutputCollection largeChild)
         {
             this.joinAlgo = joinAlgo;
             this.smallChild = smallChild;

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/Operator.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/Operator.java
@@ -65,6 +65,9 @@ public abstract class Operator implements OperatorExecutor
      * @param parentStageId the stage id of the parent (i.e., downstream) stage of this operator, for the
      *                      root operator, the parentStageId should be negative (e.g., -1), meaning the
      *                      parent does not exist for root
+     * @param wideDependOnParent true if this operator has a wide dependency on the parent (i.e., downstream)
+     *                          stage, for root operator, this parameter is ignored
      */
-    public abstract void initPlanCoordinator(PlanCoordinator planCoordinator, int parentStageId);
+    public abstract void initPlanCoordinator(PlanCoordinator planCoordinator,
+                                             int parentStageId, boolean wideDependOnParent);
 }

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/Operator.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/Operator.java
@@ -20,6 +20,7 @@
 package io.pixelsdb.pixels.planner.plan.physical;
 
 import io.pixelsdb.pixels.common.utils.ConfigFactory;
+import io.pixelsdb.pixels.planner.coordinate.PlanCoordinator;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -55,4 +56,6 @@ public abstract class Operator implements OperatorExecutor
     {
         return name;
     }
+
+    public abstract void initPlanCoordinator(PlanCoordinator planCoordinator);
 }

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/Operator.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/Operator.java
@@ -57,5 +57,14 @@ public abstract class Operator implements OperatorExecutor
         return name;
     }
 
-    public abstract void initPlanCoordinator(PlanCoordinator planCoordinator);
+    /**
+     * Initialize the query plan coordinator. This method should be invoked recursively to traverse all
+     * the operators in the query plan. Each operator added its own query execution stages into the plan
+     * coordinator. Therefore, the users only need to call this method on the root operator of the plan.
+     * @param planCoordinator the plan coordinator to be initialized
+     * @param parentStageId the stage id of the parent (i.e., downstream) stage of this operator, for the
+     *                      root operator, the parentStageId should be negative (e.g., -1), meaning the
+     *                      parent does not exist for root
+     */
+    public abstract void initPlanCoordinator(PlanCoordinator planCoordinator, int parentStageId);
 }

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/OperatorExecutor.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/OperatorExecutor.java
@@ -41,7 +41,7 @@ public interface OperatorExecutor
      * @return the completable future that completes when this operator is complete, and
      * provides the computable futures of the outputs of this operator
      */
-    public abstract CompletableFuture<CompletableFuture<?>[]> execute();
+    CompletableFuture<CompletableFuture<?>[]> execute();
 
     /**
      * Execute the previous stages (if any) before the last stage, recursively.
@@ -49,7 +49,7 @@ public interface OperatorExecutor
      *
      * @return empty array if the previous stages do not exist or do not need to be waited for
      */
-    public abstract CompletableFuture<Void> executePrev();
+    CompletableFuture<Void> executePrev();
 
     /**
      * This method collects the outputs of the operator. It may block until the join
@@ -57,9 +57,9 @@ public interface OperatorExecutor
      * it will block the query execution.
      * @return the outputs of the workers in this operator
      */
-    public abstract OutputCollection collectOutputs() throws ExecutionException, InterruptedException;
+    OutputCollection collectOutputs() throws ExecutionException, InterruptedException;
 
-    public interface OutputCollection
+    interface OutputCollection
     {
         long getTotalGBMs();
 
@@ -78,12 +78,12 @@ public interface OperatorExecutor
         long getLayerOutputCostMs();
     }
 
-    public static void waitForCompletion(CompletableFuture<?>[] stageOutputs) throws InterruptedException
+    static void waitForCompletion(CompletableFuture<?>[] stageOutputs) throws InterruptedException
     {
         waitForCompletion(stageOutputs, StageCompletionRatio);
     }
 
-    public static void waitForCompletion(CompletableFuture<?>[] stageOutputs, double completionRatio)
+    static void waitForCompletion(CompletableFuture<?>[] stageOutputs, double completionRatio)
             throws InterruptedException
     {
         requireNonNull(stageOutputs, "stageOutputs is null");

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/PartitionedJoinBatchOperator.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/PartitionedJoinBatchOperator.java
@@ -149,6 +149,8 @@ public class PartitionedJoinBatchOperator extends PartitionedJoinOperator
                 } else
                 {
                     // no children exist, partition both tables and wait for the small table partitioning.
+                    checkArgument(!smallPartitionInputs.isEmpty(), "smallPartitionInputs is empty");
+                    checkArgument(!largePartitionInputs.isEmpty(), "largePartitionInputs is empty");
                     smallPartitionOutputs = new CompletableFuture[smallPartitionInputs.size()];
                     int i = 0;
                     for (PartitionInput partitionInput : smallPartitionInputs)

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/PartitionedJoinOperator.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/PartitionedJoinOperator.java
@@ -126,7 +126,7 @@ public abstract class PartitionedJoinOperator extends SingleStageJoinOperator
     }
 
     @Override
-    public void initPlanCoordinator(PlanCoordinator planCoordinator)
+    public void initPlanCoordinator(PlanCoordinator planCoordinator, int parentStageId)
     {
         // TODO: implement
     }

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/PartitionedJoinOperator.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/PartitionedJoinOperator.java
@@ -126,7 +126,7 @@ public abstract class PartitionedJoinOperator extends SingleStageJoinOperator
     }
 
     @Override
-    public void initPlanCoordinator(PlanCoordinator planCoordinator, int parentStageId)
+    public void initPlanCoordinator(PlanCoordinator planCoordinator, int parentStageId, boolean wideDependOnParent)
     {
         // TODO: implement
     }

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/PartitionedJoinOperator.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/PartitionedJoinOperator.java
@@ -22,6 +22,7 @@ package io.pixelsdb.pixels.planner.plan.physical;
 import com.google.common.collect.ImmutableList;
 import io.pixelsdb.pixels.common.turbo.Output;
 import io.pixelsdb.pixels.executor.join.JoinAlgorithm;
+import io.pixelsdb.pixels.planner.coordinate.PlanCoordinator;
 import io.pixelsdb.pixels.planner.plan.physical.input.JoinInput;
 import io.pixelsdb.pixels.planner.plan.physical.input.PartitionInput;
 
@@ -122,6 +123,12 @@ public abstract class PartitionedJoinOperator extends SingleStageJoinOperator
     public List<PartitionInput> getLargePartitionInputs()
     {
         return largePartitionInputs;
+    }
+
+    @Override
+    public void initPlanCoordinator(PlanCoordinator planCoordinator)
+    {
+        // TODO: implement
     }
 
     @Override

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/SingleStageJoinOperator.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/SingleStageJoinOperator.java
@@ -22,6 +22,7 @@ package io.pixelsdb.pixels.planner.plan.physical;
 import com.google.common.collect.ImmutableList;
 import io.pixelsdb.pixels.common.turbo.Output;
 import io.pixelsdb.pixels.executor.join.JoinAlgorithm;
+import io.pixelsdb.pixels.planner.coordinate.PlanCoordinator;
 import io.pixelsdb.pixels.planner.plan.physical.input.JoinInput;
 
 import java.util.List;
@@ -96,6 +97,12 @@ public abstract class SingleStageJoinOperator extends JoinOperator
     public JoinOperator getLargeChild()
     {
         return this.largeChild;
+    }
+
+    @Override
+    public void initPlanCoordinator(PlanCoordinator planCoordinator)
+    {
+        // TODO: implement
     }
 
     @Override

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/SingleStageJoinOperator.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/SingleStageJoinOperator.java
@@ -100,7 +100,7 @@ public abstract class SingleStageJoinOperator extends JoinOperator
     }
 
     @Override
-    public void initPlanCoordinator(PlanCoordinator planCoordinator)
+    public void initPlanCoordinator(PlanCoordinator planCoordinator, int parentStageId)
     {
         // TODO: implement
     }

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/SingleStageJoinOperator.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/SingleStageJoinOperator.java
@@ -100,7 +100,7 @@ public abstract class SingleStageJoinOperator extends JoinOperator
     }
 
     @Override
-    public void initPlanCoordinator(PlanCoordinator planCoordinator, int parentStageId)
+    public void initPlanCoordinator(PlanCoordinator planCoordinator, int parentStageId, boolean wideDependOnParent)
     {
         // TODO: implement
     }

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/StarlingAggregationOperator.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/StarlingAggregationOperator.java
@@ -219,7 +219,7 @@ public class StarlingAggregationOperator extends Operator
     }
 
     @Override
-    public void initPlanCoordinator(PlanCoordinator planCoordinator, int parentStageId)
+    public void initPlanCoordinator(PlanCoordinator planCoordinator, int parentStageId, boolean wideDependOnParent)
     {
         // TODO: implement
     }

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/StarlingAggregationOperator.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/StarlingAggregationOperator.java
@@ -22,6 +22,7 @@ package io.pixelsdb.pixels.planner.plan.physical;
 import com.google.common.collect.ImmutableList;
 import io.pixelsdb.pixels.common.turbo.InvokerFactory;
 import io.pixelsdb.pixels.common.turbo.WorkerType;
+import io.pixelsdb.pixels.planner.coordinate.PlanCoordinator;
 import io.pixelsdb.pixels.planner.plan.physical.input.AggregationInput;
 import io.pixelsdb.pixels.planner.plan.physical.input.PartitionInput;
 import io.pixelsdb.pixels.common.turbo.Output;
@@ -215,6 +216,12 @@ public class StarlingAggregationOperator extends Operator
             outputCollection.setFinalAggrOutputs(outputs);
         }
         return outputCollection;
+    }
+
+    @Override
+    public void initPlanCoordinator(PlanCoordinator planCoordinator)
+    {
+        // TODO: implement
     }
 
     public static class AggregationOutputCollection implements OutputCollection

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/StarlingAggregationOperator.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/StarlingAggregationOperator.java
@@ -19,22 +19,28 @@
  */
 package io.pixelsdb.pixels.planner.plan.physical;
 
+import com.alibaba.fastjson.JSON;
 import com.google.common.collect.ImmutableList;
+import io.pixelsdb.pixels.common.task.Task;
 import io.pixelsdb.pixels.common.turbo.InvokerFactory;
+import io.pixelsdb.pixels.common.turbo.Output;
 import io.pixelsdb.pixels.common.turbo.WorkerType;
 import io.pixelsdb.pixels.planner.coordinate.PlanCoordinator;
+import io.pixelsdb.pixels.planner.coordinate.StageCoordinator;
+import io.pixelsdb.pixels.planner.coordinate.StageDependency;
+import io.pixelsdb.pixels.planner.plan.physical.domain.InputSplit;
 import io.pixelsdb.pixels.planner.plan.physical.input.AggregationInput;
 import io.pixelsdb.pixels.planner.plan.physical.input.PartitionInput;
-import io.pixelsdb.pixels.common.turbo.Output;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static java.util.Objects.requireNonNull;
 import static io.pixelsdb.pixels.planner.plan.physical.OperatorExecutor.waitForCompletion;
+import static java.util.Objects.requireNonNull;
 
 /**
  * @author hank
@@ -221,7 +227,35 @@ public class StarlingAggregationOperator extends Operator
     @Override
     public void initPlanCoordinator(PlanCoordinator planCoordinator, int parentStageId, boolean wideDependOnParent)
     {
-        // TODO: implement
+        int aggrStageId = planCoordinator.assignStageId();
+        StageDependency aggrStageDependency = new StageDependency(aggrStageId, parentStageId, wideDependOnParent);
+        StageCoordinator aggrStageCoordinator = new StageCoordinator(aggrStageId, this.finalAggrInputs.size());
+        planCoordinator.addStageCoordinator(aggrStageCoordinator, aggrStageDependency);
+        if (this.partitionInputs != null)
+        {
+            checkArgument(this.child == null,
+                    "child operator should be null when base table partition exists");
+            int partitionStageId = planCoordinator.assignStageId();
+            StageDependency partitionStageDependency = new StageDependency(partitionStageId, aggrStageId, true);
+            List<Task> tasks = new ArrayList<>();
+            int taskId = 0;
+            for (PartitionInput partitionInput : this.partitionInputs)
+            {
+                List<InputSplit> inputSplits = partitionInput.getTableInfo().getInputSplits();
+                for (InputSplit inputSplit : inputSplits)
+                {
+                    partitionInput.getTableInfo().setInputSplits(ImmutableList.of(inputSplit));
+                    tasks.add(new Task(taskId++, JSON.toJSONString(partitionInput)));
+                }
+            }
+            StageCoordinator partitionStageCoordinator = new StageCoordinator(partitionStageId, tasks);
+            planCoordinator.addStageCoordinator(partitionStageCoordinator, partitionStageDependency);
+        }
+        else
+        {
+            requireNonNull(this.child, "child operator should not be null");
+            this.child.initPlanCoordinator(planCoordinator, aggrStageId, true);
+        }
     }
 
     public static class AggregationOutputCollection implements OutputCollection

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/StarlingAggregationOperator.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/StarlingAggregationOperator.java
@@ -219,7 +219,7 @@ public class StarlingAggregationOperator extends Operator
     }
 
     @Override
-    public void initPlanCoordinator(PlanCoordinator planCoordinator)
+    public void initPlanCoordinator(PlanCoordinator planCoordinator, int parentStageId)
     {
         // TODO: implement
     }

--- a/proto/turbo.proto
+++ b/proto/turbo.proto
@@ -129,9 +129,9 @@ message TaskInput {
   string payload = 2;
 }
 
-message TaskOutput {
+message TaskResult {
   string taskId = 1;
-  string output = 2;
+  bool success = 2;
 }
 
 message GetTasksToExecuteResponse {
@@ -141,7 +141,7 @@ message GetTasksToExecuteResponse {
 
 message CompleteTasksRequest {
   int64 workerId = 1;
-  repeated TaskOutput taskOutputs = 2;
+  repeated TaskResult taskResults = 2;
 }
 
 message CompleteTasksResponse {

--- a/proto/turbo.proto
+++ b/proto/turbo.proto
@@ -125,12 +125,12 @@ message GetTasksToExecuteRequest {
 }
 
 message TaskInput {
-  string taskId = 1;
+  int32 taskId = 1;
   string payload = 2;
 }
 
 message TaskResult {
-  string taskId = 1;
+  int32 taskId = 1;
   bool success = 2;
 }
 


### PR DESCRIPTION
Users can initialize the plan coordinator of a query plan by invoking initPlanCoordinator on the root operator of the plan.
TaskId is changed from a string to an integer starting from 0 per stage.