### PR TITLE
[pixels-example] make simple writer reader test work for s3

### DIFF
--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/StorageFactory.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/StorageFactory.java
@@ -168,7 +168,8 @@ public class StorageFactory
         }
         catch (RuntimeException re)
         {
-            throw new IOException("Invalid storage scheme or path: " + schemeOrPath, re);
+            throw new IOException("Invalid s" +
+                    "torage scheme or path: " + schemeOrPath, re);
         }
     }
 

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/StorageFactory.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/StorageFactory.java
@@ -168,8 +168,7 @@ public class StorageFactory
         }
         catch (RuntimeException re)
         {
-            throw new IOException("Invalid s" +
-                    "torage scheme or path: " + schemeOrPath, re);
+            throw new IOException("Invalid storage scheme or path: " + schemeOrPath, re);
         }
     }
 

--- a/pixels-example/src/main/java/io/pixelsdb/pixels/example/core/TestPixelsReader.java
+++ b/pixels-example/src/main/java/io/pixelsdb/pixels/example/core/TestPixelsReader.java
@@ -53,6 +53,7 @@ public class TestPixelsReader
 
             TypeDescription schema = reader.getFileSchema();
             List<String> fieldNames = schema.getFieldNames();
+            System.out.println("fieldNames: " + fieldNames);
             String[] cols = new String[fieldNames.size()];
             for (int i = 0; i < fieldNames.size(); i++) {
                 cols[i] = fieldNames.get(i);
@@ -72,6 +73,7 @@ public class TestPixelsReader
             int numBatches = 0;
             while (true) {
                 rowBatch = recordReader.readBatch(batchSize);
+                System.out.println("rowBatch: " + rowBatch);
                 numBatches++;
                 String result = rowBatch.toString();
                 len += result.length();

--- a/pixels-example/src/main/java/io/pixelsdb/pixels/example/core/TestPixelsWriter.java
+++ b/pixels-example/src/main/java/io/pixelsdb/pixels/example/core/TestPixelsWriter.java
@@ -39,8 +39,8 @@ public class TestPixelsWriter
 {
     public static void main(String[] args) throws IOException
     {
-        String pixelsFile = "hdfs://localhost:9000//pixels/pixels/test_105/v_0_order/.pxl";
-        Storage storage = StorageFactory.Instance().getStorage("hdfs");
+        String pixelsFile = System.getenv("PIXELS_WRITE_READ_TO_S3_TEST_FILE");
+        Storage storage = StorageFactory.Instance().getStorage("s3");
 
         String schemaStr = "struct<a:int,b:float,c:double,d:timestamp,e:boolean,z:string>";
 
@@ -49,10 +49,10 @@ public class TestPixelsWriter
             TypeDescription schema = TypeDescription.fromString(schemaStr);
             VectorizedRowBatch rowBatch = schema.createRowBatch();
             LongColumnVector a = (LongColumnVector) rowBatch.cols[0];              // int
-            DoubleColumnVector b = (DoubleColumnVector) rowBatch.cols[1];          // float
+            FloatColumnVector b = (FloatColumnVector) rowBatch.cols[1];          // float
             DoubleColumnVector c = (DoubleColumnVector) rowBatch.cols[2];          // double
             TimestampColumnVector d = (TimestampColumnVector) rowBatch.cols[3];    // timestamp
-            LongColumnVector e = (LongColumnVector) rowBatch.cols[4];              // boolean
+            ByteColumnVector e = (ByteColumnVector) rowBatch.cols[4];              // boolean
             BinaryColumnVector z = (BinaryColumnVector) rowBatch.cols[5];            // string
 
             PixelsWriter pixelsWriter =
@@ -82,7 +82,7 @@ public class TestPixelsWriter
                 c.isNull[row] = false;
                 d.set(row, timestamp);
                 d.isNull[row] = false;
-                e.vector[row] = i > 25000 ? 1 : 0;
+                e.vector[row] = (byte) (i > 25000 ? 1 : 0);
                 e.isNull[row] = false;
                 z.setVal(row, String.valueOf(i).getBytes());
                 z.isNull[row] = false;
@@ -96,6 +96,7 @@ public class TestPixelsWriter
             if (rowBatch.size != 0)
             {
                 pixelsWriter.addRowBatch(rowBatch);
+                System.out.println("A rowBatch of size " + rowBatch.size + " has been written to " + pixelsFile);
                 rowBatch.reset();
             }
 

--- a/pixels-example/src/main/java/io/pixelsdb/pixels/example/core/TestPixelsWriter.java
+++ b/pixels-example/src/main/java/io/pixelsdb/pixels/example/core/TestPixelsWriter.java
@@ -39,6 +39,8 @@ public class TestPixelsWriter
 {
     public static void main(String[] args) throws IOException
     {
+        // Note you may need to restart intellij to let it pick up the updated environment variable value
+        // example path: s3://bucket-name/test-file.pxl
         String pixelsFile = System.getenv("PIXELS_WRITE_READ_TO_S3_TEST_FILE");
         Storage storage = StorageFactory.Instance().getStorage("s3");
 


### PR DESCRIPTION
This PR makes a simple writer reader test work for s3. Fixed some issues of the test and updated the test to write to and read from a test file on S3 instead of local file system, since pixels is primarily designed to be used as a cloud based system.