### PR TITLE
[Issue #506] support billed cents in pixels-server

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -38,8 +38,8 @@ Oracle JDK 17.0, Azul Zulu JDK 17, or GraalVM 22 for Java 17 also works.
 
 ## Install Maven
 
-Pixels requires maven 3.6 to build the source code (maven 3.1-3.5 might work, but we didn't test them yet). On some old operating systems, the maven installed by `apt` or `yum` might be incompatible with new JDKs such as 17. 
-In this case, manually install a newer maven compatible with your JDK. 
+Pixels requires maven 3.8 or later to build the source code (some early maven versions may work, but we haven't test them yet). On some operating systems, the maven installed by `apt` or `yum` might be incompatible with new JDKs such as 17. 
+In this case, manually install a newer maven compatible with your JDK.
 
 ## Setup AWS Credentials*
 

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/server/ExecutionHint.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/server/ExecutionHint.java
@@ -25,7 +25,7 @@ package io.pixelsdb.pixels.common.server;
  */
 public enum ExecutionHint
 {
-    BEST_EFFORT, // execute the query at best effort, without any guarantee of timeliness or performance
+    BEST_OF_EFFORT, // execute the query at best of effort, without any guarantee of timeliness or performance
     RELAXED, // the query can be postponed a few minutes for execution
     IMMEDIATE, // execute the query immediately using Pixel-Turbo
 }

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/server/PriceModel.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/server/PriceModel.java
@@ -42,7 +42,7 @@ public class PriceModel
                 return scanSize / 1024 / 1024 / 2048;
             case RELAXED:
                 return scanSize / 1024 / 1024 / 10240;
-            case BEST_EFFORT:
+            case BEST_OF_EFFORT:
                 return scanSize / 1024 / 1024 / 20480;
             default:
                 throw new QueryServerException("invalid execution hint for calculating billed cents");

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/server/PriceModel.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/server/PriceModel.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2024 PixelsDB.
+ *
+ * This file is part of Pixels.
+ *
+ * Pixels is free software: you can redistribute it and/or modify
+ * it under the terms of the Affero GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * Pixels is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Affero GNU General Public License for more details.
+ *
+ * You should have received a copy of the Affero GNU General Public
+ * License along with Pixels.  If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package io.pixelsdb.pixels.common.server;
+
+import io.pixelsdb.pixels.common.exception.QueryServerException;
+
+/**
+ * @author hank
+ * @create 2024-04-10
+ */
+public class PriceModel
+{
+    private PriceModel () { }
+
+    /**
+     *
+     * @param scanSize
+     * @return
+     */
+    public static double billedCents(double scanSize, ExecutionHint executionHint)
+    {
+        switch (executionHint)
+        {
+            case IMMEDIATE:
+                return scanSize / 1024 / 1024 / 2048;
+            case RELAXED:
+                return scanSize / 1024 / 1024 / 10240;
+            case BEST_EFFORT:
+                return scanSize / 1024 / 1024 / 20480;
+            default:
+                throw new QueryServerException("invalid execution hint for calculating billed cents");
+        }
+    }
+}

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/transaction/TransService.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/transaction/TransService.java
@@ -137,6 +137,26 @@ public class TransService
     {
         TransProto.SetTransPropertyRequest request = TransProto.SetTransPropertyRequest.newBuilder()
                 .setTransId(transId).setKey(key).setValue(value).build();
+        return setTransProperty(request);
+    }
+
+    /**
+     * Set the string property of a transaction.
+     * @param externalTraceId the external trace id (token) of the transaction
+     * @param key the property key
+     * @param value the property value
+     * @return the previous value of the property key, or null if not present
+     * @throws TransException if the transaction does not exist
+     */
+    public String setTransProperty(String externalTraceId, String key, String value) throws TransException
+    {
+        TransProto.SetTransPropertyRequest request = TransProto.SetTransPropertyRequest.newBuilder()
+                .setExternalTraceId(externalTraceId).setKey(key).setValue(value).build();
+        return setTransProperty(request);
+    }
+
+    private String setTransProperty(TransProto.SetTransPropertyRequest request) throws TransException
+    {
         TransProto.SetTransPropertyResponse response = this.stub.setTransProperty(request);
         if (response.getErrorCode() != ErrorCode.SUCCESS)
         {

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/utils/Constants.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/utils/Constants.java
@@ -48,7 +48,7 @@ public final class Constants
     public static final int MAX_BLOCK_ID_LEN = 20480;
 
     public static final String TRANS_CONTEXT_COST_CENTS_KEY = "trans_cost_cents";
-    public static final String TRANS_CONTEXT_BILLED_CENTS_KEY = "trans_billed_cents";
+    public static final String TRANS_CONTEXT_SCAN_BYTES_KEY = "trans_scan_bytes";
 
     /**
      * The time in seconds that a relaxed query can be postponed for execution.

--- a/pixels-common/src/main/resources/pixels.properties
+++ b/pixels-common/src/main/resources/pixels.properties
@@ -2,7 +2,7 @@
 # pixels.var.dir is where the lock files are created
 pixels.var.dir=/home/pixels/opt/pixels/var/
 # metadata database connection properties
-metadata.db.driver=com.mysql.jdbc.Driver
+metadata.db.driver=com.mysql.cj.jdbc.Driver
 metadata.db.user=pixels
 metadata.db.password=password
 metadata.db.url=jdbc:mysql://localhost:3306/pixels_metadata?useUnicode=true&characterEncoding=UTF-8&zeroDateTimeBehavior=convertToNull

--- a/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/transaction/TransServiceImpl.java
+++ b/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/transaction/TransServiceImpl.java
@@ -176,13 +176,22 @@ public class TransServiceImpl extends TransServiceGrpc.TransServiceImplBase
     }
 
     @Override
-    public void setTransProperty(TransProto.SetTransPropertyRequest request, StreamObserver<TransProto.SetTransPropertyResponse> responseObserver)
+    public void setTransProperty(TransProto.SetTransPropertyRequest request,
+                                 StreamObserver<TransProto.SetTransPropertyResponse> responseObserver)
     {
-        long transId = request.getTransId();
+        TransContext context = null;
+        if (request.hasTransId())
+        {
+            context = TransContextManager.Instance().getTransContext(request.getTransId());
+        }
+        else if (request.hasExternalTraceId())
+        {
+            context = TransContextManager.Instance().getTransContext(request.getExternalTraceId());
+
+        }
         String key = request.getKey();
         String value = request.getValue();
         TransProto.SetTransPropertyResponse.Builder builder = TransProto.SetTransPropertyResponse.newBuilder();
-        TransContext context = TransContextManager.Instance().getTransContext(transId);
         if (context != null)
         {
             String prevValue = (String) context.getProperties().setProperty(key, value);

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/StarlingPlanner.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/StarlingPlanner.java
@@ -28,18 +28,15 @@ import io.pixelsdb.pixels.common.exception.MetadataException;
 import io.pixelsdb.pixels.common.layout.*;
 import io.pixelsdb.pixels.common.metadata.MetadataService;
 import io.pixelsdb.pixels.common.metadata.SchemaTableName;
-import io.pixelsdb.pixels.common.metadata.domain.Layout;
-import io.pixelsdb.pixels.common.metadata.domain.Ordered;
-import io.pixelsdb.pixels.common.metadata.domain.Projections;
-import io.pixelsdb.pixels.common.metadata.domain.Splits;
+import io.pixelsdb.pixels.common.metadata.domain.*;
 import io.pixelsdb.pixels.common.physical.Storage;
 import io.pixelsdb.pixels.common.physical.StorageFactory;
-import io.pixelsdb.pixels.planner.plan.physical.domain.StorageInfo;
 import io.pixelsdb.pixels.common.utils.ConfigFactory;
 import io.pixelsdb.pixels.executor.join.JoinAlgorithm;
 import io.pixelsdb.pixels.executor.join.JoinType;
 import io.pixelsdb.pixels.executor.predicate.TableScanFilter;
 import io.pixelsdb.pixels.planner.plan.PlanOptimizer;
+import io.pixelsdb.pixels.planner.plan.logical.Table;
 import io.pixelsdb.pixels.planner.plan.logical.*;
 import io.pixelsdb.pixels.planner.plan.physical.*;
 import io.pixelsdb.pixels.planner.plan.physical.domain.*;
@@ -77,6 +74,11 @@ public class StarlingPlanner
     private final boolean compactPathEnabled;
     private final Storage storage;
     private final long transId;
+
+    /**
+     * The data size in bytes to be scanned by the input query.
+     */
+    private double scanSize = 0;
 
     static
     {
@@ -145,6 +147,11 @@ public class StarlingPlanner
             throw new UnsupportedOperationException("root table type '" +
                     this.rootTable.getTableType() + "' is currently not supported");
         }
+    }
+
+    public double getScanSize()
+    {
+        return scanSize;
     }
 
     private StarlingAggregationOperator getAggregationOperator(AggregatedTable aggregatedTable)
@@ -1164,6 +1171,18 @@ public class StarlingPlanner
         checkArgument(tableStorageScheme.equals(this.storage.getScheme()), String.format(
                 "the storage scheme of table '%s.%s' is not consistent with the input storage scheme for Pixels Turbo",
                 table.getSchemaName(), table.getTableName()));
+        // Issue #506: add the column size of the base table to the scan size of this query.
+        List<Column> columns = metadataService.getColumns(table.getSchemaName(), table.getTableName(), true);
+        Map<String, Column> nameToColumnMap = new HashMap<>(columns.size());
+        for (Column column : columns)
+        {
+            nameToColumnMap.put(column.getName(), column);
+        }
+        for (String columnName : table.getColumnNames())
+        {
+            this.scanSize += nameToColumnMap.get(columnName).getSize();
+        }
+
         List<Layout> layouts = metadataService.getLayouts(table.getSchemaName(), table.getTableName());
         for (Layout layout : layouts)
         {

--- a/pixels-server/src/main/java/io/pixelsdb/pixels/server/controller/QueryManager.java
+++ b/pixels-server/src/main/java/io/pixelsdb/pixels/server/controller/QueryManager.java
@@ -231,7 +231,7 @@ public class QueryManager
                     if (query != null)
                     {
                         // this queue should only contain best-effort queries that are to be executed in the mpp cluster
-                        checkArgument(query.getRequest().getExecutionHint() == ExecutionHint.BEST_EFFORT,
+                        checkArgument(query.getRequest().getExecutionHint() == ExecutionHint.BEST_OF_EFFORT,
                                 "pending queue should only contain cost-effective queries");
                         QueryScheduleService.QueryConcurrency queryConcurrency = queryScheduleService.getQueryConcurrency();
                         if (queryConcurrency.mppConcurrency == 0)
@@ -264,7 +264,7 @@ public class QueryManager
      */
     public SubmitQueryResponse submitQuery(SubmitQueryRequest request)
     {
-        if (request.getExecutionHint() == ExecutionHint.RELAXED || request.getExecutionHint() == ExecutionHint.BEST_EFFORT)
+        if (request.getExecutionHint() == ExecutionHint.RELAXED || request.getExecutionHint() == ExecutionHint.BEST_OF_EFFORT)
         {
             try
             {
@@ -289,7 +289,7 @@ public class QueryManager
             try
             {
                 String traceToken = UUID.randomUUID().toString();
-                this.submit(new ReceivedQuery(traceToken, request, 0L)); // received time is not needed
+                this.submit(new ReceivedQuery(traceToken, request, System.currentTimeMillis()));
                 return new SubmitQueryResponse(ErrorCode.SUCCESS, "", traceToken);
             } catch (Throwable e)
             {
@@ -311,7 +311,7 @@ public class QueryManager
     {
         Properties properties;
         SubmitQueryRequest request = query.getRequest();
-        if (request.getExecutionHint() == ExecutionHint.RELAXED || request.getExecutionHint() == ExecutionHint.BEST_EFFORT)
+        if (request.getExecutionHint() == ExecutionHint.RELAXED || request.getExecutionHint() == ExecutionHint.BEST_OF_EFFORT)
         {
             // submit it to the mpp connection
             properties = this.costEffectiveConnProp;

--- a/pixels-server/src/main/java/io/pixelsdb/pixels/server/controller/QueryManager.java
+++ b/pixels-server/src/main/java/io/pixelsdb/pixels/server/controller/QueryManager.java
@@ -24,6 +24,7 @@ import io.pixelsdb.pixels.common.exception.QueryScheduleException;
 import io.pixelsdb.pixels.common.exception.QueryServerException;
 import io.pixelsdb.pixels.common.exception.TransException;
 import io.pixelsdb.pixels.common.server.ExecutionHint;
+import io.pixelsdb.pixels.common.server.PriceModel;
 import io.pixelsdb.pixels.common.server.QueryStatus;
 import io.pixelsdb.pixels.common.server.rest.request.SubmitQueryRequest;
 import io.pixelsdb.pixels.common.server.rest.response.GetQueryResultResponse;
@@ -339,8 +340,9 @@ public class QueryManager
                 TransContext transContext = this.transService.getTransContext(traceToken);
                 double costCents = Double.parseDouble(transContext.getProperties().getProperty(
                         Constants.TRANS_CONTEXT_COST_CENTS_KEY, "0"));
-                double billedCents = Double.parseDouble(transContext.getProperties().getProperty(
-                        Constants.TRANS_CONTEXT_BILLED_CENTS_KEY, "0"));
+                double scanBytes = Double.parseDouble(transContext.getProperties().getProperty(
+                        Constants.TRANS_CONTEXT_SCAN_BYTES_KEY, "0"));
+                double billedCents = PriceModel.billedCents(scanBytes, request.getExecutionHint());
                 int columnCount = resultSet.getMetaData().getColumnCount();
                 int[] columnPrintSizes = new int[columnCount];
                 String[] columnNames = new String[columnCount];

--- a/pixels-server/src/test/java/io/pixelsdb/pixels/server/TestQueryAPI.java
+++ b/pixels-server/src/test/java/io/pixelsdb/pixels/server/TestQueryAPI.java
@@ -139,7 +139,7 @@ public class TestQueryAPI
         String json = this.mockMvc.perform(
                         post(RestUrlPath.SUBMIT_QUERY).contentType(MediaType.APPLICATION_JSON).content(
                                 JSON.toJSONString(new SubmitQueryRequest(
-                                        "SELECT * FROM clickbench.hits LIMIT 1", ExecutionHint.RELAXED, 10))))
+                                        "SELECT * FROM clickbench.hits LIMIT 1", ExecutionHint.IMMEDIATE, 10))))
                 .andDo(print()).andExpect(status().isOk()).andReturn().getResponse().getContentAsString();
         SubmitQueryResponse response = JSON.parseObject(json, SubmitQueryResponse.class);
         TimeUnit.SECONDS.sleep(5);

--- a/pixels-server/src/test/java/io/pixelsdb/pixels/server/TestQueryAPI.java
+++ b/pixels-server/src/test/java/io/pixelsdb/pixels/server/TestQueryAPI.java
@@ -62,7 +62,7 @@ public class TestQueryAPI
         String json1 = this.mockMvc.perform(
                         post(RestUrlPath.SUBMIT_QUERY).contentType(MediaType.APPLICATION_JSON).content(
                                 JSON.toJSONString(new SubmitQueryRequest(
-                                        "SELECT COUNT(l_orderkey) AS d_l_orderkey FROM lineitem",
+                                        "SELECT COUNT(l_orderkey) AS d_l_orderkey FROM tpch.lineitem",
                                         ExecutionHint.RELAXED, 1))))
                 .andExpect(status().isOk()).andReturn().getResponse().getContentAsString();
         System.out.println(json1);
@@ -73,7 +73,7 @@ public class TestQueryAPI
         String json2 = this.mockMvc.perform(
                         post(RestUrlPath.SUBMIT_QUERY).contentType(MediaType.APPLICATION_JSON).content(
                                 JSON.toJSONString(new SubmitQueryRequest(
-                                        "SELECT * FROM nation", ExecutionHint.BEST_EFFORT, 10))))
+                                        "SELECT * FROM tpch.nation", ExecutionHint.BEST_OF_EFFORT, 10))))
                 .andExpect(status().isOk()).andReturn().getResponse().getContentAsString();
         System.out.println(json2);
         SubmitQueryResponse response2 = JSON.parseObject(json2, SubmitQueryResponse.class);
@@ -115,7 +115,7 @@ public class TestQueryAPI
         String json = this.mockMvc.perform(
                 post(RestUrlPath.SUBMIT_QUERY).contentType(MediaType.APPLICATION_JSON).content(
                         JSON.toJSONString(new SubmitQueryRequest(
-                                "SELECT * FROM nation", ExecutionHint.RELAXED, 10))))
+                                "SELECT * FROM tpch.nation", ExecutionHint.RELAXED, 10))))
                 .andDo(print()).andExpect(status().isOk()).andReturn().getResponse().getContentAsString();
         SubmitQueryResponse response = JSON.parseObject(json, SubmitQueryResponse.class);
 
@@ -139,7 +139,7 @@ public class TestQueryAPI
         String json = this.mockMvc.perform(
                         post(RestUrlPath.SUBMIT_QUERY).contentType(MediaType.APPLICATION_JSON).content(
                                 JSON.toJSONString(new SubmitQueryRequest(
-                                        "SELECT * FROM nation", ExecutionHint.IMMEDIATE, 10))))
+                                        "SELECT * FROM clickbench.hits LIMIT 1", ExecutionHint.RELAXED, 10))))
                 .andDo(print()).andExpect(status().isOk()).andReturn().getResponse().getContentAsString();
         SubmitQueryResponse response = JSON.parseObject(json, SubmitQueryResponse.class);
         TimeUnit.SECONDS.sleep(5);

