### PR TITLE
[Issue #649] clean query results periodically and fix bugs in query manager

### DIFF
--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/error/ErrorCode.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/error/ErrorCode.java
@@ -97,6 +97,7 @@ public class ErrorCode
     public static final int QUERY_SERVER_NOT_SUPPORTED = (ERROR_QUERY_SERVER + 3);
     public static final int QUERY_SERVER_BAD_REQUEST = (ERROR_QUERY_SERVER + 4);
     public static final int QUERY_SERVER_QUERY_NOT_FINISHED = (ERROR_QUERY_SERVER + 5);
+    public static final int QUERY_SERVER_QUERY_RESULT_NOT_FOUND = (ERROR_QUERY_SERVER + 6);
 
     // begin error code for pixels-turbo worker coordinate service
     private static final int ERROR_WORKER_COORDINATE = ERROR_BASE + 500;

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/server/rest/response/GetQueryResultResponse.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/server/rest/response/GetQueryResultResponse.java
@@ -44,23 +44,17 @@ public class GetQueryResultResponse
      */
     private double executionTimeMs;
     /**
+     * The milliseconds since Unix epoch at which the query is finished.
+     */
+    private long finishTimestampMs = -1;
+    /**
      * The amount of money in cents really spent by the query.
      */
-    private double costCents = 0;
+    private double costCents = -1;
     /**
      * The amount of money in cents billed according to our price model.
      */
-    private double billedCents = 0;
-
-    // Issue #649: Breakdown costs into vmCost and cfCost
-    /**
-     * The amount of money in cents really spent in vm by the query.
-     */
-    private double vmCostCents = -1;
-    /**
-     * The amount of money in cents really spent in cf by the query.
-     */
-    private double cfCostCents = -1;
+    private double billedCents = -1;
     /**
      * The execution hint of query.
      */
@@ -88,8 +82,9 @@ public class GetQueryResultResponse
 
     public GetQueryResultResponse(int errorCode, String errorMessage, ExecutionHint executionHint, int[] columnPrintSizes,
                                   String[] columnNames, String[][] rows, double pendingTimeMs,
-                                  double executionTimeMs)
+                                  double executionTimeMs, long finishTimestampMs)
     {
+        checkArgument(finishTimestampMs > 0, "finish timestamp is invalid");
         this.errorCode = errorCode;
         this.errorMessage = errorMessage;
         this.executionHint = executionHint;
@@ -98,6 +93,7 @@ public class GetQueryResultResponse
         this.rows = rows;
         this.pendingTimeMs = pendingTimeMs;
         this.executionTimeMs = executionTimeMs;
+        this.finishTimestampMs = finishTimestampMs;
     }
 
     public int getErrorCode()
@@ -174,6 +170,16 @@ public class GetQueryResultResponse
         this.executionTimeMs = executionTimeMs;
     }
 
+    public long getFinishTimestampMs()
+    {
+        return finishTimestampMs;
+    }
+
+    public void setFinishTimestampMs(long finishTimestampMs)
+    {
+        this.finishTimestampMs = finishTimestampMs;
+    }
+
     public double getCostCents()
     {
         return costCents;
@@ -196,28 +202,11 @@ public class GetQueryResultResponse
         this.billedCents = billedCents;
     }
 
-    public void setVmCostCents(double vmCostCents)
+    /**
+     * @return true if this query result has valid billed and cost cents
+     */
+    public boolean hasValidCents()
     {
-        this.vmCostCents = vmCostCents;
-    }
-
-    public double getVmCostCents()
-    {
-        return vmCostCents;
-    }
-
-    public void setCfCostCents(double cfCostCents)
-    {
-        this.cfCostCents = cfCostCents;
-    }
-
-    public double getCfCostCents()
-    {
-        return cfCostCents;
-    }
-
-    public boolean hasValidVmCostCents()
-    {
-        return this.vmCostCents >= 0;
+        return this.costCents >= 0 && this.billedCents >= 0;
     }
 }

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/server/rest/response/GetQueryResultResponse.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/server/rest/response/GetQueryResultResponse.java
@@ -46,25 +46,21 @@ public class GetQueryResultResponse
     /**
      * The amount of money in cents really spent by the query.
      */
