### PR TITLE
[Issue #506] get query costs from transaction service

### DIFF
--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/server/rest/response/GetQueryResultResponse.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/server/rest/response/GetQueryResultResponse.java
@@ -34,8 +34,17 @@ public class GetQueryResultResponse
     private int[] columnPrintSizes;
     private String[] columnNames;
     private String[][] rows;
-    private double latencyMs;
+    /**
+     * The time in ms the query waits in the queue for execution.
+     */
+    private double pendingTimeMs;
+    /**
+     * The time the query really executes.
+     */
+    private double executionTimeMs;
     private double costCents;
+
+    private double billedCents;
 
     /**
      * Default constructor for Jackson.
@@ -58,15 +67,18 @@ public class GetQueryResultResponse
     }
 
     public GetQueryResultResponse(int errorCode, String errorMessage, int[] columnPrintSizes,
-                                  String[] columnNames, String[][] rows, double latencyMs, double costCents)
+                                  String[] columnNames, String[][] rows, double pendingTimeMs,
+                                  double executionTimeMs, double costCents, double billedCents)
     {
         this.errorCode = errorCode;
         this.errorMessage = errorMessage;
         this.columnPrintSizes = columnPrintSizes;
         this.columnNames = columnNames;
         this.rows = rows;
-        this.latencyMs = latencyMs;
+        this.pendingTimeMs = pendingTimeMs;
+        this.executionTimeMs = executionTimeMs;
         this.costCents = costCents;
+        this.billedCents = billedCents;
     }
 
     public int getErrorCode()
@@ -119,14 +131,24 @@ public class GetQueryResultResponse
         this.rows = rows;
     }
 
-    public double getLatencyMs()
+    public double getPendingTimeMs()
     {
-        return latencyMs;
+        return pendingTimeMs;
     }
 
-    public void setLatencyMs(double latencyMs)
+    public void setPendingTimeMs(double pendingTimeMs)
     {
-        this.latencyMs = latencyMs;
+        this.pendingTimeMs = pendingTimeMs;
+    }
+
+    public double getExecutionTimeMs()
+    {
+        return executionTimeMs;
+    }
+
+    public void setExecutionTimeMs(double executionTimeMs)
+    {
+        this.executionTimeMs = executionTimeMs;
     }
 
     public double getCostCents()
@@ -137,5 +159,15 @@ public class GetQueryResultResponse
     public void setCostCents(double costCents)
     {
         this.costCents = costCents;
+    }
+
+    public double getBilledCents()
+    {
+        return billedCents;
+    }
+
+    public void setBilledCents(double billedCents)
+    {
+        this.billedCents = billedCents;
     }
 }

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/server/rest/response/GetQueryResultResponse.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/server/rest/response/GetQueryResultResponse.java
@@ -42,8 +42,13 @@ public class GetQueryResultResponse
      * The time the query really executes.
      */
     private double executionTimeMs;
+    /**
+     * The amount of money in cents really spent by the query.
+     */
     private double costCents;
-
+    /**
+     * The amount of money in cents billed according to our price model.
+     */
     private double billedCents;
 
     /**

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/transaction/TransContextCache.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/transaction/TransContextCache.java
@@ -28,7 +28,7 @@ import static java.util.Objects.requireNonNull;
 
 /**
  * This is only a cache of the contexts of the transactions handled in this process.
- * The context is this cache may be not strictly consistent with the global transaction context.
+ * The context in this cache may be not strictly consistent with the global transaction context.
  * Thus, the result returned by this cache may be inaccurate.
  *
  * @create 2022-02-20

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/transaction/TransService.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/transaction/TransService.java
@@ -125,6 +125,30 @@ public class TransService
         return new TransContext(response.getTransContext());
     }
 
+    /**
+     * Set the string property of a transaction.
+     * @param transId the id of the transaction
+     * @param key the property key
+     * @param value the property value
+     * @return the previous value of the property key, or null if not present
+     * @throws TransException if the transaction does not exist
+     */
+    public String setTransProperty(long transId, String key, String value) throws TransException
+    {
+        TransProto.SetTransPropertyRequest request = TransProto.SetTransPropertyRequest.newBuilder()
+                .setTransId(transId).setKey(key).setValue(value).build();
+        TransProto.SetTransPropertyResponse response = this.stub.setTransProperty(request);
+        if (response.getErrorCode() != ErrorCode.SUCCESS)
+        {
+            throw new TransException("failed to set transaction property, error code=" + response.getErrorCode());
+        }
+        if (response.hasPrevValue())
+        {
+            return response.getPrevValue();
+        }
+        return null;
+    }
+
     public int getTransConcurrency(boolean readOnly) throws TransException
     {
         TransProto.GetTransConcurrencyRequest request = TransProto.GetTransConcurrencyRequest.newBuilder()

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/utils/Constants.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/utils/Constants.java
@@ -47,6 +47,9 @@ public final class Constants
     public static final String CACHE_LOCATION_LITERAL = "location_";
     public static final int MAX_BLOCK_ID_LEN = 20480;
 
+    public static final String TRANS_CONTEXT_COST_CENTS_KEY = "trans_cost_cents";
+    public static final String TRANS_CONTEXT_BILLED_CENTS_KEY = "trans_billed_cents";
+
     /**
      * The time in seconds that a relaxed query can be postponed for execution.
      */

--- a/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/transaction/TransServiceImpl.java
+++ b/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/transaction/TransServiceImpl.java
@@ -176,6 +176,31 @@ public class TransServiceImpl extends TransServiceGrpc.TransServiceImplBase
     }
 
     @Override
+    public void setTransProperty(TransProto.SetTransPropertyRequest request, StreamObserver<TransProto.SetTransPropertyResponse> responseObserver)
+    {
+        long transId = request.getTransId();
+        String key = request.getKey();
+        String value = request.getValue();
+        TransProto.SetTransPropertyResponse.Builder builder = TransProto.SetTransPropertyResponse.newBuilder();
+        TransContext context = TransContextManager.Instance().getTransContext(transId);
+        if (context != null)
+        {
+            String prevValue = (String) context.getProperties().setProperty(key, value);
+            if (prevValue != null)
+            {
+                builder.setPrevValue(prevValue);
+            }
+            builder.setErrorCode(ErrorCode.SUCCESS);
+        }
+        else
+        {
+            builder.setErrorCode(ErrorCode.TRANS_CONTEXT_NOT_FOUND);
+        }
+        responseObserver.onNext(builder.build());
+        responseObserver.onCompleted();
+    }
+
+    @Override
     public void getTransConcurrency(TransProto.GetTransConcurrencyRequest request,
                                     StreamObserver<TransProto.GetTransConcurrencyResponse> responseObserver) {
         int concurrency = TransContextManager.Instance().getQueryConcurrency(request.getReadOnly());

--- a/pixels-turbo/README.md
+++ b/pixels-turbo/README.md
@@ -61,7 +61,7 @@ Then, deploy the serverless workers following the instructions in the README.md 
 Currently, we support AWS Lambda and vHive. So the worker service can be `pixels-worker-lambda` or `pixels-worker-vhive`.
 More platform integrations will be provided in the future.
 
-If the MPP cluster is running in a cloud machine service such as AWS EC2, follow the instructions in the README.md of `pixels-scakubg-[service]`
+If the MPP cluster is running in a cloud machine service such as AWS EC2, follow the instructions in the README.md of `pixels-scaling-[service]`
 to deploy the auto-scaling manager for the MPP cluster. Currently, we support auto-scaling in AWS EC2. So `pixels-scaling-ec2` is the only option.
 It can be used as an example to implement the auto-scaling manager for other cloud platforms.
 

--- a/proto/transaction.proto
+++ b/proto/transaction.proto
@@ -34,6 +34,7 @@ service TransService {
     rpc CommitTrans (CommitTransRequest) returns (CommitTransResponse);
     rpc RollbackTrans (RollbackTransRequest) returns (RollbackTransResponse);
     rpc GetTransContext (GetTransContextRequest) returns (GetTransContextResponse);
+    rpc SetTransProperty (SetTransPropertyRequest) returns (SetTransPropertyResponse);
     rpc GetTransConcurrency (GetTransConcurrencyRequest) returns (GetTransConcurrencyResponse);
     rpc BindExternalTraceId (BindExternalTraceIdRequest) returns (BindExternalTraceIdResponse);
 }
@@ -94,6 +95,17 @@ message GetTransContextRequest {
 message GetTransContextResponse {
     int32 errorCode = 1;
     TransContext transContext = 2;
+}
+
+message SetTransPropertyRequest {
+    int64 transId = 1;
+    string key = 2;
+    string value = 3;
+}
+
+message SetTransPropertyResponse {
+    int32 errorCode = 1;
+    optional string prevValue = 2;
 }
 
 message GetTransConcurrencyRequest {


### PR DESCRIPTION
Add rpc protocol to set query costs as transaction properties.
Get the spent and billed cents from the transaction service.
Return the query costs and the query pending time in the get query result response.