### PR TITLE
[Issue #615] fix alignment for isNull decompaction

### DIFF
--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/BooleanColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/BooleanColumnReader.java
@@ -41,6 +41,11 @@ public class BooleanColumnReader extends ColumnReader
      * or the index of {@link #inputBuffer} if the column chunk is nulls-padded.
      */
     private int bitsOrInputIndex = 0;
+    /**
+     * The number of bits to skip in the first byte (start from bitsOrInputIndex)
+     * when decompacting values from nulls-padded column chunk.
+     */
+    private int inputSkipBits = 0;
 
     BooleanColumnReader(TypeDescription type)
     {
@@ -106,8 +111,10 @@ public class BooleanColumnReader extends ColumnReader
             }
             // read isNull
             isNullOffset = input.position() + chunkIndex.getIsNullOffset();
+            isNullSkipBits = 0;
             // re-init
             bitsOrInputIndex = 0;
+            inputSkipBits = 0;
             hasNull = true;
             elementIndex = 0;
         }
@@ -125,14 +132,17 @@ public class BooleanColumnReader extends ColumnReader
             {
                 numToRead = numLeft;
             }
-            bytesToDeCompact = (numToRead + 7) / 8;
+
             // read isNull
             int pixelId = elementIndex / pixelStride;
             hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
             if (hasNull)
             {
-                BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset, littleEndian);
+                bytesToDeCompact = (numToRead + isNullSkipBits) / 8;
+                BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead,
+                        inputBuffer, isNullOffset, isNullSkipBits, littleEndian);
                 isNullOffset += bytesToDeCompact;
+                isNullSkipBits = (numToRead + isNullSkipBits) % 8;
                 columnVector.noNulls = false;
             }
             else