--- a/pixels-turbo/README.md
+++ b/pixels-turbo/README.md
@@ -65,7 +65,7 @@ If the MPP cluster is running in a cloud machine service such as AWS EC2, follow
 to deploy the auto-scaling manager for the MPP cluster. Currently, we support auto-scaling in AWS EC2. So `pixels-scaling-ec2` is the only option.
 It can be used as an example to implement the auto-scaling manager for other cloud platforms.
 
-## ## Start Pixels (with Turbo)
+## Start Pixels (with Turbo)
 
 In `etc/catalogpixels.properties` under the installation directory of Trino, set `cloud.function.switch` to `auto` if you have installed the auto-scaling manager and 
 want to enable auto-scaling of MPP cluster and adaptive invocation of serverless workers; or set it to `on` if you want to always push the queries into serverless workers.

--- a/proto/transaction.proto
+++ b/proto/transaction.proto
@@ -98,9 +98,12 @@ message GetTransContextResponse {
 }
 
 message SetTransPropertyRequest {
-    int64 transId = 1;
-    string key = 2;
-    string value = 3;
+    oneof lookupKey {
+        string externalTraceId = 1;
+        uint64 transId = 2;
+    }
+    string key = 3;
+    string value = 4;
 }
 
 message SetTransPropertyResponse {


### PR DESCRIPTION
Allow pixels-trino to set scan size in the transaction properties and use it to calculate the billed cents.