-    private double costCents;
+    private double costCents = 0;
     /**
      * The amount of money in cents billed according to our price model.
      */
-    private double billedCents;
+    private double billedCents = 0;
 
     // Issue #649: Breakdown costs into vmCost and cfCost
     /**
      * The amount of money in cents really spent in vm by the query.
      */
-    private double vmCostCents;
+    private double vmCostCents = -1;
     /**
      * The amount of money in cents really spent in cf by the query.
      */
-    private double cfCostCents;
-    /**
-     * The validity of vmCostCents.
-     */
-    private boolean isValidVmCostCents;
+    private double cfCostCents = -1;
     /**
      * The execution hint of query.
      */
@@ -102,8 +98,6 @@ public class GetQueryResultResponse
         this.rows = rows;
         this.pendingTimeMs = pendingTimeMs;
         this.executionTimeMs = executionTimeMs;
-        this.costCents = 0;
-        this.isValidVmCostCents = false;
     }
 
     public int getErrorCode()
@@ -202,15 +196,28 @@ public class GetQueryResultResponse
         this.billedCents = billedCents;
     }
 
-    public void setVmCostCents(double vmCostCents) { this.vmCostCents = vmCostCents; }
+    public void setVmCostCents(double vmCostCents)
+    {
+        this.vmCostCents = vmCostCents;
+    }
 
-    public double getVmCostCents() { return vmCostCents; }
+    public double getVmCostCents()
+    {
+        return vmCostCents;
+    }
 
-    public void setCfCostCents(double cfCostCents) { this.cfCostCents = cfCostCents; }
+    public void setCfCostCents(double cfCostCents)
+    {
+        this.cfCostCents = cfCostCents;
+    }
 
-    public double getCfCostCents() { return cfCostCents; }
+    public double getCfCostCents()
+    {
+        return cfCostCents;
+    }
 
-    public boolean isValidVmCostCents() { return isValidVmCostCents; }
-
-    public void setValidVmCostCents() { this.isValidVmCostCents = true; }
+    public boolean hasValidVmCostCents()
+    {
+        return this.vmCostCents >= 0;
+    }
 }

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/transaction/TransService.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/transaction/TransService.java
@@ -172,23 +172,23 @@ public class TransService
     /**
      * Update the costs of a transaction (query).
      * @param transId the id of the transaction
-     * @param newScanBytes the new scan bytes to set in the transaction context
-     * @param addCostCents the additional cost in cents to add into the transaction context
+     * @param scanBytes the scan bytes to set in the transaction context
+     * @param costCents the cost in cents to set in the transaction context
      * @return true of the costs are updates successfully, otherwise false
      * @throws TransException if the transaction does not exist
      */
