### PR TITLE
[Issue #580] make pixels vector type support trino array type

### DIFF
--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/TypeDescription.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/TypeDescription.java
@@ -741,7 +741,7 @@ public final class TypeDescription
             case VECTOR:
                 {
                     // handle type string passed from trino. Check that the type is double(array).
-                    if (result.toString().equals("array")) {
+                    if (source.value.contains("array")) {
                         if (consumeChar(source, '('))
                         {
                             // the array type must be double
@@ -751,7 +751,7 @@ public final class TypeDescription
                     }
                     // handle type string passed from Pixels writer, should be vector(d), where (d) specifies that
                     // this column has dimension d, and is optional
-                    else if (result.toString().equals("vector")) {
+                    else if (source.value.contains("vector")) {
                         if (consumeChar(source, '(')) {
                             // with dimension specified
                             result.withDimension(parseInt(source));

--- a/pixels-example/src/main/java/io/pixelsdb/pixels/example/core/ITTestReadVectorColumnFromS3.java
+++ b/pixels-example/src/main/java/io/pixelsdb/pixels/example/core/ITTestReadVectorColumnFromS3.java
@@ -17,9 +17,13 @@ public class ITTestReadVectorColumnFromS3 {
 
     public static void main(String[] args)
     {
+        readVectorColumn("s3://tiannan-test/test_arr_table_4/v-0-ordered/1.pxl");
+    }
+
+    public static void readVectorColumn(String currentPath) {
         // Note you may need to restart intellij to let it pick up the updated environment variable value
         // example path: s3://bucket-name/test-file.pxl
-        String currentPath = System.getenv("PIXELS_S3_TEST_BUCKET_PATH") + "test-vec-larger2.pxl";
+//        String currentPath = System.getenv("PIXELS_S3_TEST_BUCKET_PATH") + "test-vec-larger2.pxl";
         System.out.println(currentPath);
         try {
             Storage storage = StorageFactory.Instance().getStorage("s3");

--- a/pixels-example/src/main/java/io/pixelsdb/pixels/example/core/ITTestWriteVectorColumnToS3.java
+++ b/pixels-example/src/main/java/io/pixelsdb/pixels/example/core/ITTestWriteVectorColumnToS3.java
@@ -16,13 +16,19 @@ public class ITTestWriteVectorColumnToS3 {
 
     public static void main(String[] args) throws IOException
     {
+        writeVectorColumn();
+//        writeVarcharColumn();
+    }
+
+    public static void writeVectorColumn() throws IOException {
         // Note you may need to restart intellij to let it pick up the updated environment variable value
         // example path: s3://bucket-name/test-file.pxl
-        String pixelsFile = System.getenv("PIXELS_S3_TEST_BUCKET_PATH") + "test-vec-larger2.pxl";
+        //String pixelsFile = System.getenv("PIXELS_S3_TEST_BUCKET_PATH") + "test-vec-larger2.pxl";
+        String pixelsFile = "s3://tiannan-test/test_arr_table_7/v-0-ordered/1.pxl";
         Storage storage = StorageFactory.Instance().getStorage("s3");
 
         int dimension = 256;
-        String schemaStr = String.format("struct<v:vector(%s)>", dimension);
+        String schemaStr = String.format("struct<arr_col:vector(%s)>", dimension);
 
         try
         {
@@ -74,5 +80,4 @@ public class ITTestWriteVectorColumnToS3 {
             e.printStackTrace();
         }
     }
-
 }


### PR DESCRIPTION
This PR implements the necessary support in TypeDescription for parsing different schema string as the pixels vector type so that we can use the trino `array(double)` type in trino to query pixels `vector(d)` type, where d is the optional dimension of the vector column.

The main tricky issue was trino `array(double)` doesn't support a fixed dimension where as pixels `vector(d)` type uses a fixed dimension to simplify and speed up calculations. This issue is resolved by letting `TypeDescription` be able to parse different schema strings from trino (`array(double)`) or pixels files (`vector(d)`). This way we can simply use `PixelsWriter` to write pxl files to S3 and then read them from trino using `array(double)`, but the actual type read from s3 will be `vector(d)`, and will be turned into a block representing an `array(double)` before passing to trino.