### PR TITLE
[Issue #595] support rate-limited query execution in pixels-cli

### DIFF
--- a/pixels-cli/src/main/java/io/pixelsdb/pixels/cli/Main.java
+++ b/pixels-cli/src/main/java/io/pixelsdb/pixels/cli/Main.java
@@ -47,13 +47,16 @@ import static java.util.Objects.requireNonNull;
  *
  * <br>This should be run under root user to execute cache cleaning commands
  * <p>
- * QUERY -w /home/iir/opt/pixels/1187_dedup_query.txt -l /home/iir/opt/pixels/pixels_duration_1187_v_1_compact_cache_2020.01.10-2.csv -c /home/iir/opt/presto-server/sbin/drop-caches.sh
- * </p>
- * <p> Local
- * QUERY -w /home/tao/software/station/bitbucket/105_dedup_query.txt -l /home/tao/software/station/bitbucket/pixels_duration_local.csv
+ * QUERY -w /home/pixels/opt/pixels/1187_dedup_query.txt -l /home/pixels/opt/pixels/pixels_duration_1187_v_1_compact_cache_2020.01.10-2.csv -d /home/pixels/opt/presto-server/sbin/drop-caches.sh
  * </p>
  * <p>
- * COPY -p .pxl -s hdfs://dbiir27:9000/pixels/pixels/test_105/v_1_order -d hdfs://dbiir27:9000/pixels/pixels/test_105/v_1_order -n 3 -c 3
+ * QUERY -w /home/pixels/opt/pixels/105_dedup_query.txt -l /home/pixels/opt/pixels/pixels_duration_local.csv
+ * </p>
+ * <p>
+ * QUERY -w /home/pixels/opt/pixels/105_dedup_query.txt -l /home/pixels/opt/pixels/pixels_duration_local.csv -r true -q 3
+ * </p>
+ * <p>
+ * COPY -p .pxl -s hdfs://node01:9000/pixels/pixels/test_105/v_1_order -d hdfs://node01:9000/pixels/pixels/test_105/v_1_order -n 3 -c 3
  * </p>
  * <p>
  * COMPACT -s pixels -t test_105 -n yes -c 8
@@ -155,16 +158,16 @@ public class Main
                 ArgumentParser argumentParser = ArgumentParsers.newArgumentParser("Pixels QUERY")
                         .defaultHelp(true);
 
-                argumentParser.addArgument("-r", "--repeat").required(true)
-                        .help("specify whether run the queries in the workload file repeatedly");
                 argumentParser.addArgument("-w", "--workload").required(true)
                         .help("specify the path of workload file");
                 argumentParser.addArgument("-l", "--log").required(true)
                         .help("specify the path of query log files");
-                argumentParser.addArgument("-c", "--cache").required(false)
-                        .help("specify the command of dropping cache");
-
-
+                argumentParser.addArgument("-r", "--rate_limited").required(false).setDefault(false)
+                        .help("specify whether the queries are executed in a rate-limited manner");
+                argumentParser.addArgument("-d", "--drop_cache").required(false)
+                        .help("specify the path of the script file that is used to drop cache after each query");
+                argumentParser.addArgument("-q", "--query_per_minute").required(false).setDefault(0)
+                        .help("specify the number of queries to execute if rate_limited is true");
 
                 Namespace ns = null;
                 try

--- a/pixels-cli/src/main/java/io/pixelsdb/pixels/cli/Main.java
+++ b/pixels-cli/src/main/java/io/pixelsdb/pixels/cli/Main.java
@@ -155,12 +155,16 @@ public class Main
                 ArgumentParser argumentParser = ArgumentParsers.newArgumentParser("Pixels QUERY")
                         .defaultHelp(true);
 
+                argumentParser.addArgument("-r", "--repeat").required(true)
+                        .help("specify whether run the queries in the workload file repeatedly");
                 argumentParser.addArgument("-w", "--workload").required(true)
                         .help("specify the path of workload file");
                 argumentParser.addArgument("-l", "--log").required(true)
                         .help("specify the path of query log files");
-                argumentParser.addArgument("-c", "--cache")
+                argumentParser.addArgument("-c", "--cache").required(false)
                         .help("specify the command of dropping cache");
+
+
 
                 Namespace ns = null;
                 try

--- a/pixels-cli/src/main/java/io/pixelsdb/pixels/cli/executor/QueryExecutor.java
+++ b/pixels-cli/src/main/java/io/pixelsdb/pixels/cli/executor/QueryExecutor.java
@@ -42,8 +42,9 @@ public class QueryExecutor implements CommandExecutor
         String workload = ns.getString("workload");
         String log = ns.getString("log");
         String cache = ns.getString("drop_cache");
-        Boolean rateLimited = ns.getBoolean("rate_limited");
-        int queryPerMinute = ns.getInt("query_per_minute");
+        Boolean rateLimited = Boolean.parseBoolean(ns.getString("rate_limited"));
+        String qpmStr = ns.getString("query_per_minute");
+        int queryPerMinute = qpmStr != null ? Integer.parseInt(qpmStr) : 0;
         ExecutorService threadPool = null;
         if (rateLimited)
         {

--- a/pixels-cli/src/main/java/io/pixelsdb/pixels/cli/executor/QueryExecutor.java
+++ b/pixels-cli/src/main/java/io/pixelsdb/pixels/cli/executor/QueryExecutor.java
@@ -41,7 +41,7 @@ public class QueryExecutor implements CommandExecutor
     {
         String workload = ns.getString("workload");
         String log = ns.getString("log");
-        String cache = ns.getString("cache");
+        String cache = ns.getString("drop_cache");
 
         if (workload != null && log != null)
         {

--- a/pixels-cli/src/main/java/io/pixelsdb/pixels/cli/executor/QueryExecutor.java
+++ b/pixels-cli/src/main/java/io/pixelsdb/pixels/cli/executor/QueryExecutor.java
@@ -133,6 +133,7 @@ public class QueryExecutor implements CommandExecutor
 
                             System.out.println(i + "," + cost + "ms");
                             i++;
+                            Thread.sleep(1000); // wait for 1 second before submitting the next query
                         }
                     }
                 }


### PR DESCRIPTION
This makes query throughput experiments easier.