### PR TITLE
[Issue #657] add PIXELS_SRC environment variable to compile pixels c++

### DIFF
--- a/cpp/README.md
+++ b/cpp/README.md
@@ -31,7 +31,7 @@ If the command outputs the following information, it means your system supports 
 0000000000000000 d _eil_addr___x64_sys_io_uring_setup
 ```
 
-Then set the `PIXELS_HOME` environment variable (Ignore it if you have already set it when installing Pixels).
+Then set the `PIXELS_SRC` and `PIXELS_HOME` environment variable (Ignore it if you have already set it when installing Pixels). `PIXELS_SRC` is the source directory of pixels (e.g. `/home/liyu/pixels`). It is used to locate proto files. `PIXELS_HOME` is the path where `pixels-cxx.properties` locates. `PIXELS_HOME` is usually the same as the installation path of pixels.
 
 Pull the dependency code:
 
@@ -61,7 +61,7 @@ In order to run the code in CLion, we should set the cmake configuration in CLio
 In `"setting"`->`"Build,Execution,Deployment"`->`"CMake"`, set `"Generator"` as `"Let CMake decide"`, and
 set `CMake options` as:
 ```shell
--DDUCKDB_OOT_EXTENSION_NAMES="pixels" -DDUCKDB_OOT_EXTENSION_PIXELS_PATH=${PIXELS_HOME}/cpp -DDUCKDB_OOT_EXTENSION_PIXELS_SHOULD_LINK="TRUE" -DDUCKDB_OOT_EXTENSION_PIXELS_INCLUDE_PATH=${PIXELS_HOME}/cpp/include -DCMAKE_PREFIX_PATH=${PIXELS_HOME}/cpp/third-party/protobuf/cmake/build
+-DDUCKDB_OOT_EXTENSION_NAMES="pixels" -DDUCKDB_OOT_EXTENSION_PIXELS_PATH=${PIXELS_SRC}/cpp -DDUCKDB_OOT_EXTENSION_PIXELS_SHOULD_LINK="TRUE" -DDUCKDB_OOT_EXTENSION_PIXELS_INCLUDE_PATH=${PIXELS_SRC}/cpp/include -DCMAKE_PREFIX_PATH=${PIXELS_SRC}/cpp/third-party/protobuf/cmake/build
 ```
 
 ### Benchmark

--- a/cpp/pixels-common/CMakeLists.txt
+++ b/cpp/pixels-common/CMakeLists.txt
@@ -40,11 +40,11 @@ set(pixels_common_cxx
 
 include_directories(include)
 
-if(NOT DEFINED ENV{PIXELS_HOME})
-	message(FATAL_ERROR "You must set PIXELS_HOME environment variable. The value should be set to the Pixels base directory.")
+if(NOT DEFINED ENV{PIXELS_SRC})
+	message(FATAL_ERROR "You must set PIXELS_SRC environment variable. The value should be set to the Pixels base directory.")
 endif()
 
-protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS $ENV{PIXELS_HOME}/proto/pixels.proto)
+protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS $ENV{PIXELS_SRC}/proto/pixels.proto)
 
 add_library(pixels-common ${pixels_common_cxx} ${PROTO_SRCS} ${PROTO_HDRS})
 


### PR DESCRIPTION
Replace PIXELS_HOME with PIXELS_SRC to locate proto file. PIXELS_SRC is the source path of pixels. PIXELS_HOME is the installation path of pixels.