### PR TITLE
[Issue #579] Fix variable name in StringColumnReader

### DIFF
--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/StringColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/StringColumnReader.java
@@ -283,7 +283,7 @@ public class StringColumnReader extends ColumnReader
                         else
                         {
                             int originId = cascadeRLE ? (int) contentDecoder.next() : contentBuf.readInt();
-                            columnVector.setId(i + vectorIndex, originId);
+                            columnVector.setId(j + vectorIndex, originId);
                         }
                     }
                     // update variables


### PR DESCRIPTION
Under current code, the string column reader does not function correctly, returning wrongly repeated values for string queries.
Debugging found that the problem comes from a wrong variable name in StringColumnReader. Fix as in commit.