### PR TITLE
[Issue #660] pixels-example should read the example.pxl file from PIXELS_SRC

### DIFF
--- a/cpp/pixels-common/include/utils/ConfigFactory.h
+++ b/cpp/pixels-common/include/utils/ConfigFactory.h
@@ -21,9 +21,11 @@ public:
 	std::string getProperty(std::string key);
     bool boolCheckProperty(std::string key);
 	std::string getPixelsDirectory();
+    std::string getPixelsSourceDirectory();
 private:
 	ConfigFactory();
 	std::map<std::string, std::string> prop;
 	std::string pixelsHome;
+    std::string pixelsSrc;
 };
 #endif // DUCKDB_CONFIGFACTORY_H

--- a/cpp/pixels-common/lib/utils/ConfigFactory.cpp
+++ b/cpp/pixels-common/lib/utils/ConfigFactory.cpp
@@ -10,6 +10,15 @@ ConfigFactory & ConfigFactory::Instance() {
 }
 
 ConfigFactory::ConfigFactory() {
+    if(std::getenv("PIXELS_SRC") == nullptr) {
+        throw InvalidArgumentException("The environment variable 'PIXELS_SRC' is not set. ");
+    }
+    pixelsSrc = std::string(std::getenv("PIXELS_SRC"));
+    std::cout<<"PIXELS_SRC is "<<pixelsSrc<<std::endl;
+    if(pixelsSrc.back() != '/') {
+        pixelsSrc += "/";
+    }
+
 	if(std::getenv("PIXELS_HOME") == nullptr) {
 		throw InvalidArgumentException("The environment variable 'PIXELS_HOME' is not set. ");
 	}
@@ -55,4 +64,8 @@ bool ConfigFactory::boolCheckProperty(std::string key) {
 
 std::string ConfigFactory::getPixelsDirectory() {
 	return pixelsHome;
+}
+
+std::string ConfigFactory::getPixelsSourceDirectory() {
+    return pixelsSrc;
 }


### PR DESCRIPTION
pixels-example should read the example.pxl file from PIXELS_SRC instead of PIXELS_HOME