-    public boolean updateQueryCosts(long transId, double newScanBytes, QueryCost addCostCents) throws TransException
+    public boolean updateQueryCosts(long transId, double scanBytes, QueryCost costCents) throws TransException
     {
         TransProto.UpdateQueryCostsRequest request = null;
-        if (addCostCents.getType() == QueryCostType.VMCOST)
+        if (costCents.getType() == QueryCostType.VMCOST)
         {
             request = TransProto.UpdateQueryCostsRequest.newBuilder()
-                .setTransId(transId).setNewScanBytes(newScanBytes).setAddVMCostCents(addCostCents.getCostCents()).build();
+                .setTransId(transId).setScanBytes(scanBytes).setVmCostCents(costCents.getCostCents()).build();
         }
-        else if (addCostCents.getType() == QueryCostType.CFCOST)
+        else if (costCents.getType() == QueryCostType.CFCOST)
         {
             request = TransProto.UpdateQueryCostsRequest.newBuilder()
-                    .setTransId(transId).setNewScanBytes(newScanBytes).setAddCFCostCents(addCostCents.getCostCents()).build();
+                    .setTransId(transId).setScanBytes(scanBytes).setCfCostCents(costCents.getCostCents()).build();
         }
         assert(request != null);
         return updateQueryCosts(request);
@@ -197,23 +197,23 @@ public class TransService
     /**
      * Update the costs of a transaction (query).
      * @param externalTraceId the external trace id (token) of the transaction
-     * @param newScanBytes the new scan bytes to set in the transaction context
-     * @param addCostCents the additional cost in cents to add into the transaction context
+     * @param scanBytes the scan bytes to set in the transaction context
+     * @param costCents the cost in cents to set in the transaction context
      * @return true of the costs are updates successfully, otherwise false
      * @throws TransException if the transaction does not exist
      */
-    public boolean updateQueryCosts(String externalTraceId, double newScanBytes, QueryCost addCostCents) throws TransException
+    public boolean updateQueryCosts(String externalTraceId, double scanBytes, QueryCost costCents) throws TransException
     {
         TransProto.UpdateQueryCostsRequest request = null;
-        if (addCostCents.getType() == QueryCostType.VMCOST)
+        if (costCents.getType() == QueryCostType.VMCOST)
         {
             request = TransProto.UpdateQueryCostsRequest.newBuilder()
-                    .setExternalTraceId(externalTraceId).setNewScanBytes(newScanBytes).setAddVMCostCents(addCostCents.getCostCents()).build();
+                    .setExternalTraceId(externalTraceId).setScanBytes(scanBytes).setVmCostCents(costCents.getCostCents()).build();
         }
-        else if (addCostCents.getType() == QueryCostType.CFCOST)
+        else if (costCents.getType() == QueryCostType.CFCOST)
         {
             request = TransProto.UpdateQueryCostsRequest.newBuilder()
-                    .setExternalTraceId(externalTraceId).setNewScanBytes(newScanBytes).setAddCFCostCents(addCostCents.getCostCents()).build();
+                    .setExternalTraceId(externalTraceId).setScanBytes(scanBytes).setCfCostCents(costCents.getCostCents()).build();
         }
         assert(request != null);
         return updateQueryCosts(request);

--- a/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/DaemonMain.java
+++ b/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/DaemonMain.java
@@ -162,7 +162,7 @@ public class DaemonMain
                  * Shutdown the daemon thread here instead of using the SIGTERM handler.
                  */
                 mainDaemon.shutdown();
-                log.info("all the servers are shutdown, byte...");
+                log.info("all the servers are shutdown, bye...");
             }));
 
             // continue the main thread, start and check the server threads.

--- a/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/transaction/TransServiceImpl.java
+++ b/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/transaction/TransServiceImpl.java
@@ -224,23 +224,19 @@ public class TransServiceImpl extends TransServiceGrpc.TransServiceImplBase
             context = TransContextManager.Instance().getTransContext(request.getExternalTraceId());
 
         }
-        double newScanBytes = request.getNewScanBytes();
+        double newScanBytes = request.getScanBytes();
         TransProto.UpdateQueryCostsResponse.Builder builder = TransProto.UpdateQueryCostsResponse.newBuilder();
         if (context != null)
         {
             context.getProperties().setProperty(Constants.TRANS_CONTEXT_SCAN_BYTES_KEY, String.valueOf(newScanBytes));
-            if (request.hasAddVMCostCents()) {
-                double addVMCostCents = request.getAddVMCostCents();
-                double curCostCents = Double.parseDouble(
-                        context.getProperties().getProperty(Constants.TRANS_CONTEXT_VM_COST_CENTS_KEY, "0"));
+            if (request.hasVmCostCents())
+            {
                 context.getProperties().setProperty(Constants.TRANS_CONTEXT_VM_COST_CENTS_KEY,
-                        String.valueOf(curCostCents + addVMCostCents));
-            } else if (request.hasAddCFCostCents()) {
-                double addCFCostCents = request.getAddCFCostCents();
-                double curCostCents = Double.parseDouble(
-                        context.getProperties().getProperty(Constants.TRANS_CONTEXT_CF_COST_CENTS_KEY, "0"));
+                        String.valueOf(request.getVmCostCents()));
+            } else if (request.hasCfCostCents())
+            {
                 context.getProperties().setProperty(Constants.TRANS_CONTEXT_CF_COST_CENTS_KEY,
-                        String.valueOf(curCostCents + addCFCostCents));
+                        String.valueOf(request.getCfCostCents()));
             }
             builder.setErrorCode(ErrorCode.SUCCESS);
         }

