### PR TITLE
[Issue #643] add scan operator and fix scan input and aggregation operators

### DIFF
--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/turbo/Output.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/turbo/Output.java
@@ -19,6 +19,8 @@
  */
 package io.pixelsdb.pixels.common.turbo;
 
+import java.util.ArrayList;
+
 /**
  * The base class for the output of a cloud function.
  * @author hank
@@ -39,6 +41,10 @@ public abstract class Output
     private int numWriteRequests;
     private long totalReadBytes;
     private long totalWriteBytes;
+    /**
+     * The path of the result files. No need to contain endpoint information.
+     */
+    private ArrayList<String> outputs = new ArrayList<>();
 
     public String getRequestId()
     {
@@ -178,12 +184,28 @@ public abstract class Output
         this.totalWriteBytes = totalWriteBytes;
     }
 
+    public ArrayList<String> getOutputs()
+    {
+        return outputs;
+    }
+
+    public void setOutputs(ArrayList<String> outputs)
+    {
+        this.outputs = outputs;
+    }
+
+    public synchronized void addOutput(String output)
+    {
+        this.outputs.add(output);
+    }
+
     public SimpleOutput toSimpleOutput()
     {
         SimpleOutput simpleOutput = new SimpleOutput();
         simpleOutput.setRequestId(this.requestId);
         simpleOutput.setSuccessful(this.successful);
-        simpleOutput.setErrorMessage(this.errorMessage);
+        simpleOutput.setErrorMessage(this.errorMessage != null ? this.errorMessage : "");
+        simpleOutput.setNumOutputs(this.outputs != null ? this.outputs.size() : 0);
         return simpleOutput;
     }
 }

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/turbo/SimpleOutput.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/turbo/SimpleOutput.java
@@ -28,6 +28,7 @@ public class SimpleOutput
     private String requestId;
     private boolean successful;
     private String errorMessage;
+    private int numOutputs;
 
     public String getRequestId()
     {
@@ -57,5 +58,15 @@ public class SimpleOutput
     public void setErrorMessage(String errorMessage)
     {
         this.errorMessage = errorMessage;
+    }
+
+    public int getNumOutputs()
+    {
+        return numOutputs;
+    }
+
+    public void setNumOutputs(int numOutputs)
+    {
+        this.numOutputs = numOutputs;
     }
 }

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/PixelsPlanner.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/PixelsPlanner.java
@@ -196,7 +196,7 @@ public class PixelsPlanner
             tableInfo.setStorageInfo(InputStorageInfo);
             scanInput.setTableInfo(tableInfo);
             scanInput.setScanProjection(scanProjection);