@@ -142,12 +152,16 @@ public class BooleanColumnReader extends ColumnReader
             // read content
             if (nullsPadding)
             {
-                BitUtils.bitWiseDeCompact(columnVector.vector, i, numToRead, inputBuffer, bitsOrInputIndex, littleEndian);
+                bytesToDeCompact = (numToRead + inputSkipBits) / 8;
+                BitUtils.bitWiseDeCompact(columnVector.vector, i, numToRead,
+                        inputBuffer, bitsOrInputIndex, inputSkipBits, littleEndian);
                 bitsOrInputIndex += bytesToDeCompact;
+                inputSkipBits = (numToRead + inputSkipBits) % 8;
             }
             else
             {
-                bitsOrInputIndex = (bitsOrInputIndex + 7) / 8 * 8;
+                // Issue #615: no need to align bitsOrInputIndex to 8.
+                // bitsOrInputIndex = (bitsOrInputIndex + 7) / 8 * 8;
                 for (int j = i; j < i + numToRead; ++j)
                 {
                     if (!(hasNull && columnVector.isNull[j]))

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/BooleanColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/BooleanColumnReader.java
@@ -41,7 +41,6 @@ public class BooleanColumnReader extends ColumnReader
      * or the index of {@link #inputBuffer} if the column chunk is nulls-padded.
      */
     private int bitsOrInputIndex = 0;
-    private int isNullOffset = 0;
 
     BooleanColumnReader(TypeDescription type)
     {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/ColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/ColumnReader.java
@@ -35,6 +35,8 @@ import static java.util.Objects.requireNonNull;
  * Read from file, and decode column values
  *
  * @author guodong, hank
+ * @update 2024-01-08 add isNullSkipBits
+ *
  */
 public abstract class ColumnReader implements Closeable
 {
@@ -42,6 +44,15 @@ public abstract class ColumnReader implements Closeable
 
     int elementIndex = 0;
     boolean hasNull = true;
+    /**
+     * The current offset in the input buffer of this column chunk from which to decompact the isNull array.
+     * It starts from the offset of the bit-packed isNull array in this column chunk.
+     */
+    int isNullOffset = 0;
+    /**
+     * The number of bits to skip in the first byte (start from isNullOffset) when decompacting the isNull array.
+     */
+    int isNullSkipBits = 0;
 
     public static ColumnReader newColumnReader(TypeDescription type)
     {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/DateColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/DateColumnReader.java
@@ -106,6 +106,7 @@ public class DateColumnReader extends ColumnReader
             inputStream = new ByteBufferInputStream(inputBuffer, inputBuffer.position(), inputBuffer.limit());
             decoder = new RunLenIntDecoder(inputStream, true);
             isNullOffset = inputBuffer.position() + chunkIndex.getIsNullOffset();
+            isNullSkipBits = 0;
             hasNull = true;
             elementIndex = 0;
         }
@@ -124,14 +125,16 @@ public class DateColumnReader extends ColumnReader
             {
                 numToRead = numLeft;
             }
-            bytesToDeCompact = (numToRead + 7) / 8;
+            bytesToDeCompact = (numToRead + isNullSkipBits) / 8;
             // read isNull
             int pixelId = elementIndex / pixelStride;
             hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
             if (hasNull)
             {
-                BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset, littleEndian);
+                BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead,
+                        inputBuffer, isNullOffset, isNullSkipBits, littleEndian);
                 isNullOffset += bytesToDeCompact;
+                isNullSkipBits = (numToRead + isNullSkipBits) % 8;
                 columnVector.noNulls = false;
             }
             else

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/DateColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/DateColumnReader.java
@@ -46,7 +46,6 @@ public class DateColumnReader extends ColumnReader
     private ByteBuffer inputBuffer = null;
     private InputStream inputStream = null;
     private RunLenIntDecoder decoder = null;
-    private int isNullOffset = 0;
 
     DateColumnReader(TypeDescription type)
     {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/DecimalColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/DecimalColumnReader.java
@@ -42,7 +42,6 @@ public class DecimalColumnReader extends ColumnReader
 {
     // private final EncodingUtils encodingUtils;
     private ByteBuffer inputBuffer;
-    private int isNullOffset = 0;
     private int inputIndex = 0;
 
     DecimalColumnReader(TypeDescription type)

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/DecimalColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/DecimalColumnReader.java
@@ -102,6 +102,7 @@ public class DecimalColumnReader extends ColumnReader
             inputIndex = this.inputBuffer.position();
             // isNull
             isNullOffset = inputIndex + chunkIndex.getIsNullOffset();
+            isNullSkipBits = 0;
             // re-init
             hasNull = true;
             elementIndex = 0;
@@ -119,14 +120,16 @@ public class DecimalColumnReader extends ColumnReader
             {
                 numToRead = numLeft;
             }
-            bytesToDeCompact = (numToRead + 7) / 8;
+            bytesToDeCompact = (numToRead + isNullSkipBits) / 8;
             // read isNull
             int pixelId = elementIndex / pixelStride;
             hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
             if (hasNull)
             {
-                BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset, littleEndian);
+                BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead,
+                        inputBuffer, isNullOffset, isNullSkipBits, littleEndian);
                 isNullOffset += bytesToDeCompact;
+                isNullSkipBits = (numToRead + isNullSkipBits) % 8;
                 columnVector.noNulls = false;
             } else
             {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/DoubleColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/DoubleColumnReader.java
@@ -93,6 +93,7 @@ public class DoubleColumnReader extends ColumnReader
             inputIndex = inputBuffer.position();
             // isNull
             isNullOffset = inputIndex + chunkIndex.getIsNullOffset();
+            isNullSkipBits = 0;
             // re-init
             hasNull = true;
             elementIndex = 0;
@@ -110,14 +111,16 @@ public class DoubleColumnReader extends ColumnReader
             {
                 numToRead = numLeft;
             }
-            bytesToDeCompact = (numToRead + 7) / 8;
+            bytesToDeCompact = (numToRead + isNullSkipBits) / 8;
             // read isNull
             int pixelId = elementIndex / pixelStride;
             hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
             if (hasNull)
             {
-                BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset, littleEndian);
+                BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead,
+                        inputBuffer, isNullOffset, isNullSkipBits, littleEndian);
                 isNullOffset += bytesToDeCompact;
+                isNullSkipBits = (numToRead + isNullSkipBits) % 8;
                 columnVector.noNulls = false;
             } else
             {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/DoubleColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/DoubleColumnReader.java
@@ -39,7 +39,6 @@ public class DoubleColumnReader extends ColumnReader
 {
     // private final EncodingUtils encodingUtils;
     private ByteBuffer inputBuffer;
-    private int isNullOffset = 0;
     private int inputIndex = 0;
 
     DoubleColumnReader(TypeDescription type)

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/FloatColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/FloatColumnReader.java
@@ -40,7 +40,6 @@ public class FloatColumnReader extends ColumnReader
     // private final EncodingUtils encodingUtils;
     private ByteBuffer inputBuffer;
     private int inputIndex = 0;
-    private int isNullOffset = 0;
 
     FloatColumnReader(TypeDescription type)
     {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/FloatColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/FloatColumnReader.java
@@ -91,6 +91,7 @@ public class FloatColumnReader extends ColumnReader
             this.inputBuffer.order(littleEndian ? ByteOrder.LITTLE_ENDIAN : ByteOrder.BIG_ENDIAN);
             inputIndex = inputBuffer.position();
             isNullOffset = inputIndex + chunkIndex.getIsNullOffset();
+            isNullSkipBits = 0;
             hasNull = true;
             elementIndex = 0;
         }
@@ -107,14 +108,16 @@ public class FloatColumnReader extends ColumnReader
             {
                 numToRead = numLeft;
             }
-            bytesToDeCompact = (numToRead + 7) / 8;
+            bytesToDeCompact = (numToRead + isNullSkipBits) / 8;
             // read isNull
             int pixelId = elementIndex / pixelStride;
             hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
             if (hasNull)
             {
-                BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset, littleEndian);
+                BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead,
+                        inputBuffer, isNullOffset, isNullSkipBits, littleEndian);
                 isNullOffset += bytesToDeCompact;
+                isNullSkipBits = (numToRead + isNullSkipBits) % 8;
                 columnVector.noNulls = false;
             } else
             {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/IntegerColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/IntegerColumnReader.java
@@ -43,7 +43,6 @@ public class IntegerColumnReader extends ColumnReader
     private RunLenIntDecoder decoder;
     private ByteBuffer inputBuffer;
     private InputStream inputStream;
-    private int isNullOffset = 0;
 
     /**
      * True if the data type of the values is long (int64), otherwise the data type is int32.

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/IntegerColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/IntegerColumnReader.java
@@ -113,6 +113,7 @@ public class IntegerColumnReader extends ColumnReader
             decoder = new RunLenIntDecoder(inputStream, true);
             // isNull
             isNullOffset = inputBuffer.position() + chunkIndex.getIsNullOffset();
+            isNullSkipBits = 0;
             // re-init
             hasNull = true;
             elementIndex = 0;
@@ -134,14 +135,16 @@ public class IntegerColumnReader extends ColumnReader
             {
                 numToRead = numLeft;
             }
-            bytesToDeCompact = (numToRead + 7) / 8;
+            bytesToDeCompact = (numToRead + isNullSkipBits) / 8;
             // read isNull
             int pixelId = elementIndex / pixelStride;
             hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
             if (hasNull)
             {
-                BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset, littleEndian);
+                BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead,
+                        inputBuffer, isNullOffset, isNullSkipBits, littleEndian);
                 isNullOffset += bytesToDeCompact;
+                isNullSkipBits = (numToRead + isNullSkipBits) % 8;
                 columnVector.noNulls = false;
             } else
             {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/LongDecimalColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/LongDecimalColumnReader.java
@@ -41,7 +41,6 @@ public class LongDecimalColumnReader extends ColumnReader
 {
     // private final EncodingUtils encodingUtils;
     private ByteBuffer inputBuffer;
-    private int isNullOffset = 0;
     private int inputIndex = 0;
 
     LongDecimalColumnReader(TypeDescription type)

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/LongDecimalColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/LongDecimalColumnReader.java
@@ -100,6 +100,7 @@ public class LongDecimalColumnReader extends ColumnReader
             inputIndex = inputBuffer.position();
             // isNull
             isNullOffset = inputIndex + chunkIndex.getIsNullOffset();
+            isNullSkipBits = 0;
             // re-init
             hasNull = true;
             elementIndex = 0;
@@ -117,14 +118,16 @@ public class LongDecimalColumnReader extends ColumnReader
             {
                 numToRead = numLeft;
             }
-            bytesToDeCompact = (numToRead + 7) / 8;
+            bytesToDeCompact = (numToRead + isNullSkipBits) / 8;
             // read isNull
             int pixelId = elementIndex / pixelStride;
             hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
             if (hasNull)
             {
-                BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset, littleEndian);
+                BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead,
+                        inputBuffer, isNullOffset, isNullSkipBits, littleEndian);
                 isNullOffset += bytesToDeCompact;
+                isNullSkipBits = (numToRead + isNullSkipBits) % 8;
                 columnVector.noNulls = false;
             } else
             {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/StringColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/StringColumnReader.java
@@ -206,7 +206,7 @@ public class StringColumnReader extends ColumnReader
                     hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
                     if (hasNull)
                     {
-                        BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset, littleEndian);
+                        BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset, 0, littleEndian);
                         isNullOffset += bytesToDeCompact;
                         columnVector.noNulls = false;
                     } else
@@ -264,7 +264,7 @@ public class StringColumnReader extends ColumnReader
                     hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
                     if (hasNull)
                     {
-                        BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset, littleEndian);
+                        BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset, 0, littleEndian);
                         isNullOffset += bytesToDeCompact;
                         columnVector.noNulls = false;
                     } else
@@ -321,7 +321,7 @@ public class StringColumnReader extends ColumnReader
                 hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
                 if (hasNull)
                 {
-                    BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset, littleEndian);
+                    BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset, 0, littleEndian);
                     isNullOffset += bytesToDeCompact;
                     columnVector.noNulls = false;
                 } else

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/TimeColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/TimeColumnReader.java
@@ -46,7 +46,6 @@ public class TimeColumnReader extends ColumnReader
     private ByteBuffer inputBuffer = null;
     private InputStream inputStream = null;
     private RunLenIntDecoder decoder = null;
-    private int isNullOffset = 0;
 
     TimeColumnReader(TypeDescription type)
     {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/TimeColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/TimeColumnReader.java
@@ -107,6 +107,7 @@ public class TimeColumnReader extends ColumnReader
             inputStream = new ByteBufferInputStream(inputBuffer, inputBuffer.position(), inputBuffer.limit());
             decoder = new RunLenIntDecoder(inputStream, true);
             isNullOffset = inputBuffer.position() + chunkIndex.getIsNullOffset();
+            isNullSkipBits = 0;
             hasNull = true;
             elementIndex = 0;
         }
@@ -124,14 +125,16 @@ public class TimeColumnReader extends ColumnReader
             {
                 numToRead = numLeft;
             }
-            bytesToDeCompact = (numToRead + 7) / 8;
+            bytesToDeCompact = (numToRead + isNullSkipBits) / 8;
             // read isNull
             int pixelId = elementIndex / pixelStride;
             hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
             if (hasNull)
             {
-                BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset, littleEndian);
+                BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead,
+                        inputBuffer, isNullOffset, isNullSkipBits, littleEndian);
                 isNullOffset += bytesToDeCompact;
+                isNullSkipBits = (numToRead + isNullSkipBits) % 8;
                 columnVector.noNulls = false;
             }
             else

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/TimestampColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/TimestampColumnReader.java
@@ -46,7 +46,6 @@ public class TimestampColumnReader extends ColumnReader
     private ByteBuffer inputBuffer = null;
     private InputStream inputStream = null;
     private RunLenIntDecoder decoder = null;
-    private int isNullOffset = 0;
 
     TimestampColumnReader(TypeDescription type)
     {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/TimestampColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/TimestampColumnReader.java
@@ -107,6 +107,7 @@ public class TimestampColumnReader extends ColumnReader
             inputStream = new ByteBufferInputStream(inputBuffer, inputBuffer.position(), inputBuffer.limit());
             decoder = new RunLenIntDecoder(inputStream, true);
             isNullOffset = inputBuffer.position() + chunkIndex.getIsNullOffset();
+            isNullSkipBits = 0;
             hasNull = true;
             elementIndex = 0;
         }
@@ -124,14 +125,16 @@ public class TimestampColumnReader extends ColumnReader
             {
                 numToRead = numLeft;
             }
-            bytesToDeCompact = (numToRead + 7) / 8;
+            bytesToDeCompact = (numToRead + isNullSkipBits) / 8;
             // read isNull
             int pixelId = elementIndex / pixelStride;
             hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
             if (hasNull)
             {
-                BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead, inputBuffer, isNullOffset, littleEndian);
+                BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead,
+                        inputBuffer, isNullOffset, isNullSkipBits, littleEndian);
                 isNullOffset += bytesToDeCompact;
+                isNullSkipBits = (numToRead + isNullSkipBits) % 8;
                 columnVector.noNulls = false;
             }
             else

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/VectorColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/VectorColumnReader.java
@@ -13,7 +13,6 @@ import java.util.Arrays;
 public class VectorColumnReader extends ColumnReader {
 
     private ByteBuffer inputBuffer;
-    private int isNullOffset = 0;
     private int inputIndex = 0;
     private int dimension;
 

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/VectorColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/VectorColumnReader.java
@@ -48,6 +48,7 @@ public class VectorColumnReader extends ColumnReader {
             inputIndex = inputBuffer.position();
             // isNull
             isNullOffset = inputIndex + chunkIndex.getIsNullOffset();
+            isNullSkipBits = 0;
             // re-init
             hasNull = true;
             elementIndex = 0;
@@ -66,14 +67,16 @@ public class VectorColumnReader extends ColumnReader {
             {
                 numToRead = numLeft;
             }
-            bytesToDeCompact = (numToRead + 7) / 8;
+            bytesToDeCompact = (numToRead + isNullSkipBits) / 8;
             // read isNull
             int pixelId = elementIndex / pixelStride;
             hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
             if (hasNull)
             {
-                BitUtils.bitWiseDeCompact(vectorColumnVector.isNull, i, numToRead, inputBuffer, isNullOffset, littleEndian);
+                BitUtils.bitWiseDeCompact(vectorColumnVector.isNull, i, numToRead,
+                        inputBuffer, isNullOffset, isNullSkipBits, littleEndian);
                 isNullOffset += bytesToDeCompact;
+                isNullSkipBits = (numToRead + isNullSkipBits) % 8;
                 vectorColumnVector.noNulls = false;
             } else
             {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/utils/BitUtils.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/utils/BitUtils.java
@@ -541,19 +541,19 @@ public class BitUtils
      * @param littleEndian whether the byte order of input is little endian
      */
     public static void bitWiseDeCompact(boolean[] bits, int bitsOffset, int bitsLength,
-                                        ByteBuf input, int offset, boolean littleEndian)
+                                        ByteBuf input, int offset, int skipBits, boolean littleEndian)
     {
         if (littleEndian)
         {
-            bitWiseDeCompactLE(bits, bitsOffset, bitsLength, input, offset);
+            bitWiseDeCompactLE(bits, bitsOffset, bitsLength, input, offset, skipBits);
         }
         else
         {
-            bitWiseDeCompactBE(bits, bitsOffset, bitsLength, input, offset);
+            bitWiseDeCompactBE(bits, bitsOffset, bitsLength, input, offset, skipBits);
         }
     }
 
-    private static void bitWiseDeCompactBE(boolean[] bits, int bitsOffset, int bitsLength, ByteBuf input, int offset)
+    private static void bitWiseDeCompactBE(boolean[] bits, int bitsOffset, int bitsLength, ByteBuf input, int offset, int skipBits)
     {
         byte bitsLeft = 8, b;
         int bitsEnd = bitsOffset + bitsLength;
@@ -569,7 +569,7 @@ public class BitUtils
         }
     }
 
-    private static void bitWiseDeCompactLE(boolean[] bits, int bitsOffset, int bitsLength, ByteBuf input, int offset)
+    private static void bitWiseDeCompactLE(boolean[] bits, int bitsOffset, int bitsLength, ByteBuf input, int offset, int skipBits)
     {
         byte currBit = 0, b;
         int bitsEnd = bitsOffset + bitsLength;

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/utils/BitUtils.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/utils/BitUtils.java
@@ -553,10 +553,20 @@ public class BitUtils
         }
     }
 