--- a/pixels-server/src/main/java/io/pixelsdb/pixels/server/constant/ControllerParameters.java
+++ b/pixels-server/src/main/java/io/pixelsdb/pixels/server/constant/ControllerParameters.java
@@ -1,0 +1,11 @@
+package io.pixelsdb.pixels.server.constant;
+
+/**
+ * @author hank
+ * @create 2024-05-14
+ */
+public class ControllerParameters
+{
+    public final static int QUERY_RESULT_CLEAR_DELAY_MS = 300000;
+    public final static int GET_QUERY_COSTS_DELAY_MS = 500;
+}

--- a/pixels-server/src/main/java/io/pixelsdb/pixels/server/constant/ControllerParameters.java
+++ b/pixels-server/src/main/java/io/pixelsdb/pixels/server/constant/ControllerParameters.java
@@ -6,6 +6,7 @@ package io.pixelsdb.pixels.server.constant;
  */
 public class ControllerParameters
 {
-    public final static int QUERY_RESULT_CLEAR_DELAY_MS = 300000;
+    public final static int QUERY_RESULT_CLEAR_INTERVAL_MS = 300000;
+    public final static int QUERY_RESULT_CLEAR_DELAY_MS = 60000;
     public final static int GET_QUERY_COSTS_DELAY_MS = 500;
 }

--- a/pixels-server/src/main/java/io/pixelsdb/pixels/server/controller/QueryController.java
+++ b/pixels-server/src/main/java/io/pixelsdb/pixels/server/controller/QueryController.java
@@ -94,7 +94,7 @@ public class QueryController
         {
             return response;
         }
-        return new GetQueryResultResponse(ErrorCode.QUERY_SERVER_QUERY_NOT_FINISHED,
-                "the query is not finished yet");
+        return new GetQueryResultResponse(ErrorCode.QUERY_SERVER_QUERY_RESULT_NOT_FOUND,
+                "the query is not finished yet or its result has been cleared");
     }
 }

--- a/pixels-server/src/main/java/io/pixelsdb/pixels/server/controller/QueryManager.java
+++ b/pixels-server/src/main/java/io/pixelsdb/pixels/server/controller/QueryManager.java
@@ -34,7 +34,6 @@ import io.pixelsdb.pixels.common.transaction.TransService;
 import io.pixelsdb.pixels.common.turbo.QueryScheduleService;
 import io.pixelsdb.pixels.common.utils.ConfigFactory;
 import io.pixelsdb.pixels.common.utils.Constants;
-import org.apache.hadoop.yarn.webapp.hamlet2.Hamlet;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 

--- a/pixels-server/src/main/java/io/pixelsdb/pixels/server/controller/QueryManager.java
+++ b/pixels-server/src/main/java/io/pixelsdb/pixels/server/controller/QueryManager.java
@@ -47,8 +47,7 @@ import java.util.concurrent.*;
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.pixelsdb.pixels.common.utils.Constants.RELAXED_EXECUTION_MAX_POSTPONE_SEC;
 import static io.pixelsdb.pixels.common.utils.Constants.RELAXED_EXECUTION_RETRY_INTERVAL_SEC;