-            scanInput.setPartialAggregationPresent(true);
+            scanInput.setPartialAggregationPresent(false);
             scanInput.setPartialAggregationInfo(null);
             String folderName = intermediateBase + (outputId++) + "/";
             scanInput.setOutput(new OutputInfo(folderName, IntermediateStorageInfo, true));

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/PixelsPlanner.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/PixelsPlanner.java
@@ -137,7 +137,11 @@ public class PixelsPlanner
 
     public Operator getRootOperator() throws IOException, MetadataException
     {
-        if (this.rootTable.getTableType() == Table.TableType.JOINED)
+        if (this.rootTable.getTableType() == Table.TableType.BASE)
+        {
+            return this.getScanOperator((BaseTable) this.rootTable);
+        }
+        else if (this.rootTable.getTableType() == Table.TableType.JOINED)
         {
             return this.getJoinOperator((JoinedTable) this.rootTable, Optional.empty());
         }
@@ -160,6 +164,47 @@ public class PixelsPlanner
     public static String getIntermediateFolderForTrans(long transId)
     {
         return IntermediateFolder + transId + "/";
+    }
+
+    private ScanOperator getScanOperator(BaseTable scanTable) throws IOException, MetadataException
+    {
+        final String intermediateBase = getIntermediateFolderForTrans(transId) +
+                scanTable.getSchemaName() + "/" + scanTable.getTableName() + "/";
+        ImmutableList.Builder<ScanInput> scanInputsBuilder = ImmutableList.builder();
+        List<InputSplit> inputSplits = this.getInputSplits(scanTable);
+        int outputId = 0;
+        boolean[] scanProjection = new boolean[scanTable.getColumnNames().length];
+        Arrays.fill(scanProjection, true);
+
+        for (int i = 0; i < inputSplits.size(); )
+        {
+            ScanInput scanInput = new ScanInput();
+            scanInput.setTransId(transId);
+            ScanTableInfo tableInfo = new ScanTableInfo();
+            ImmutableList.Builder<InputSplit> inputsBuilder = ImmutableList
+                    .builderWithExpectedSize(IntraWorkerParallelism);
+            for (int j = 0; j < IntraWorkerParallelism && i < inputSplits.size(); ++j, ++i)
+            {
+                // We assign a number of IntraWorkerParallelism input-splits to each partition worker.
+                inputsBuilder.add(inputSplits.get(i));
+            }
+            tableInfo.setInputSplits(inputsBuilder.build());
+            tableInfo.setColumnsToRead(scanTable.getColumnNames());
+            tableInfo.setTableName(scanTable.getTableName());
+            tableInfo.setFilter(JSON.toJSONString(scanTable.getFilter()));
+            tableInfo.setBase(true);
+            tableInfo.setStorageInfo(InputStorageInfo);
+            scanInput.setTableInfo(tableInfo);
+            scanInput.setScanProjection(scanProjection);
+            scanInput.setPartialAggregationPresent(true);
+            scanInput.setPartialAggregationInfo(null);
+            String folderName = intermediateBase + (outputId++) + "/";
+            scanInput.setOutput(new OutputInfo(folderName, IntermediateStorageInfo, true));
+            scanInputsBuilder.add(scanInput);
+        }
+        return EnabledExchangeMethod == ExchangeMethod.batch ?
+                new ScanBatchOperator(scanTable.getTableName(), scanInputsBuilder.build()) :
+                new ScanStreamOperator(scanTable.getTableName(), scanInputsBuilder.build());
     }
 
     private AggregationOperator getAggregationOperator(AggregatedTable aggregatedTable)

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/PixelsPlanner.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/PixelsPlanner.java
@@ -120,8 +120,10 @@ public class PixelsPlanner
     {
         this.transId = transId;
         this.rootTable = requireNonNull(rootTable, "rootTable is null");
-        checkArgument(rootTable.getTableType() == Table.TableType.JOINED || rootTable.getTableType() == Table.TableType.AGGREGATED,
-                "currently, PixelsPlanner only supports join and aggregation");
+        checkArgument(rootTable.getTableType() == Table.TableType.BASE ||
+                        rootTable.getTableType() == Table.TableType.JOINED ||
+                        rootTable.getTableType() == Table.TableType.AGGREGATED,
+                "currently, PixelsPlanner only supports scan, join, and aggregation");
         this.config = ConfigFactory.Instance();
         this.metadataService = metadataService.orElseGet(() ->
                 new MetadataService(config.getProperty("metadata.server.host"),

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/PixelsPlanner.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/PixelsPlanner.java
@@ -115,9 +115,7 @@ public class PixelsPlanner
      * @param metadataService the metadata service to access Pixels metadata
      * @throws IOException
      */
-    public PixelsPlanner(long transId, Table rootTable,
-                         boolean orderedPathEnabled,
-                         boolean compactPathEnabled,
+    public PixelsPlanner(long transId, Table rootTable, boolean orderedPathEnabled, boolean compactPathEnabled,
                          Optional<MetadataService> metadataService) throws IOException
     {
         this.transId = transId;

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/StarlingPlanner.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/StarlingPlanner.java
@@ -134,7 +134,11 @@ public class StarlingPlanner
 
     public Operator getRootOperator() throws IOException, MetadataException
     {
-        if (this.rootTable.getTableType() == Table.TableType.JOINED)
+        if (this.rootTable.getTableType() == Table.TableType.BASE)
+        {
+            return this.getScanOperator((BaseTable) this.rootTable);
+        }
+        else if (this.rootTable.getTableType() == Table.TableType.JOINED)
         {
             return this.getJoinOperator((JoinedTable) this.rootTable, Optional.empty());
         }
@@ -157,6 +161,45 @@ public class StarlingPlanner
     public static String getIntermediateFolderForTrans(long transId)
     {
         return IntermediateFolder + transId + "/";
+    }
+
+    private ScanOperator getScanOperator(BaseTable scanTable) throws IOException, MetadataException
+    {
+        final String intermediateBase = getIntermediateFolderForTrans(transId) +
+                scanTable.getSchemaName() + "/" + scanTable.getTableName() + "/";
+        ImmutableList.Builder<ScanInput> scanInputsBuilder = ImmutableList.builder();
+        List<InputSplit> inputSplits = this.getInputSplits(scanTable);
+        int outputId = 0;
+        boolean[] scanProjection = new boolean[scanTable.getColumnNames().length];
+        Arrays.fill(scanProjection, true);
+
+        for (int i = 0; i < inputSplits.size(); )
+        {
+            ScanInput scanInput = new ScanInput();
+            scanInput.setTransId(transId);
+            ScanTableInfo tableInfo = new ScanTableInfo();
+            ImmutableList.Builder<InputSplit> inputsBuilder = ImmutableList
+                    .builderWithExpectedSize(IntraWorkerParallelism);
+            for (int j = 0; j < IntraWorkerParallelism && i < inputSplits.size(); ++j, ++i)
+            {
+                // We assign a number of IntraWorkerParallelism input-splits to each partition worker.
+                inputsBuilder.add(inputSplits.get(i));
+            }
+            tableInfo.setInputSplits(inputsBuilder.build());
+            tableInfo.setColumnsToRead(scanTable.getColumnNames());
+            tableInfo.setTableName(scanTable.getTableName());
+            tableInfo.setFilter(JSON.toJSONString(scanTable.getFilter()));
+            tableInfo.setBase(true);
+            tableInfo.setStorageInfo(InputStorageInfo);
+            scanInput.setTableInfo(tableInfo);
+            scanInput.setScanProjection(scanProjection);
+            scanInput.setPartialAggregationPresent(true);
+            scanInput.setPartialAggregationInfo(null);
+            String folderName = intermediateBase + (outputId++) + "/";
+            scanInput.setOutput(new OutputInfo(folderName, IntermediateStorageInfo, true));
+            scanInputsBuilder.add(scanInput);
+        }
+        return new ScanBatchOperator(scanTable.getTableName(), scanInputsBuilder.build());
     }
 
     private StarlingAggregationOperator getAggregationOperator(AggregatedTable aggregatedTable)

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/StarlingPlanner.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/StarlingPlanner.java
@@ -117,8 +117,10 @@ public class StarlingPlanner
     {
         this.transId = transId;
         this.rootTable = requireNonNull(rootTable, "rootTable is null");
-        checkArgument(rootTable.getTableType() == Table.TableType.JOINED || rootTable.getTableType() == Table.TableType.AGGREGATED,
-                "currently, StarlingPlanner only supports join and aggregation");
+        checkArgument(rootTable.getTableType() == Table.TableType.BASE ||
+                        rootTable.getTableType() == Table.TableType.JOINED ||
+                        rootTable.getTableType() == Table.TableType.AGGREGATED,
+                "currently, StarlingPlanner only supports scan, join, and aggregation");
         this.config = ConfigFactory.Instance();
         this.metadataService = metadataService.orElseGet(() ->
                 new MetadataService(config.getProperty("metadata.server.host"),

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/StarlingPlanner.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/StarlingPlanner.java
@@ -193,7 +193,7 @@ public class StarlingPlanner
             tableInfo.setStorageInfo(InputStorageInfo);
             scanInput.setTableInfo(tableInfo);
             scanInput.setScanProjection(scanProjection);
-            scanInput.setPartialAggregationPresent(true);
+            scanInput.setPartialAggregationPresent(false);
             scanInput.setPartialAggregationInfo(null);
             String folderName = intermediateBase + (outputId++) + "/";
             scanInput.setOutput(new OutputInfo(folderName, IntermediateStorageInfo, true));

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/StarlingPlanner.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/StarlingPlanner.java
@@ -112,9 +112,7 @@ public class StarlingPlanner
      * @param metadataService the metadata service to access Pixels metadata
      * @throws IOException
      */
-    public StarlingPlanner(long transId, Table rootTable,
-                           boolean orderedPathEnabled,
-                           boolean compactPathEnabled,
+    public StarlingPlanner(long transId, Table rootTable, boolean orderedPathEnabled, boolean compactPathEnabled,
                            Optional<MetadataService> metadataService) throws IOException
     {
         this.transId = transId;

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/coordinate/PlanCoordinator.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/coordinate/PlanCoordinator.java
@@ -51,6 +51,13 @@ public class PlanCoordinator
         this.transId = transId;
     }
 
+    /**
+     * Add a new stage and its downstream dependency to this plan coordinator. All the stages must be added in the order
+     * of downstream to up stream, i.e., from the root operator to leaf operators.
+     * @param stageCoordinator the stage coordinator of the current stage
+     * @param stageDependency the downstream dependency of the current stage, for the root operator, the down stream
+     *                       dependency is empty (with downstream stage id < 0)
+     */
     public void addStageCoordinator(StageCoordinator stageCoordinator, StageDependency stageDependency)
     {
         int stageId = requireNonNull(stageCoordinator, "stageCoordinator is null").getStageId();
@@ -67,16 +74,30 @@ public class PlanCoordinator
         return this.stageCoordinators.get(stageId);
     }
 
+    /**
+     * Get this stage's dependency on the parent (downstream) stage.
+     * @param stageId the id of this stage
+     * @return the dependency
+     */
     public StageDependency getStageDependency(int stageId)
     {
         return this.stageDependencies.get(stageId);
     }
 
+    /**
+     * @return the transaction id of this query
+     */
     public long getTransId()
     {
         return transId;
     }
 
+    /**
+     * Assign an id for a stage. This should only be called in
+     * {@link io.pixelsdb.pixels.planner.plan.physical.Operator#initPlanCoordinator(PlanCoordinator, int, boolean)}
+     * when building the plan coordinator for a query plan.
+     * @return the assigned stage id
+     */
     public int assignStageId()
     {
         return this.stageIdAssigner.getAndIncrement();

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/coordinate/PlanCoordinatorFactory.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/coordinate/PlanCoordinatorFactory.java
@@ -44,13 +44,25 @@ public class PlanCoordinatorFactory
         this.transIdToPlanCoordinator = new ConcurrentHashMap<>();
     }
 
-    public void createPlanCoordinator(long transId, Operator planRootOperator)
+    /**
+     * Create the plan coordinator for the query plan.
+     * @param transId the transaction id
+     * @param planRootOperator the root operator of the query plan
+     * @return the plan coordinator
+     */
+    public PlanCoordinator createPlanCoordinator(long transId, Operator planRootOperator)
     {
         PlanCoordinator planCoordinator = new PlanCoordinator(transId);
         planRootOperator.initPlanCoordinator(planCoordinator, -1, false);
         this.transIdToPlanCoordinator.put(transId, planCoordinator);
+        return planCoordinator;
     }
 
+    /**
+     * Retrieve the plan coordinator of the query.
+     * @param transId the transaction id of the query
+     * @return the plan coordinator
+     */
     public PlanCoordinator getPlanCoordinator(long transId)
     {
         return this.transIdToPlanCoordinator.get(transId);

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/coordinate/StageDependency.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/coordinate/StageDependency.java
@@ -22,6 +22,7 @@ package io.pixelsdb.pixels.planner.coordinate;
 import static com.google.common.base.Preconditions.checkArgument;
 
 /**
+ * The dependency of a query execution stage.
  * @author hank
  * @create 2023-09-24
  */
@@ -34,6 +35,12 @@ public class StageDependency
     private final int downStreamStageId;
     private final boolean isWide;
 
+    /**
+     * Create a dependency between the current stage and the downstream (parent) stage.
+     * @param currentStageId the id of the current stage
+     * @param downStreamStageId the id of the downstream stage
+     * @param isWide whether this dependency is wide or not
+     */
     public StageDependency(int currentStageId, int downStreamStageId, boolean isWide)
     {
         checkArgument(currentStageId >= 0, "currentStageId must be non-negative");

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/coordinate/TaskBatch.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/coordinate/TaskBatch.java
@@ -22,6 +22,8 @@ package io.pixelsdb.pixels.planner.coordinate;
 import java.util.List;
 
 /**
+ * A batch of tasks to execute. If {@link #isEndOfTasks()} returns true, it means this is the last batch
+ * of tasks for the stage.
  * @author hank
  * @create 2023-10-04
  */
@@ -36,11 +38,17 @@ public class TaskBatch
         this.tasks = tasks;
     }
 
+    /**
+     * @return true if this the last batch of tasks in the stage
+     */
     public boolean isEndOfTasks()
     {
         return endOfTasks;
     }
 
+    /**
+     * @return the tasks in the batch
+     */
     public List<TaskInfo> getTasks()
     {
         return tasks;

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/AggregationBatchOperator.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/AggregationBatchOperator.java
@@ -57,10 +57,10 @@ public class AggregationBatchOperator extends AggregationOperator
             {
                 this.finalAggrOutputs = new CompletableFuture[this.finalAggrInputs.size()];
                 int i = 0;
-                for (AggregationInput preAggrInput : this.finalAggrInputs)
+                for (AggregationInput aggrInput : this.finalAggrInputs)
                 {
                     this.finalAggrOutputs[i++] = InvokerFactory.Instance()
-                            .getInvoker(WorkerType.AGGREGATION).invoke(preAggrInput);
+                            .getInvoker(WorkerType.AGGREGATION).invoke(aggrInput);
                 }
                 waitForCompletion(this.finalAggrOutputs);
             } catch (InterruptedException e)

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/AggregationOperator.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/AggregationOperator.java
@@ -158,7 +158,7 @@ public abstract class AggregationOperator extends Operator
     {
         AggregationOutputCollection outputCollection = new AggregationOutputCollection();
 
-        if (this.scanOutputs.length > 0)
+        if (this.scanOutputs != null && this.scanOutputs.length > 0)
         {
             Output[] outputs = new Output[this.scanOutputs.length];
             for (int i = 0; i < this.scanOutputs.length; ++i)
@@ -166,6 +166,10 @@ public abstract class AggregationOperator extends Operator
                 outputs[i] = this.scanOutputs[i].get();
             }
             outputCollection.setScanOutputs(outputs);
+        }
+        if (this.child != null)
+        {
+            outputCollection.setChild(this.child.collectOutputs());
         }
         if (this.finalAggrOutputs != null && this.finalAggrOutputs.length > 0)
         {
@@ -182,13 +186,15 @@ public abstract class AggregationOperator extends Operator
     public static class AggregationOutputCollection implements OutputCollection
     {
         private Output[] scanOutputs = null;
+        private OutputCollection child;
         private Output[] finalAggrOutputs = null;
 
         public AggregationOutputCollection() { }
 
-        public AggregationOutputCollection(Output[] scanOutputs, Output[] preAggrOutputs)
+        public AggregationOutputCollection(Output[] scanOutputs, OutputCollection child, Output[] preAggrOutputs)
         {
             this.scanOutputs = scanOutputs;
+            this.child = child;
             this.finalAggrOutputs = preAggrOutputs;
         }
 
@@ -200,6 +206,16 @@ public abstract class AggregationOperator extends Operator
         public void setScanOutputs(Output[] scanOutputs)
         {
             this.scanOutputs = scanOutputs;
+        }
+
+        public OutputCollection getChild()
+        {
+            return child;
+        }
+
+        public void setChild(OutputCollection child)
+        {
+            this.child = child;
         }
 
         public Output[] getFinalAggrOutputs()
@@ -223,6 +239,10 @@ public abstract class AggregationOperator extends Operator
                     totalGBMs += output.getGBMs();
                 }
             }
+            if (child != null)
+            {
+                totalGBMs += child.getTotalGBMs();
+            }
             if (this.finalAggrOutputs != null)
             {
                 for (Output output : finalAggrOutputs)
@@ -243,6 +263,10 @@ public abstract class AggregationOperator extends Operator
                 {
                     numReadRequests += output.getNumReadRequests();
                 }
+            }
+            if (child != null)
+            {
+                numReadRequests += child.getTotalNumReadRequests();
             }
             if (this.finalAggrOutputs != null)
             {
@@ -265,6 +289,10 @@ public abstract class AggregationOperator extends Operator
                     numWriteRequests += output.getNumWriteRequests();
                 }
             }
+            if (this.child != null)
+            {
+                numWriteRequests += this.child.getTotalNumWriteRequests();
+            }
             if (this.finalAggrOutputs != null)
             {
                 for (Output output : finalAggrOutputs)
@@ -286,6 +314,10 @@ public abstract class AggregationOperator extends Operator
                     readBytes += output.getTotalReadBytes();
                 }
             }
+            if (this.child != null)
+            {
+                readBytes += this.child.getTotalReadBytes();
+            }
             if (this.finalAggrOutputs != null)
             {
                 for (Output output : finalAggrOutputs)
@@ -306,6 +338,10 @@ public abstract class AggregationOperator extends Operator
                 {
                     writeBytes += output.getTotalWriteBytes();
                 }
+            }
+            if (this.child != null)
+            {
+                writeBytes += this.child.getTotalWriteBytes();
             }
             if (this.finalAggrOutputs != null)
             {

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/Operator.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/Operator.java
@@ -59,7 +59,7 @@ public abstract class Operator implements OperatorExecutor
 
     /**
      * Initialize the query plan coordinator. This method should be invoked recursively to traverse all
-     * the operators in the query plan. Each operator added its own query execution stages into the plan
+     * the operators in the query plan. Each operator adds its own query execution stages into the plan
      * coordinator. Therefore, the users only need to call this method on the root operator of the plan.
      * @param planCoordinator the plan coordinator to be initialized
      * @param parentStageId the stage id of the parent (i.e., downstream) stage of this operator, for the

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/ScanBatchOperator.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/ScanBatchOperator.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2024 PixelsDB.
+ *
+ * This file is part of Pixels.
+ *
+ * Pixels is free software: you can redistribute it and/or modify
+ * it under the terms of the Affero GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * Pixels is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Affero GNU General Public License for more details.
+ *
+ * You should have received a copy of the Affero GNU General Public
+ * License along with Pixels.  If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package io.pixelsdb.pixels.planner.plan.physical;
+
+import io.pixelsdb.pixels.common.turbo.InvokerFactory;
+import io.pixelsdb.pixels.common.turbo.Output;
+import io.pixelsdb.pixels.common.turbo.WorkerType;
+import io.pixelsdb.pixels.planner.plan.physical.input.ScanInput;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+
+import static io.pixelsdb.pixels.planner.plan.physical.OperatorExecutor.waitForCompletion;
+
+/**
+ * @author hank
+ * @create 2024-04-28
+ */
+public class ScanBatchOperator extends ScanOperator
+{
+    private static final Logger logger = LogManager.getLogger(ScanBatchOperator.class);
+
+    private static final CompletableFuture<Void> Completed = CompletableFuture.completedFuture(null);
+
+    public ScanBatchOperator(String name, List<ScanInput> scanInputs)
+    {
+        super(name, scanInputs);
+    }
+
+    @Override
+    public CompletableFuture<CompletableFuture<? extends Output>[]> execute()
+    {
+        return executePrev().handle((result, exception) ->
+        {
+            // there is no previous stage for scan operator, hence executePrev() never throws exceptions
+            try
+            {
+                this.scanOutputs = new CompletableFuture[this.scanInputs.size()];
+                int i = 0;
+                for (ScanInput scanInput : this.scanInputs)
+                {
+                    this.scanOutputs[i++] = InvokerFactory.Instance()
+                            .getInvoker(WorkerType.SCAN).invoke(scanInput);
+                }
+                waitForCompletion(this.scanOutputs);
+            } catch (InterruptedException e)
+            {
+                throw new CompletionException("interrupted when waiting for the completion of this operator", e);
+            }
+
+            return this.scanOutputs;
+        });
+    }
+
+    @Override
+    public CompletableFuture<Void> executePrev()
+    {
+        return Completed;
+    }
+}

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/ScanOperator.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/ScanOperator.java
@@ -91,7 +91,7 @@ public abstract class ScanOperator extends Operator
     }
 
     @Override
-    public OutputCollection collectOutputs() throws ExecutionException, InterruptedException
+    public ScanOutputCollection collectOutputs() throws ExecutionException, InterruptedException
     {
         ScanOutputCollection outputCollection = new ScanOutputCollection();
 

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/ScanOperator.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/ScanOperator.java
@@ -1,10 +1,35 @@
+/*
+ * Copyright 2024 PixelsDB.
+ *
+ * This file is part of Pixels.
+ *
+ * Pixels is free software: you can redistribute it and/or modify
+ * it under the terms of the Affero GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * Pixels is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Affero GNU General Public License for more details.
+ *
+ * You should have received a copy of the Affero GNU General Public
+ * License along with Pixels.  If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
 package io.pixelsdb.pixels.planner.plan.physical;
 
+import com.alibaba.fastjson.JSON;
 import com.google.common.collect.ImmutableList;
+import io.pixelsdb.pixels.common.task.Task;
 import io.pixelsdb.pixels.common.turbo.Output;
 import io.pixelsdb.pixels.planner.coordinate.PlanCoordinator;
+import io.pixelsdb.pixels.planner.coordinate.StageCoordinator;
+import io.pixelsdb.pixels.planner.coordinate.StageDependency;
+import io.pixelsdb.pixels.planner.plan.physical.domain.InputSplit;
 import io.pixelsdb.pixels.planner.plan.physical.input.ScanInput;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
@@ -47,6 +72,20 @@ public abstract class ScanOperator extends Operator
     @Override
     public void initPlanCoordinator(PlanCoordinator planCoordinator, int parentStageId, boolean wideDependOnParent)
     {
-
+        int scanStageId = planCoordinator.assignStageId();
+        StageDependency scanStageDependency = new StageDependency(scanStageId, parentStageId, wideDependOnParent);
+        List<Task> tasks = new ArrayList<>();
+        int taskId = 0;
+        for (ScanInput scanInput : this.scanInputs)
+        {
+            List<InputSplit> inputSplits = scanInput.getTableInfo().getInputSplits();
+            for (InputSplit inputSplit : inputSplits)
+            {
+                scanInput.getTableInfo().setInputSplits(ImmutableList.of(inputSplit));
+                tasks.add(new Task(taskId++, JSON.toJSONString(scanInput)));
+            }
+        }
+        StageCoordinator scanStageCoordinator = new StageCoordinator(scanStageId, tasks);
+        planCoordinator.addStageCoordinator(scanStageCoordinator, scanStageDependency);
     }
 }

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/ScanOperator.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/ScanOperator.java
@@ -1,0 +1,52 @@
+package io.pixelsdb.pixels.planner.plan.physical;
+
+import com.google.common.collect.ImmutableList;
+import io.pixelsdb.pixels.common.turbo.Output;
+import io.pixelsdb.pixels.planner.coordinate.PlanCoordinator;
+import io.pixelsdb.pixels.planner.plan.physical.input.ScanInput;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * @author hank
+ * @create 2024-04-26
+ */
+public abstract class ScanOperator extends Operator
+{
+    /**
+     * The scan inputs of the scan workers that produce the partial aggregation
+     * results. It should be empty if child is not null.
+     */
+    protected final List<ScanInput> scanInputs;
+    /**
+     * The outputs of the scan workers.
+     */
+    protected CompletableFuture<? extends Output>[] scanOutputs = null;
+
+    public ScanOperator(String name, List<ScanInput> scanInputs)
+    {
+        super(name);
+        requireNonNull(scanInputs, "scanInputs is null");
+        checkArgument(!scanInputs.isEmpty(), "scanInputs is empty");
+        this.scanInputs = ImmutableList.copyOf(scanInputs);
+        for (ScanInput scanInput : this.scanInputs)
+        {
+            scanInput.setOperatorName(name);
+        }
+    }
+
+    public List<ScanInput> getScanInputs()
+    {
+        return scanInputs;
+    }
+
+    @Override
+    public void initPlanCoordinator(PlanCoordinator planCoordinator, int parentStageId, boolean wideDependOnParent)
+    {
+
+    }
+}

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/ScanStreamOperator.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/ScanStreamOperator.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2024 PixelsDB.
+ *
+ * This file is part of Pixels.
+ *
+ * Pixels is free software: you can redistribute it and/or modify
+ * it under the terms of the Affero GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * Pixels is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Affero GNU General Public License for more details.
+ *
+ * You should have received a copy of the Affero GNU General Public
+ * License along with Pixels.  If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package io.pixelsdb.pixels.planner.plan.physical;
+
+import io.pixelsdb.pixels.common.turbo.Output;
+import io.pixelsdb.pixels.planner.plan.physical.input.ScanInput;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * @author hank
+ * @create 2024-04-28
+ */
+public class ScanStreamOperator extends ScanOperator
+{
+    public ScanStreamOperator(String name, List<ScanInput> scanInputs)
+    {
+        super(name, scanInputs);
+    }
+
+    @Override
+    public CompletableFuture<CompletableFuture<? extends Output>[]> execute()
+    {
+        // TODO: implement
+        return null;
+    }
+
+    @Override
+    public CompletableFuture<Void> executePrev()
+    {
+        // TODO: implement
+        return null;
+    }
+}

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/SingleStageJoinBatchOperator.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/SingleStageJoinBatchOperator.java
@@ -39,7 +39,7 @@ import static io.pixelsdb.pixels.planner.plan.physical.OperatorExecutor.waitForC
  */
 public class SingleStageJoinBatchOperator extends SingleStageJoinOperator
 {
-    private static final Logger logger = LogManager.getLogger(SingleStageJoinOperator.class);
+    private static final Logger logger = LogManager.getLogger(SingleStageJoinBatchOperator.class);
 
     public SingleStageJoinBatchOperator(String name, boolean complete, JoinInput joinInput, JoinAlgorithm joinAlgo)
     {

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/input/ScanInput.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/input/ScanInput.java
@@ -139,7 +139,7 @@ public class ScanInput extends Input
         String[] outputPaths = new String[numSplits];
         for (int i = 0; i < numSplits; ++i)
         {
-            outputPaths[i] = outputFolder + "scan_" + i++;
+            outputPaths[i] = outputFolder + "scan_" + i;
         }
         return outputPaths;
     }
@@ -162,7 +162,7 @@ public class ScanInput extends Input
         }
         for (int i = 0; i < numSplits; ++i)
         {
-            builder.add(folder + "scan_" + i++);
+            builder.add(folder + "scan_" + i);
         }
         return builder.build();
     }

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/output/NonPartitionOutput.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/output/NonPartitionOutput.java
@@ -31,11 +31,6 @@ import java.util.ArrayList;
 public abstract class NonPartitionOutput extends Output
 {
     /**
-     * The path of the result files. No need to contain endpoint information.
-     */
-    private ArrayList<String> outputs = new ArrayList<>();
-
-    /**
      * The number of row groups in each result files.
      */
     private ArrayList<Integer> rowGroupNums = new ArrayList<>();
@@ -44,16 +39,6 @@ public abstract class NonPartitionOutput extends Output
      * Default constructor for jackson.
      */
     public NonPartitionOutput() { }
-
-    public ArrayList<String> getOutputs()
-    {
-        return outputs;
-    }
-
-    public void setOutputs(ArrayList<String> outputs)
-    {
-        this.outputs = outputs;
-    }
 
     public ArrayList<Integer> getRowGroupNums()
     {
@@ -67,7 +52,7 @@ public abstract class NonPartitionOutput extends Output
 
     public synchronized void addOutput(String output, int rowGroupNum)
     {
-        this.outputs.add(output);
+        this.addOutput(output);
         this.rowGroupNums.add(rowGroupNum);
     }
 }

--- a/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/output/PartitionOutput.java
+++ b/pixels-planner/src/main/java/io/pixelsdb/pixels/planner/plan/physical/output/PartitionOutput.java
@@ -31,12 +31,7 @@ import java.util.Set;
 public class PartitionOutput extends Output
 {
     /**
-     * The path of the partitioned file.
-     */
-    private String path;
-
-    /**
-     * The hash value of the partitions that exist in the partitioned file.
+     * The hash value of the partitions that exist in the partitioned result.
      */
     private Set<Integer> hashValues;
 
@@ -44,22 +39,6 @@ public class PartitionOutput extends Output
      * Default constructor for Jackson.
      */
     public PartitionOutput() { }
-
-    public PartitionOutput(String path, Set<Integer> hashValues)
-    {
-        this.path = path;
-        this.hashValues = hashValues;
-    }
-
-    public String getPath()
-    {
-        return path;
-    }
-
-    public void setPath(String path)
-    {
-        this.path = path;
-    }
 
     public Set<Integer> getHashValues()
     {

--- a/pixels-turbo/pixels-invoker-lambda/src/test/java/io/pixelsdb/pixels/invoker/lambda/TestPartitionLambdaInvoker.java
+++ b/pixels-turbo/pixels-invoker-lambda/src/test/java/io/pixelsdb/pixels/invoker/lambda/TestPartitionLambdaInvoker.java
@@ -83,7 +83,8 @@ public class TestPartitionLambdaInvoker
 
             PartitionOutput output = (PartitionOutput) InvokerFactory.Instance()
                     .getInvoker(WorkerType.PARTITION).invoke(input).get();
-            System.out.println(output.getPath());
+            System.out.println(output.getOutputs().size());
+            System.out.println(Joiner.on(",").join(output.getOutputs()));
             System.out.println(Joiner.on(",").join(output.getHashValues()));
         }
     }
@@ -125,7 +126,8 @@ public class TestPartitionLambdaInvoker
 
             PartitionOutput output = (PartitionOutput) InvokerFactory.Instance()
                     .getInvoker(WorkerType.PARTITION).invoke(input).get();
-            System.out.println(output.getPath());
+            System.out.println(output.getOutputs().size());
+            System.out.println(Joiner.on(",").join(output.getOutputs()));
             System.out.println(Joiner.on(",").join(output.getHashValues()));
         }
     }

--- a/pixels-turbo/pixels-worker-common/src/main/java/io/pixelsdb/pixels/worker/common/BasePartitionWorker.java
+++ b/pixels-turbo/pixels-worker-common/src/main/java/io/pixelsdb/pixels/worker/common/BasePartitionWorker.java
@@ -165,7 +165,7 @@ public class BasePartitionWorker extends Worker<PartitionInput, PartitionOutput>
                     hashValues.add(hash);
                 }
             }
-            partitionOutput.setPath(outputPath);
+            partitionOutput.addOutput(outputPath);
             partitionOutput.setHashValues(hashValues);
 
             pixelsWriter.close();


### PR DESCRIPTION
1. add scan operator for serverless workers.
2. pixels and starling planner accepts base table and generate scan operator for table scan.
3. fix output collection in aggregation operators, it doesn't collect child output previously.
4. fix ScanInput.generateOutputPaths(), it only generates outputs end with even numbers previously.
5. move outputs from NonPartitionOutput into Output.
6. add comments for worker coordinators.