-    private static void bitWiseDeCompactBE(boolean[] bits, int bitsOffset, int bitsLength, ByteBuf input, int offset, int skipBits)
+    private static void bitWiseDeCompactBE(boolean[] bits, int bitsOffset, int bitsLength,
+                                           ByteBuf input, int offset, int skipBits)
     {
         byte bitsLeft = 8, b;
         int bitsEnd = bitsOffset + bitsLength;
+        b = input.getByte(offset++);
+        for (int i = 7; i >= 0 ; --i)
+        {
+            if (skipBits-- > 0)
+            {
+                continue;
+            }
+            bits[bitsOffset++] = (0x01 & (b >> i)) == 1;
+        }
         for (int i = offset, bitsIndex = bitsOffset; bitsIndex < bitsEnd; ++i)
         {
             b = input.getByte(i);
@@ -569,10 +579,20 @@ public class BitUtils
         }
     }
 
-    private static void bitWiseDeCompactLE(boolean[] bits, int bitsOffset, int bitsLength, ByteBuf input, int offset, int skipBits)
+    private static void bitWiseDeCompactLE(boolean[] bits, int bitsOffset, int bitsLength,
+                                           ByteBuf input, int offset, int skipBits)
     {
         byte currBit = 0, b;
         int bitsEnd = bitsOffset + bitsLength;
+        b = input.getByte(offset++);
+        for (int i = 0; i < 8 ; ++i)
+        {
+            if (skipBits-- > 0)
+            {
+                continue;
+            }
+            bits[bitsOffset++] = (0x01 & (b >> i)) == 1;
+        }
         for (int i = offset, bitsIndex = bitsOffset; bitsIndex < bitsEnd; ++i)
         {
             b = input.getByte(i);


### PR DESCRIPTION
When reading from multiple column-chunks, column readers did not ensure alignment when decompacting isNull array.
This may lead to skipping some bits in the middle of the isNull bytes in a column chunk and finally read out of the bound of the isNull bytes of a column chunk.