-import static io.pixelsdb.pixels.server.constant.ControllerParameters.GET_QUERY_COSTS_DELAY_MS;
-import static io.pixelsdb.pixels.server.constant.ControllerParameters.QUERY_RESULT_CLEAR_DELAY_MS;
+import static io.pixelsdb.pixels.server.constant.ControllerParameters.*;
 
 /**
  * @author hank
@@ -264,7 +263,7 @@ public class QueryManager
             {
                 try
                 {
-                    TimeUnit.MILLISECONDS.sleep(QUERY_RESULT_CLEAR_DELAY_MS);
+                    TimeUnit.MILLISECONDS.sleep(QUERY_RESULT_CLEAR_INTERVAL_MS);
                     for (Map.Entry<String, GetQueryResultResponse> entry : this.queryResults.entrySet())
                     {
                         long current = System.currentTimeMillis();

--- a/pixels-server/src/main/java/io/pixelsdb/pixels/server/controller/QueryManager.java
+++ b/pixels-server/src/main/java/io/pixelsdb/pixels/server/controller/QueryManager.java
@@ -360,8 +360,8 @@ public class QueryManager
                 resultSet.close();
                 statement.close();
 
-                GetQueryResultResponse result = new GetQueryResultResponse(ErrorCode.SUCCESS, "", request.getExecutionHint(),
-                        columnPrintSizes, columnNames, rows, pendingTimeMs, executeTimeMs);
+                GetQueryResultResponse result = new GetQueryResultResponse(ErrorCode.SUCCESS, "",
+                        request.getExecutionHint(), columnPrintSizes, columnNames, rows, pendingTimeMs, executeTimeMs);
                 // put result before removing from running queries, to avoid unknown query status
                 this.queryResults.put(traceToken, result);
                 this.runningQueries.remove(traceToken);
@@ -421,7 +421,7 @@ public class QueryManager
         GetQueryResultResponse response = this.queryResults.get(traceToken);
 
         // Issue #649: get the cost from the transaction service
-        if (!response.isValidVmCostCents()) {
+        if (!response.hasValidVmCostCents()) {
             TransContext transContext = null;
             try
             {
@@ -433,7 +433,6 @@ public class QueryManager
                     TimeUnit.MILLISECONDS.sleep(500);
                 }
                 response.setVmCostCents(vmCostCents);
-                response.setValidVmCostCents(); // set the vm cost as valid
                 response.addCostCents(vmCostCents);
             } catch (TransException e)
             {

--- a/pixels-server/src/test/java/io/pixelsdb/pixels/server/TestQueryAPI.java
+++ b/pixels-server/src/test/java/io/pixelsdb/pixels/server/TestQueryAPI.java
@@ -139,7 +139,7 @@ public class TestQueryAPI
         String json = this.mockMvc.perform(
                         post(RestUrlPath.SUBMIT_QUERY).contentType(MediaType.APPLICATION_JSON).content(
                                 JSON.toJSONString(new SubmitQueryRequest(
-                                        "SELECT * FROM clickbench.hits LIMIT 1", ExecutionHint.IMMEDIATE, 10))))
+                                        "SELECT * FROM tpch_10g.nation LIMIT 1", ExecutionHint.IMMEDIATE, 10))))
                 .andDo(print()).andExpect(status().isOk()).andReturn().getResponse().getContentAsString();
         SubmitQueryResponse response = JSON.parseObject(json, SubmitQueryResponse.class);
         TimeUnit.SECONDS.sleep(5);

--- a/proto/transaction.proto
+++ b/proto/transaction.proto
@@ -117,15 +117,15 @@ message UpdateQueryCostsRequest {
         string externalTraceId = 1;
         uint64 transId = 2;
     }
-    // the new scan bytes to set
-    double newScanBytes = 3;
+    // the scan bytes to set
+    double scanBytes = 3;
     /*
      * Issue #649:
      * Specify addCostCents: vmCost or cfCost
      */
-    oneof addCostCents {
-        double addVMCostCents = 4;
-        double addCFCostCents = 5;
+    oneof costCents {
+        double vmCostCents = 4;
+        double cfCostCents = 5;
     }
 }
 


### PR DESCRIPTION
Clean the result of finished queries periodically instead of immediately after the first getQueryResult request.
Fix 'Query is not finished' for the repeated getQueryResult requests.
Fix dead-lock in popQueryResult of QueryManager.
Clean code.

Closes Issue #649.