### PR TITLE
[Issue #506] support cost cents collection

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -241,7 +241,6 @@ connector.name=pixels
 # serverless config
 # it can be on, off, auto, or session
 cloud.function.switch=off
-local.scan.concurrency=40
 clean.intermediate.result=true
 ```
 **Note** that `etc/catalog/pixels.proterties` under Trino's home is different from `PIXELS_HOME/pixels.properties`.

--- a/pixels-cli/src/test/java/io/pixelsdb/pixels/cli/TestExecuteQuery.java
+++ b/pixels-cli/src/test/java/io/pixelsdb/pixels/cli/TestExecuteQuery.java
@@ -1,3 +1,22 @@
+/*
+ * Copyright 2023 PixelsDB.
+ *
+ * This file is part of Pixels.
+ *
+ * Pixels is free software: you can redistribute it and/or modify
+ * it under the terms of the Affero GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * Pixels is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Affero GNU General Public License for more details.
+ *
+ * You should have received a copy of the Affero GNU General Public
+ * License along with Pixels.  If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
 package io.pixelsdb.pixels.cli;
 
 import org.junit.Test;
@@ -11,6 +30,5 @@ public class TestExecuteQuery
     @Test
     public void test()
     {
-        int qpm = 3;
     }
 }

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/state/StateManager.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/state/StateManager.java
@@ -62,7 +62,7 @@ public class StateManager
      * Delete all the states by the prefix of their keys.
      * @param keyPredix the predix of the state keys
      */
-    public void deleteAllStatesByPrefix(String keyPredix)
+    public static void deleteAllStatesByPrefix(String keyPredix)
     {
         EtcdUtil.Instance().deleteByPrefix(keyPredix);
     }

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/state/StateManager.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/state/StateManager.java
@@ -57,4 +57,13 @@ public class StateManager
     {
         EtcdUtil.Instance().delete(key);
     }
+
+    /**
+     * Delete all the states by the prefix of their keys.
+     * @param keyPredix the predix of the state keys
+     */
+    public void deleteAllStatesByPrefix(String keyPredix)
+    {
+        EtcdUtil.Instance().deleteByPrefix(keyPredix);
+    }
 }

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/state/StateWatcher.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/state/StateWatcher.java
@@ -107,7 +107,6 @@ public class StateWatcher implements Closeable
                             } catch (Exception e)
                             {
                                 logger.error("no exception should be caught here", e);
-                                e.printStackTrace();
                             }
                         }
                     }

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/state/StateWatcher.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/state/StateWatcher.java
@@ -82,6 +82,10 @@ public class StateWatcher implements Closeable
             action.perform(keyValue.getKey().toString(StandardCharsets.UTF_8),
                     keyValue.getValue().toString(StandardCharsets.UTF_8));
         }
+        else
+        {
+            this.watchers.add(watcher);
+        }
     }
 
     private Watch.Watcher getStateWatcher(Action action)

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/state/StateWatcher.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/state/StateWatcher.java
@@ -64,7 +64,29 @@ public class StateWatcher implements Closeable
      */
     public void onStateUpdate(Action action)
     {
-        Watch.Watcher watcher = EtcdUtil.Instance().getWatchClient().watch(
+        this.watchers.add(getStateWatcher(action));
+    }
+
+    /**
+     * Set the action for the update event of the state if the key does not exist, or perform the
+     * action if the state exists. The action must be idempotent as it may be called twice for the same state update.
+     * @param action the action
+     */
+    public void onStateUpdateorExist(Action action)
+    {
+        Watch.Watcher watcher = getStateWatcher(action);
+        KeyValue keyValue = EtcdUtil.Instance().getKeyValue(this.key);
+        if (keyValue != null)
+        {
+            watcher.close();
+            action.perform(keyValue.getKey().toString(StandardCharsets.UTF_8),
+                    keyValue.getValue().toString(StandardCharsets.UTF_8));
+        }
+    }
+
+    private Watch.Watcher getStateWatcher(Action action)
+    {
+        return EtcdUtil.Instance().getWatchClient().watch(
                 ByteSequence.from(key, StandardCharsets.UTF_8),
                 WatchOption.DEFAULT, watchResponse -> {
                     for (WatchEvent event : watchResponse.getEvents())
@@ -78,8 +100,7 @@ public class StateWatcher implements Closeable
                                 action.perform(
                                         current.getKey().toString(StandardCharsets.UTF_8),
                                         current.getValue().toString(StandardCharsets.UTF_8));
-                            }
-                            catch (Exception e)
+                            } catch (Exception e)
                             {
                                 logger.error("no exception should be caught here", e);
                                 e.printStackTrace();
@@ -87,7 +108,6 @@ public class StateWatcher implements Closeable
                         }
                     }
                 });
-        this.watchers.add(watcher);
     }
 
     /**

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/state/StateWatcher.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/state/StateWatcher.java
@@ -72,7 +72,7 @@ public class StateWatcher implements Closeable
      * action if the state exists. The action must be idempotent as it may be called twice for the same state update.
      * @param action the action
      */
-    public void onStateUpdateorExist(Action action)
+    public void onStateUpdateOrExist(Action action)
     {
         Watch.Watcher watcher = getStateWatcher(action);
         KeyValue keyValue = EtcdUtil.Instance().getKeyValue(this.key);

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/state/StateWatcher.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/state/StateWatcher.java
@@ -69,7 +69,6 @@ public class StateWatcher implements Closeable
                 WatchOption.DEFAULT, watchResponse -> {
                     for (WatchEvent event : watchResponse.getEvents())
                     {
-                        System.out.println("1" + event.getEventType().toString());
                         if (event.getEventType() == WatchEvent.EventType.PUT)
                         {
                             try

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/transaction/TransService.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/transaction/TransService.java
@@ -169,6 +169,46 @@ public class TransService
         return null;
     }
 
+    /**
+     * Update the costs of a transaction (query).
+     * @param transId the id of the transaction
+     * @param newScanBytes the new scan bytes to set in the transaction context
+     * @param addCostCents the additional cost in cents to add into the transaction context
+     * @return true of the costs are updates successfully, otherwise false
+     * @throws TransException if the transaction does not exist
+     */
+    public boolean updateQueryCosts(long transId, double newScanBytes, double addCostCents) throws TransException
+    {
+        TransProto.UpdateQueryCostsRequest request = TransProto.UpdateQueryCostsRequest.newBuilder()
+                .setTransId(transId).setNewScanBytes(newScanBytes).setAddCostCents(addCostCents).build();
+        return updateQueryCosts(request);
+    }
+
+    /**
+     * Update the costs of a transaction (query).
+     * @param externalTraceId the external trace id (token) of the transaction
+     * @param newScanBytes the new scan bytes to set in the transaction context
+     * @param addCostCents the additional cost in cents to add into the transaction context
+     * @return true of the costs are updates successfully, otherwise false
+     * @throws TransException if the transaction does not exist
+     */
+    public boolean updateQueryCosts(String externalTraceId, double newScanBytes, double addCostCents) throws TransException
+    {
+        TransProto.UpdateQueryCostsRequest request = TransProto.UpdateQueryCostsRequest.newBuilder()
+                .setExternalTraceId(externalTraceId).setNewScanBytes(newScanBytes).setAddCostCents(addCostCents).build();
+        return updateQueryCosts(request);
+    }
+
+    private boolean updateQueryCosts(TransProto.UpdateQueryCostsRequest request) throws TransException
+    {
+        TransProto.UpdateQueryCostsResponse response = this.stub.updateQueryCosts(request);
+        if (response.getErrorCode() != ErrorCode.SUCCESS)
+        {
+            throw new TransException("failed to update query costs, error code=" + response.getErrorCode());
+        }
+        return true;
+    }
+
     public int getTransConcurrency(boolean readOnly) throws TransException
     {
         TransProto.GetTransConcurrencyRequest request = TransProto.GetTransConcurrencyRequest.newBuilder()

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/turbo/Output.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/turbo/Output.java
@@ -177,4 +177,13 @@ public abstract class Output
     {
         this.totalWriteBytes = totalWriteBytes;
     }
+
+    public SimpleOutput toSimpleOutput()
+    {
+        SimpleOutput simpleOutput = new SimpleOutput();
+        simpleOutput.setRequestId(this.requestId);
+        simpleOutput.setSuccessful(this.successful);
+        simpleOutput.setErrorMessage(this.errorMessage);
+        return simpleOutput;
+    }
 }

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/turbo/SimpleOutput.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/turbo/SimpleOutput.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2024 PixelsDB.
+ *
+ * This file is part of Pixels.
+ *
+ * Pixels is free software: you can redistribute it and/or modify
+ * it under the terms of the Affero GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * Pixels is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Affero GNU General Public License for more details.
+ *
+ * You should have received a copy of the Affero GNU General Public
+ * License along with Pixels.  If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package io.pixelsdb.pixels.common.turbo;
+
+/**
+ * @author hank
+ * @create 2024-04-22
+ */
+public class SimpleOutput
+{
+    private String requestId;
+    private boolean successful;
+    private String errorMessage;
+
+    public String getRequestId()
+    {
+        return requestId;
+    }
+
+    public void setRequestId(String requestId)
+    {
+        this.requestId = requestId;
+    }
+
+    public boolean isSuccessful()
+    {
+        return successful;
+    }
+
+    public void setSuccessful(boolean successful)
+    {
+        this.successful = successful;
+    }
+
+    public String getErrorMessage()
+    {
+        return errorMessage;
+    }
+
+    public void setErrorMessage(String errorMessage)
+    {
+        this.errorMessage = errorMessage;
+    }
+}

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/utils/Constants.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/utils/Constants.java
@@ -84,4 +84,6 @@ public final class Constants
     public static final String GCS_ID_KEY = "pixels_storage_gcs_id";
     // the prefix for keys of gcs metadata (i.e. file path -> file id).
     public static final String GCS_META_PREFIX = "pixels_storage_gcs_meta:";
+
+    public static final String CF_OUTPUT_STATE_KEY_PREFIX = "pixels_turbo_cf_output";
 }

--- a/pixels-common/src/test/java/io/pixelsdb/pixels/common/state/TestStateManager.java
+++ b/pixels-common/src/test/java/io/pixelsdb/pixels/common/state/TestStateManager.java
@@ -59,7 +59,7 @@ public class TestStateManager
 
         StateWatcher watcher = new StateWatcher("state-1");
 
-        watcher.onStateUpdateorExist((key, value) -> {
+        watcher.onStateUpdateOrExist((key, value) -> {
             System.out.println("on state update:");
             System.out.println("key=" + key);
             System.out.println("value=" + value);

--- a/pixels-common/src/test/java/io/pixelsdb/pixels/common/state/TestStateManager.java
+++ b/pixels-common/src/test/java/io/pixelsdb/pixels/common/state/TestStateManager.java
@@ -30,7 +30,7 @@ import java.io.IOException;
 public class TestStateManager
 {
     @Test
-    public void testSetState() throws IOException, InterruptedException
+    public void testStateUpdate() throws IOException, InterruptedException
     {
         StateManager manager = new StateManager("state-1");
         manager.setState("1");
@@ -41,6 +41,31 @@ public class TestStateManager
             System.out.println("key=" + key);
             System.out.println("value=" + value);
         });
+
+        manager.setState("2");
+
+        manager.setState("3");
+
+        manager.deleteState();
+
+        watcher.close();
+        Thread.sleep(1000);
+    }
+
+    @Test
+    public void testStateUpdateOrExist() throws IOException, InterruptedException
+    {
+        StateManager manager = new StateManager("state-1");
+
+        StateWatcher watcher = new StateWatcher("state-1");
+
+        watcher.onStateUpdateorExist((key, value) -> {
+            System.out.println("on state update:");
+            System.out.println("key=" + key);
+            System.out.println("value=" + value);
+        });
+
+        manager.setState("1");
 
         manager.setState("2");
 

--- a/pixels-common/src/test/java/io/pixelsdb/pixels/common/state/TestStateManager.java
+++ b/pixels-common/src/test/java/io/pixelsdb/pixels/common/state/TestStateManager.java
@@ -56,16 +56,14 @@ public class TestStateManager
     public void testStateUpdateOrExist() throws IOException, InterruptedException
     {
         StateManager manager = new StateManager("state-1");
+        manager.setState("1");
 
         StateWatcher watcher = new StateWatcher("state-1");
-
         watcher.onStateUpdateOrExist((key, value) -> {
             System.out.println("on state update:");
             System.out.println("key=" + key);
             System.out.println("value=" + value);
         });
-
-        manager.setState("1");
 
         manager.setState("2");
 

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/stats/VectorColumnStats.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/stats/VectorColumnStats.java
@@ -1,3 +1,22 @@
+/*
+ * Copyright 2023 PixelsDB.
+ *
+ * This file is part of Pixels.
+ *
+ * Pixels is free software: you can redistribute it and/or modify
+ * it under the terms of the Affero GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * Pixels is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Affero GNU General Public License for more details.
+ *
+ * You should have received a copy of the Affero GNU General Public
+ * License along with Pixels.  If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
 package io.pixelsdb.pixels.core.stats;
 
 public interface VectorColumnStats {

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/stats/VectorStatsRecorder.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/stats/VectorStatsRecorder.java
@@ -1,3 +1,22 @@
+/*
+ * Copyright 2023 PixelsDB.
+ *
+ * This file is part of Pixels.
+ *
+ * Pixels is free software: you can redistribute it and/or modify
+ * it under the terms of the Affero GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * Pixels is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Affero GNU General Public License for more details.
+ *
+ * You should have received a copy of the Affero GNU General Public
+ * License along with Pixels.  If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
 package io.pixelsdb.pixels.core.stats;
 
 import io.pixelsdb.pixels.core.PixelsProto;

--- a/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/transaction/TransServiceImpl.java
+++ b/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/transaction/TransServiceImpl.java
@@ -229,11 +229,11 @@ public class TransServiceImpl extends TransServiceGrpc.TransServiceImplBase
         TransProto.UpdateQueryCostsResponse.Builder builder = TransProto.UpdateQueryCostsResponse.newBuilder();
         if (context != null)
         {
+            context.getProperties().setProperty(Constants.TRANS_CONTEXT_SCAN_BYTES_KEY, String.valueOf(newScanBytes));
             double curCostCents = Double.parseDouble(
                     context.getProperties().getProperty(Constants.TRANS_CONTEXT_COST_CENTS_KEY, "0"));
             context.getProperties().setProperty(Constants.TRANS_CONTEXT_COST_CENTS_KEY,
                     String.valueOf(curCostCents + addCostCents));
-            context.getProperties().setProperty(Constants.TRANS_CONTEXT_SCAN_BYTES_KEY, String.valueOf(newScanBytes));
             builder.setErrorCode(ErrorCode.SUCCESS);
         }
         else

--- a/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/transaction/TransServiceImpl.java
+++ b/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/transaction/TransServiceImpl.java
@@ -22,6 +22,7 @@ package io.pixelsdb.pixels.daemon.transaction;
 import io.grpc.stub.StreamObserver;
 import io.pixelsdb.pixels.common.error.ErrorCode;
 import io.pixelsdb.pixels.common.transaction.TransContext;
+import io.pixelsdb.pixels.common.utils.Constants;
 import io.pixelsdb.pixels.daemon.TransProto;
 import io.pixelsdb.pixels.daemon.TransServiceGrpc;
 import org.apache.logging.log4j.LogManager;
@@ -199,6 +200,40 @@ public class TransServiceImpl extends TransServiceGrpc.TransServiceImplBase
             {
                 builder.setPrevValue(prevValue);
             }
+            builder.setErrorCode(ErrorCode.SUCCESS);
+        }
+        else
+        {
+            builder.setErrorCode(ErrorCode.TRANS_CONTEXT_NOT_FOUND);
+        }
+        responseObserver.onNext(builder.build());
+        responseObserver.onCompleted();
+    }
+
+    @Override
+    public void updateQueryCosts(TransProto.UpdateQueryCostsRequest request,
+                                 StreamObserver<TransProto.UpdateQueryCostsResponse> responseObserver)
+    {
+        TransContext context = null;
+        if (request.hasTransId())
+        {
+            context = TransContextManager.Instance().getTransContext(request.getTransId());
+        }
+        else if (request.hasExternalTraceId())
+        {
+            context = TransContextManager.Instance().getTransContext(request.getExternalTraceId());
+
+        }
+        double newScanBytes = request.getNewScanBytes();
+        double addCostCents = request.getAddCostCents();
+        TransProto.UpdateQueryCostsResponse.Builder builder = TransProto.UpdateQueryCostsResponse.newBuilder();
+        if (context != null)
+        {
+            double curCostCents = Double.parseDouble(
+                    context.getProperties().getProperty(Constants.TRANS_CONTEXT_COST_CENTS_KEY, "0"));
+            context.getProperties().setProperty(Constants.TRANS_CONTEXT_COST_CENTS_KEY,
+                    String.valueOf(curCostCents + addCostCents));
+            context.getProperties().setProperty(Constants.TRANS_CONTEXT_SCAN_BYTES_KEY, String.valueOf(newScanBytes));
             builder.setErrorCode(ErrorCode.SUCCESS);
         }
         else

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/PixelsPlanner.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/PixelsPlanner.java
@@ -157,6 +157,11 @@ public class PixelsPlanner
         return scanSize;
     }
 
+    public static String getIntermediateFolderForTrans(long transId)
+    {
+        return IntermediateFolder + transId + "/";
+    }
+
     private AggregationOperator getAggregationOperator(AggregatedTable aggregatedTable)
             throws IOException, MetadataException
     {
@@ -177,7 +182,7 @@ public class PixelsPlanner
         partialAggregationInfo.setPartition(numPartitions > 1);
         partialAggregationInfo.setNumPartition(numPartitions);
 
-        final String intermediateBase = IntermediateFolder + transId + "/" +
+        final String intermediateBase = getIntermediateFolderForTrans(transId) +
                 aggregatedTable.getSchemaName() + "/" + aggregatedTable.getTableName() + "/";
 
         ImmutableList.Builder<String> aggrInputFilesBuilder = ImmutableList.builder();
@@ -378,7 +383,7 @@ public class PixelsPlanner
                         BroadcastTableInfo rightTableInfo = getBroadcastTableInfo(
                                 rightTable, ImmutableList.of(rightInputSplit), join.getRightKeyColumnIds());
 
-                        String path = IntermediateFolder + transId + "/" + joinedTable.getSchemaName() + "/" +
+                        String path = getIntermediateFolderForTrans(transId) + joinedTable.getSchemaName() + "/" +
                                 joinedTable.getTableName() + "/";
                         MultiOutputInfo output = new MultiOutputInfo(path, IntermediateStorageInfo, true, outputs);
 
@@ -703,7 +708,7 @@ public class PixelsPlanner
                         BroadcastTableInfo rightTableInfo = getBroadcastTableInfo(
                                 rightTable, inputsBuilder.build(), join.getRightKeyColumnIds());
 
-                        String path = IntermediateFolder + transId + "/" + joinedTable.getSchemaName() + "/" +
+                        String path = getIntermediateFolderForTrans(transId) + joinedTable.getSchemaName() + "/" +
                                 joinedTable.getTableName() + "/";
                         MultiOutputInfo output = new MultiOutputInfo(path, IntermediateStorageInfo, true, outputs);
 
@@ -818,7 +823,7 @@ public class PixelsPlanner
                     BroadcastTableInfo rightTableInfo = getBroadcastTableInfo(
                             rightTable, inputsBuilder.build(), join.getRightKeyColumnIds());
 
-                    String path = IntermediateFolder + transId + "/" + joinedTable.getSchemaName() + "/" +
+                    String path = getIntermediateFolderForTrans(transId) + joinedTable.getSchemaName() + "/" +
                             joinedTable.getTableName() + "/";
                     MultiOutputInfo output = new MultiOutputInfo(path, IntermediateStorageInfo, true, outputs);
 
@@ -866,7 +871,7 @@ public class PixelsPlanner
                     BroadcastTableInfo leftTableInfo = getBroadcastTableInfo(
                             leftTable, inputsBuilder.build(), join.getLeftKeyColumnIds());
 
-                    String path = IntermediateFolder + transId + "/" + joinedTable.getSchemaName() + "/" +
+                    String path = getIntermediateFolderForTrans(transId) + joinedTable.getSchemaName() + "/" +
                             joinedTable.getTableName() + "/";
                     MultiOutputInfo output = new MultiOutputInfo(path, IntermediateStorageInfo, true, outputs);
 
@@ -911,7 +916,7 @@ public class PixelsPlanner
 
                 List<PartitionInput> rightPartitionInputs = getPartitionInputs(
                         rightTable, rightInputSplits, rightKeyColumnIds, rightPartitionProjection, numPartition,
-                        IntermediateFolder + transId + "/" + joinedTable.getSchemaName() + "/" +
+                        getIntermediateFolderForTrans(transId) + joinedTable.getSchemaName() + "/" +
                                 joinedTable.getTableName() + "/" + rightTable.getTableName() + "/");
 
                 PartitionedTableInfo rightTableInfo = getPartitionedTableInfo(
@@ -946,7 +951,7 @@ public class PixelsPlanner
                 boolean[] leftPartitionProjection = getPartitionProjection(leftTable, join.getLeftProjection());
                 List<PartitionInput> leftPartitionInputs = getPartitionInputs(
                         leftTable, leftInputSplits, leftKeyColumnIds, leftPartitionProjection, numPartition,
-                        IntermediateFolder + transId + "/" + joinedTable.getSchemaName() + "/" +
+                        getIntermediateFolderForTrans(transId) + joinedTable.getSchemaName() + "/" +
                                 joinedTable.getTableName() + "/" + leftTable.getTableName() + "/");
                 PartitionedTableInfo leftTableInfo = getPartitionedTableInfo(
                         leftTable, leftKeyColumnIds, leftPartitionInputs, leftPartitionProjection);
@@ -954,7 +959,7 @@ public class PixelsPlanner
                 boolean[] rightPartitionProjection = getPartitionProjection(rightTable, join.getRightProjection());
                 List<PartitionInput> rightPartitionInputs = getPartitionInputs(
                         rightTable, rightInputSplits, rightKeyColumnIds, rightPartitionProjection, numPartition,
-                        IntermediateFolder + transId + "/" + joinedTable.getSchemaName() + "/" +
+                        getIntermediateFolderForTrans(transId) + joinedTable.getSchemaName() + "/" +
                                 joinedTable.getTableName() + "/" + rightTable.getTableName() + "/");
                 PartitionedTableInfo rightTableInfo = getPartitionedTableInfo(
                         rightTable, rightKeyColumnIds, rightPartitionInputs, rightPartitionProjection);
@@ -1314,7 +1319,7 @@ public class PixelsPlanner
                 outputFileNames.add(i + "/join_left");
             }
 
-            String path = IntermediateFolder + transId + "/" + joinedTable.getSchemaName() + "/" +
+            String path = getIntermediateFolderForTrans(transId) + joinedTable.getSchemaName() + "/" +
                     joinedTable.getTableName() + "/";
             MultiOutputInfo output = new MultiOutputInfo(path, IntermediateStorageInfo, true, outputFileNames.build());
 

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/StarlingPlanner.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/StarlingPlanner.java
@@ -154,6 +154,11 @@ public class StarlingPlanner
         return scanSize;
     }
 
+    public static String getIntermediateFolderForTrans(long transId)
+    {
+        return IntermediateFolder + transId + "/";
+    }
+
     private StarlingAggregationOperator getAggregationOperator(AggregatedTable aggregatedTable)
             throws IOException, MetadataException
     {
@@ -176,7 +181,7 @@ public class StarlingPlanner
 
         PartitionInfo partitionInfo = new PartitionInfo(aggregation.getGroupKeyColumnIds(), 16);
 
-        final String intermediateBase = IntermediateFolder + transId + "/" +
+        final String intermediateBase = getIntermediateFolderForTrans(transId) +
                 aggregatedTable.getSchemaName() + "/" + aggregatedTable.getTableName() + "/";
 
         ImmutableList.Builder<String> AggrInputFilesBuilder = ImmutableList.builder();
@@ -346,7 +351,7 @@ public class StarlingPlanner
                 BroadcastTableInfo rightTableInfo = getBroadcastTableInfo(
                         rightTable, ImmutableList.of(rightInputSplit), join.getRightKeyColumnIds());
 
-                String path = IntermediateFolder + transId + "/" + joinedTable.getSchemaName() + "/" +
+                String path = getIntermediateFolderForTrans(transId) + joinedTable.getSchemaName() + "/" +
                         joinedTable.getTableName() + "/";
                 MultiOutputInfo output = new MultiOutputInfo(path, IntermediateStorageInfo, true, outputs);
 
@@ -558,7 +563,7 @@ public class StarlingPlanner
                     BroadcastTableInfo rightTableInfo = getBroadcastTableInfo(
                             rightTable, inputsBuilder.build(), join.getRightKeyColumnIds());
 
-                    String path = IntermediateFolder + transId + "/" + joinedTable.getSchemaName() + "/" +
+                    String path = getIntermediateFolderForTrans(transId) + joinedTable.getSchemaName() + "/" +
                             joinedTable.getTableName() + "/";
                     MultiOutputInfo output = new MultiOutputInfo(path, IntermediateStorageInfo, true, outputs);
 
@@ -606,7 +611,7 @@ public class StarlingPlanner
                     BroadcastTableInfo leftTableInfo = getBroadcastTableInfo(
                             leftTable, inputsBuilder.build(), join.getLeftKeyColumnIds());
 
-                    String path = IntermediateFolder + transId + "/" + joinedTable.getSchemaName() + "/" +
+                    String path = getIntermediateFolderForTrans(transId) + joinedTable.getSchemaName() + "/" +
                             joinedTable.getTableName() + "/";
                     MultiOutputInfo output = new MultiOutputInfo(path, IntermediateStorageInfo, true, outputs);
 
@@ -648,7 +653,7 @@ public class StarlingPlanner
 
                 List<PartitionInput> rightPartitionInputs = getPartitionInputs(
                         rightTable, rightInputSplits, rightKeyColumnIds, rightPartitionProjection, numPartition,
-                        IntermediateFolder + transId + "/" + joinedTable.getSchemaName() + "/" +
+                        getIntermediateFolderForTrans(transId) + joinedTable.getSchemaName() + "/" +
                                 joinedTable.getTableName() + "/" + rightTable.getTableName() + "/");
 
                 PartitionedTableInfo rightTableInfo = getPartitionedTableInfo(
@@ -677,7 +682,7 @@ public class StarlingPlanner
                 boolean[] leftPartitionProjection = getPartitionProjection(leftTable, join.getLeftProjection());
                 List<PartitionInput> leftPartitionInputs = getPartitionInputs(
                         leftTable, leftInputSplits, leftKeyColumnIds, leftPartitionProjection, numPartition,
-                        IntermediateFolder + transId + "/" + joinedTable.getSchemaName() + "/" +
+                        getIntermediateFolderForTrans(transId) + joinedTable.getSchemaName() + "/" +
                                 joinedTable.getTableName() + "/" + leftTable.getTableName() + "/");
                 PartitionedTableInfo leftTableInfo = getPartitionedTableInfo(
                         leftTable, leftKeyColumnIds, leftPartitionInputs, leftPartitionProjection);
@@ -685,7 +690,7 @@ public class StarlingPlanner
                 boolean[] rightPartitionProjection = getPartitionProjection(rightTable, join.getRightProjection());
                 List<PartitionInput> rightPartitionInputs = getPartitionInputs(
                         rightTable, rightInputSplits, rightKeyColumnIds, rightPartitionProjection, numPartition,
-                        IntermediateFolder + transId + "/" + joinedTable.getSchemaName() + "/" +
+                        getIntermediateFolderForTrans(transId) + joinedTable.getSchemaName() + "/" +
                                 joinedTable.getTableName() + "/" + rightTable.getTableName() + "/");
                 PartitionedTableInfo rightTableInfo = getPartitionedTableInfo(
                         rightTable, rightKeyColumnIds, rightPartitionInputs, rightPartitionProjection);
@@ -1059,7 +1064,7 @@ public class StarlingPlanner
                 outputFileNames.add(i + "/join_left");
             }
 
-            String path = IntermediateFolder + transId + "/" + joinedTable.getSchemaName() + "/" +
+            String path = getIntermediateFolderForTrans(transId) + joinedTable.getSchemaName() + "/" +
                     joinedTable.getTableName() + "/";
             MultiOutputInfo output = new MultiOutputInfo(path, IntermediateStorageInfo, true, outputFileNames.build());
 

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/AggregationBatchOperator.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/AggregationBatchOperator.java
@@ -20,6 +20,7 @@
 package io.pixelsdb.pixels.planner.plan.physical;
 
 import io.pixelsdb.pixels.common.turbo.InvokerFactory;
+import io.pixelsdb.pixels.common.turbo.Output;
 import io.pixelsdb.pixels.common.turbo.WorkerType;
 import io.pixelsdb.pixels.planner.plan.physical.input.AggregationInput;
 import io.pixelsdb.pixels.planner.plan.physical.input.ScanInput;
@@ -43,7 +44,7 @@ public class AggregationBatchOperator extends AggregationOperator
     }
 
     @Override
-    public CompletableFuture<CompletableFuture<?>[]> execute()
+    public CompletableFuture<CompletableFuture<? extends Output>[]> execute()
     {
         return executePrev().handle((result, exception) ->
         {
@@ -79,7 +80,7 @@ public class AggregationBatchOperator extends AggregationOperator
         {
             try
             {
-                CompletableFuture<CompletableFuture<?>[]> childFuture = null;
+                CompletableFuture<CompletableFuture<? extends Output>[]> childFuture = null;
                 if (this.child != null)
                 {
                     checkArgument(this.scanInputs.isEmpty(), "scanInputs is not empty");

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/AggregationOperator.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/AggregationOperator.java
@@ -62,11 +62,11 @@ public abstract class AggregationOperator extends Operator
     /**
      * The outputs of the scan workers.
      */
-    protected CompletableFuture<?>[] scanOutputs = null;
+    protected CompletableFuture<? extends Output>[] scanOutputs = null;
     /**
      * The outputs of the final aggregation workers.
      */
-    protected CompletableFuture<?>[] finalAggrOutputs = null;
+    protected CompletableFuture<? extends Output>[] finalAggrOutputs = null;
 
     public AggregationOperator(String name, List<AggregationInput> finalAggrInputs, List<ScanInput> scanInputs)
     {
@@ -163,7 +163,7 @@ public abstract class AggregationOperator extends Operator
             Output[] outputs = new Output[this.scanOutputs.length];
             for (int i = 0; i < this.scanOutputs.length; ++i)
             {
-                outputs[i] = (Output) this.scanOutputs[i].get();
+                outputs[i] = this.scanOutputs[i].get();
             }
             outputCollection.setScanOutputs(outputs);
         }
@@ -172,7 +172,7 @@ public abstract class AggregationOperator extends Operator
             Output[] outputs = new Output[this.finalAggrOutputs.length];
             for (int i = 0; i < this.finalAggrOutputs.length; ++i)
             {
-                outputs[i] = (Output) this.finalAggrOutputs[i].get();
+                outputs[i] = this.finalAggrOutputs[i].get();
             }
             outputCollection.setFinalAggrOutputs(outputs);
         }

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/AggregationStreamOperator.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/AggregationStreamOperator.java
@@ -19,6 +19,7 @@
  */
 package io.pixelsdb.pixels.planner.plan.physical;
 
+import io.pixelsdb.pixels.common.turbo.Output;
 import io.pixelsdb.pixels.planner.plan.physical.input.AggregationInput;
 import io.pixelsdb.pixels.planner.plan.physical.input.ScanInput;
 
@@ -37,7 +38,7 @@ public class AggregationStreamOperator extends AggregationOperator
     }
 
     @Override
-    public CompletableFuture<CompletableFuture<?>[]> execute()
+    public CompletableFuture<CompletableFuture<? extends Output>[]> execute()
     {
         // TODO: implement
         return null;

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/OperatorExecutor.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/OperatorExecutor.java
@@ -19,6 +19,8 @@
  */
 package io.pixelsdb.pixels.planner.plan.physical;
 
+import io.pixelsdb.pixels.common.turbo.Output;
+
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -41,7 +43,7 @@ public interface OperatorExecutor
      * @return the completable future that completes when this operator is complete, and
      * provides the computable futures of the outputs of this operator
      */
-    CompletableFuture<CompletableFuture<?>[]> execute();
+    CompletableFuture<CompletableFuture<? extends Output>[]> execute();
 
     /**
      * Execute the previous stages (if any) before the last stage, recursively.
@@ -78,12 +80,12 @@ public interface OperatorExecutor
         long getLayerOutputCostMs();
     }
 
-    static void waitForCompletion(CompletableFuture<?>[] stageOutputs) throws InterruptedException
+    static void waitForCompletion(CompletableFuture<? extends Output>[] stageOutputs) throws InterruptedException
     {
         waitForCompletion(stageOutputs, StageCompletionRatio);
     }
 
-    static void waitForCompletion(CompletableFuture<?>[] stageOutputs, double completionRatio)
+    static void waitForCompletion(CompletableFuture<? extends Output>[] stageOutputs, double completionRatio)
             throws InterruptedException
     {
         requireNonNull(stageOutputs, "stageOutputs is null");
@@ -96,7 +98,7 @@ public interface OperatorExecutor
         while (true)
         {
             double completed = 0;
-            for (CompletableFuture<?> childOutput : stageOutputs)
+            for (CompletableFuture<? extends Output> childOutput : stageOutputs)
             {
                 if (childOutput.isDone())
                 {

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/PartitionedJoinBatchOperator.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/PartitionedJoinBatchOperator.java
@@ -76,7 +76,7 @@ public class PartitionedJoinBatchOperator extends PartitionedJoinOperator
                 else if (joinAlgo == JoinAlgorithm.PARTITIONED_CHAIN)
                 {
                     joinOutputs[i] = InvokerFactory.Instance()
-                            .getInvoker(WorkerType.PARTITIONED_JOIN).invoke(joinInput);
+                            .getInvoker(WorkerType.PARTITIONED_CHAIN_JOIN).invoke(joinInput);
                 }
                 else
                 {

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/PartitionedJoinBatchOperator.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/PartitionedJoinBatchOperator.java
@@ -20,6 +20,7 @@
 package io.pixelsdb.pixels.planner.plan.physical;
 
 import io.pixelsdb.pixels.common.turbo.InvokerFactory;
+import io.pixelsdb.pixels.common.turbo.Output;
 import io.pixelsdb.pixels.common.turbo.WorkerType;
 import io.pixelsdb.pixels.executor.join.JoinAlgorithm;
 import io.pixelsdb.pixels.planner.plan.physical.input.JoinInput;
@@ -55,7 +56,7 @@ public class PartitionedJoinBatchOperator extends PartitionedJoinOperator
      * @return the completable future of the completable futures of the join outputs.
      */
     @Override
-    public CompletableFuture<CompletableFuture<?>[]> execute()
+    public CompletableFuture<CompletableFuture<? extends Output>[]> execute()
     {
         return executePrev().handle((result, exception) ->
         {
@@ -96,8 +97,8 @@ public class PartitionedJoinBatchOperator extends PartitionedJoinOperator
         {
             try
             {
-                CompletableFuture<CompletableFuture<?>[]> smallChildFuture = null;
-                CompletableFuture<CompletableFuture<?>[]> largeChildFuture = null;
+                CompletableFuture<CompletableFuture<? extends Output>[]> smallChildFuture = null;
+                CompletableFuture<CompletableFuture<? extends Output>[]> largeChildFuture = null;
                 if (smallChild != null && largeChild != null)
                 {
                     // both children exist, we should execute both children and wait for the small child.

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/PartitionedJoinOperator.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/PartitionedJoinOperator.java
@@ -48,8 +48,8 @@ public abstract class PartitionedJoinOperator extends SingleStageJoinOperator
 {
     protected final List<PartitionInput> smallPartitionInputs;
     protected final List<PartitionInput> largePartitionInputs;
-    protected CompletableFuture<?>[] smallPartitionOutputs = null;
-    protected CompletableFuture<?>[] largePartitionOutputs = null;
+    protected CompletableFuture<? extends Output>[] smallPartitionOutputs = null;
+    protected CompletableFuture<? extends Output>[] largePartitionOutputs = null;
 
     public PartitionedJoinOperator(String name, List<PartitionInput> smallPartitionInputs,
                                    List<PartitionInput> largePartitionInputs,
@@ -221,7 +221,7 @@ public abstract class PartitionedJoinOperator extends SingleStageJoinOperator
             Output[] outputs = new Output[joinOutputs.length];
             for (int i = 0; i < joinOutputs.length; ++i)
             {
-                outputs[i] = (Output) joinOutputs[i].get();
+                outputs[i] = joinOutputs[i].get();
             }
             outputCollection.setJoinOutputs(outputs);
         }
@@ -230,7 +230,7 @@ public abstract class PartitionedJoinOperator extends SingleStageJoinOperator
             Output[] outputs = new Output[smallPartitionOutputs.length];
             for (int i = 0; i < smallPartitionOutputs.length; ++i)
             {
-                outputs[i] = (Output) smallPartitionOutputs[i].get();
+                outputs[i] = smallPartitionOutputs[i].get();
             }
             outputCollection.setSmallPartitionOutputs(outputs);
         }
@@ -239,7 +239,7 @@ public abstract class PartitionedJoinOperator extends SingleStageJoinOperator
             Output[] outputs = new Output[largePartitionOutputs.length];
             for (int i = 0; i < largePartitionOutputs.length; ++i)
             {
-                outputs[i] = (Output) largePartitionOutputs[i].get();
+                outputs[i] = largePartitionOutputs[i].get();
             }
             outputCollection.setLargePartitionOutputs(outputs);
         }

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/PartitionedJoinStreamOperator.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/PartitionedJoinStreamOperator.java
@@ -19,6 +19,7 @@
  */
 package io.pixelsdb.pixels.planner.plan.physical;
 
+import io.pixelsdb.pixels.common.turbo.Output;
 import io.pixelsdb.pixels.executor.join.JoinAlgorithm;
 import io.pixelsdb.pixels.planner.plan.physical.input.JoinInput;
 import io.pixelsdb.pixels.planner.plan.physical.input.PartitionInput;
@@ -40,7 +41,7 @@ public class PartitionedJoinStreamOperator extends PartitionedJoinOperator
     }
 
     @Override
-    public CompletableFuture<CompletableFuture<?>[]> execute()
+    public CompletableFuture<CompletableFuture<? extends Output>[]> execute()
     {
         // TODO: implement
         return null;

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/SingleStageJoinBatchOperator.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/SingleStageJoinBatchOperator.java
@@ -20,6 +20,7 @@
 package io.pixelsdb.pixels.planner.plan.physical;
 
 import io.pixelsdb.pixels.common.turbo.InvokerFactory;
+import io.pixelsdb.pixels.common.turbo.Output;
 import io.pixelsdb.pixels.common.turbo.WorkerType;
 import io.pixelsdb.pixels.executor.join.JoinAlgorithm;
 import io.pixelsdb.pixels.planner.plan.physical.input.JoinInput;
@@ -56,7 +57,7 @@ public class SingleStageJoinBatchOperator extends SingleStageJoinOperator
      * @return the completable future of the completable futures of the join outputs.
      */
     @Override
-    public CompletableFuture<CompletableFuture<?>[]> execute()
+    public CompletableFuture<CompletableFuture<? extends Output>[]> execute()
     {
         return executePrev().handle((result, exception) ->
         {
@@ -97,24 +98,24 @@ public class SingleStageJoinBatchOperator extends SingleStageJoinOperator
         {
             try
             {
-                CompletableFuture<CompletableFuture<?>[]> smallChildFuture = null;
+                CompletableFuture<CompletableFuture<? extends Output>[]> smallChildFuture = null;
                 if (smallChild != null)
                 {
                     smallChildFuture = smallChild.execute();
                 }
-                CompletableFuture<CompletableFuture<?>[]> largeChildFuture = null;
+                CompletableFuture<CompletableFuture<? extends Output>[]> largeChildFuture = null;
                 if (largeChild != null)
                 {
                     largeChildFuture = largeChild.execute();
                 }
                 if (smallChildFuture != null)
                 {
-                    CompletableFuture<?>[] smallChildOutputs = smallChildFuture.join();
+                    CompletableFuture<? extends Output>[] smallChildOutputs = smallChildFuture.join();
                     waitForCompletion(smallChildOutputs);
                 }
                 if (largeChildFuture != null)
                 {
-                    CompletableFuture<?>[] largeChildOutputs = largeChildFuture.join();
+                    CompletableFuture<? extends Output>[] largeChildOutputs = largeChildFuture.join();
                     waitForCompletion(largeChildOutputs, LargeSideCompletionRatio);
                 }
                 prevStagesFuture.complete(null);

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/SingleStageJoinOperator.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/SingleStageJoinOperator.java
@@ -43,7 +43,7 @@ public abstract class SingleStageJoinOperator extends JoinOperator
     protected final JoinAlgorithm joinAlgo;
     protected JoinOperator smallChild = null;
     protected JoinOperator largeChild = null;
-    protected CompletableFuture<?>[] joinOutputs = null;
+    protected CompletableFuture<? extends Output>[] joinOutputs = null;
 
     public SingleStageJoinOperator(String name, boolean complete, JoinInput joinInput, JoinAlgorithm joinAlgo)
     {
@@ -136,7 +136,7 @@ public abstract class SingleStageJoinOperator extends JoinOperator
             Output[] outputs = new Output[joinOutputs.length];
             for (int i = 0; i < joinOutputs.length; ++i)
             {
-                outputs[i] = (Output) joinOutputs[i].get();
+                outputs[i] = joinOutputs[i].get();
             }
             outputCollection.setJoinOutputs(outputs);
         }

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/SingleStageJoinStreamOperator.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/SingleStageJoinStreamOperator.java
@@ -19,6 +19,7 @@
  */
 package io.pixelsdb.pixels.planner.plan.physical;
 
+import io.pixelsdb.pixels.common.turbo.Output;
 import io.pixelsdb.pixels.executor.join.JoinAlgorithm;
 import io.pixelsdb.pixels.planner.plan.physical.input.JoinInput;
 
@@ -44,7 +45,7 @@ public class SingleStageJoinStreamOperator extends SingleStageJoinOperator
     }
 
     @Override
-    public CompletableFuture<CompletableFuture<?>[]> execute()
+    public CompletableFuture<CompletableFuture<? extends Output>[]> execute()
     {
         // TODO: implement
         return null;

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/StarlingAggregationOperator.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/StarlingAggregationOperator.java
@@ -66,11 +66,11 @@ public class StarlingAggregationOperator extends Operator
     /**
      * The outputs of the partition workers.
      */
-    private CompletableFuture<?>[] partitionOutputs = null;
+    private CompletableFuture<? extends Output>[] partitionOutputs = null;
     /**
      * The outputs of the final aggregation workers.
      */
-    private CompletableFuture<?>[] finalAggrOutputs = null;
+    private CompletableFuture<? extends Output>[] finalAggrOutputs = null;
 
     public StarlingAggregationOperator(String name, List<AggregationInput> finalAggrInputs,
                                        List<PartitionInput> partitionInputs)
@@ -124,7 +124,7 @@ public class StarlingAggregationOperator extends Operator
     }
 
     @Override
-    public CompletableFuture<CompletableFuture<?>[]> execute()
+    public CompletableFuture<CompletableFuture<? extends Output>[]> execute()
     {
         return executePrev().handle((result, exception) ->
         {
@@ -160,7 +160,7 @@ public class StarlingAggregationOperator extends Operator
         {
             try
             {
-                CompletableFuture<CompletableFuture<?>[]> childFuture = null;
+                CompletableFuture<CompletableFuture<? extends Output>[]> childFuture = null;
                 if (this.child != null)
                 {
                     checkArgument(this.partitionInputs.isEmpty(), "partitionInputs is not empty");
@@ -208,7 +208,7 @@ public class StarlingAggregationOperator extends Operator
             Output[] outputs = new Output[this.partitionOutputs.length];
             for (int i = 0; i < this.partitionOutputs.length; ++i)
             {
-                outputs[i] = (Output) this.partitionOutputs[i].get();
+                outputs[i] = this.partitionOutputs[i].get();
             }
             outputCollection.setPartitionOutputs(outputs);
         }
@@ -217,7 +217,7 @@ public class StarlingAggregationOperator extends Operator
             Output[] outputs = new Output[this.finalAggrOutputs.length];
             for (int i = 0; i < this.finalAggrOutputs.length; ++i)
             {
-                outputs[i] = (Output) this.finalAggrOutputs[i].get();
+                outputs[i] = this.finalAggrOutputs[i].get();
             }
             outputCollection.setFinalAggrOutputs(outputs);
         }

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/domain/MultiOutputInfo.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/domain/MultiOutputInfo.java
@@ -52,6 +52,7 @@ public class MultiOutputInfo extends OutputInfo
 
     /**
      * Set the folder that the output files are written into.
+     * @param path the path of the folder
      */
     public void setPath(String path)
     {

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/domain/MultiOutputInfo.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/domain/MultiOutputInfo.java
@@ -19,7 +19,11 @@
  */
 package io.pixelsdb.pixels.planner.plan.physical.domain;
 
+import com.google.common.collect.ImmutableList;
+
 import java.util.List;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * @author hank
@@ -67,5 +71,27 @@ public class MultiOutputInfo extends OutputInfo
     public void setFileNames(List<String> fileNames)
     {
         this.fileNames = fileNames;
+    }
+
+    /**
+     * Generate the absolute paths of the output files.
+     * @param outputInfo the multi-output info
+     * @return the absolute output file paths
+     */
+    public static List<String> generateOutputPaths(MultiOutputInfo outputInfo)
+    {
+        requireNonNull(outputInfo, "outputInfo is null");
+        ImmutableList.Builder<String> builder =
+                ImmutableList.builderWithExpectedSize(outputInfo.fileNames.size());
+        String folder = outputInfo.getPath();
+        if (!folder.endsWith("/"))
+        {
+            folder += "/";
+        }
+        for (String filePath : outputInfo.fileNames)
+        {
+            builder.add(folder + filePath);
+        }
+        return builder.build();
     }
 }

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/domain/OutputInfo.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/domain/OutputInfo.java
@@ -50,11 +50,19 @@ public class OutputInfo
         this.encoding = encoding;
     }
 
+    /**
+     * Get the path of the output file.
+     * @return the path
+     */
     public String getPath()
     {
         return path;
     }
 
+    /**
+     * Set the path of the output file.
+     * @param the path
+     */
     public void setPath(String path)
     {
         this.path = path;

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/input/ScanInput.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/input/ScanInput.java
@@ -19,10 +19,13 @@
  */
 package io.pixelsdb.pixels.planner.plan.physical.input;
 
+import com.google.common.collect.ImmutableList;
 import io.pixelsdb.pixels.common.turbo.Input;
 import io.pixelsdb.pixels.planner.plan.physical.domain.OutputInfo;
 import io.pixelsdb.pixels.planner.plan.physical.domain.PartialAggregationInfo;
 import io.pixelsdb.pixels.planner.plan.physical.domain.ScanTableInfo;
+
+import java.util.List;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
@@ -141,10 +144,26 @@ public class ScanInput extends Input
         return outputPaths;
     }
 
-    public static String[] generateOutputPaths(ScanInput scanInput)
+    /**
+     * Generate the absolute paths of the output files for a scan input.
+     * @param scanInput the scan input
+     * @return the absolute output file paths
+     */
+    public static List<String> generateOutputPaths(ScanInput scanInput)
     {
         requireNonNull(scanInput, "scanInput is null");
-        return generateOutputPaths(scanInput.getOutput().getPath(),
-                scanInput.getTableInfo().getInputSplits().size());
+        String folder = requireNonNull(scanInput.getOutput().getPath(), "output folder is null");
+        int numSplits = scanInput.getTableInfo().getInputSplits().size();
+        checkArgument(numSplits > 0, "input splits is empty");
+        ImmutableList.Builder<String> builder = ImmutableList.builderWithExpectedSize(numSplits);
+        if (!folder.endsWith("/"))
+        {
+            folder += "/";
+        }
+        for (int i = 0; i < numSplits; ++i)
+        {
+            builder.add(folder + "scan_" + i++);
+        }
+        return builder.build();
     }
 }

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/input/ScanInput.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/input/ScanInput.java
@@ -24,6 +24,9 @@ import io.pixelsdb.pixels.planner.plan.physical.domain.OutputInfo;
 import io.pixelsdb.pixels.planner.plan.physical.domain.PartialAggregationInfo;
 import io.pixelsdb.pixels.planner.plan.physical.domain.ScanTableInfo;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
 /**
  * The input format for table scan.
  * @author hank
@@ -120,5 +123,28 @@ public class ScanInput extends Input
     public void setOutput(OutputInfo output)
     {
         this.output = output;
+    }
+
+    public static String[] generateOutputPaths(String outputFolder, int numSplits)
+    {
+        requireNonNull(outputFolder, "outputFolder is null");
+        checkArgument(numSplits > 0, "numSplits is non-positive");
+        if (!outputFolder.endsWith("/"))
+        {
+            outputFolder += "/";
+        }
+        String[] outputPaths = new String[numSplits];
+        for (int i = 0; i < numSplits; ++i)
+        {
+            outputPaths[i] = outputFolder + "scan_" + i++;
+        }
+        return outputPaths;
+    }
+
+    public static String[] generateOutputPaths(ScanInput scanInput)
+    {
+        requireNonNull(scanInput, "scanInput is null");
+        return generateOutputPaths(scanInput.getOutput().getPath(),
+                scanInput.getTableInfo().getInputSplits().size());
     }
 }

--- a/pixels-turbo/pixels-worker-common/src/main/java/io/pixelsdb/pixels/worker/common/BaseScanWorker.java
+++ b/pixels-turbo/pixels-worker-common/src/main/java/io/pixelsdb/pixels/worker/common/BaseScanWorker.java
@@ -134,6 +134,7 @@ public class BaseScanWorker extends Worker<ScanInput, ScanOutput>
 
             int outputId = 0;
             logger.info("start scan and aggregate");
+            String[] outputPaths = ScanInput.generateOutputPaths(outputFolder, inputSplits.size());
             for (InputSplit inputSplit : inputSplits)
             {
                 List<InputInfo> scanInputs = inputSplit.getInputInfos();
@@ -142,7 +143,7 @@ public class BaseScanWorker extends Worker<ScanInput, ScanOutput>
                  * For table scan without partial aggregation, the path in output info is a folder.
                  * Each scan input split generates an output file in this folder.
                  */
-                String outputPath = outputFolder + "scan_" + outputId++;
+                String outputPath = outputPaths[outputId++];
 
                 threadPool.execute(() -> {
                     try

--- a/proto/transaction.proto
+++ b/proto/transaction.proto
@@ -35,6 +35,7 @@ service TransService {
     rpc RollbackTrans (RollbackTransRequest) returns (RollbackTransResponse);
     rpc GetTransContext (GetTransContextRequest) returns (GetTransContextResponse);
     rpc SetTransProperty (SetTransPropertyRequest) returns (SetTransPropertyResponse);
+    rpc UpdateQueryCosts (UpdateQueryCostsRequest) returns (UpdateQueryCostsResponse);
     rpc GetTransConcurrency (GetTransConcurrencyRequest) returns (GetTransConcurrencyResponse);
     rpc BindExternalTraceId (BindExternalTraceIdRequest) returns (BindExternalTraceIdResponse);
 }
@@ -109,6 +110,21 @@ message SetTransPropertyRequest {
 message SetTransPropertyResponse {
     int32 errorCode = 1;
     optional string prevValue = 2;
+}
+
+message UpdateQueryCostsRequest {
+    oneof lookupKey {
+        string externalTraceId = 1;
+        uint64 transId = 2;
+    }
+    // the new scan bytes to set
+    double newScanBytes = 3;
+    // the additional cost in cents to add
+    double addCostCents = 4;
+}
+
+message UpdateQueryCostsResponse {
+    int32 errorCode = 1;
 }
 
 message GetTransConcurrencyRequest {


### PR DESCRIPTION
1. Revise the operators in pixels-planer to support getting output from the return value of the execute() method.
2. Add methods for the VM workers to check the status of the root operator executed in CF workers.
3. Add methods for the VM cluster to clean the states and intermediate results.
4. Fix a bug in PartitionedJoinOperator.execute().
5. Add protocol for the VM cluster to report scan bytes and cost cents more efficiently.