### PR TITLE
[Issue #703] fix missing DnsNameResolverProvider in /META-INF/services/io.grpc.

### DIFF
--- a/pixels-turbo/pixels-worker-vhive/pom.xml
+++ b/pixels-turbo/pixels-worker-vhive/pom.xml
@@ -170,29 +170,27 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.5.0</version>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>${maven.plugin.shade.version}</version>
+                <configuration>
+                    <createDependencyReducedPom>false</createDependencyReducedPom>
+                </configuration>
                 <executions>
                     <execution>
+                        <id>pixels-worker-vhive</id>
                         <phase>package</phase>
                         <goals>
-                            <goal>single</goal>
+                            <goal>shade</goal>
                         </goals>
                         <configuration>
-                            <archive>
-                                <manifest>
-                                    <mainClass>
-                                        io.pixelsdb.pixels.worker.vhive.Main
-                                    </mainClass>
-                                </manifest>
-                                <manifestEntries>
-                                    <Multi-Release>true</Multi-Release>
-                                </manifestEntries>
-                            </archive>
-                            <finalName>pixels-worker-vhive</finalName>
-                            <descriptorRefs>
-                                <descriptorRef>jar-with-dependencies</descriptorRef>
-                            </descriptorRefs>
+                            <finalName>pixels-worker-vhive-jar-with-dependencies</finalName>
+                            <transformers>
+                                <!-- ServicesResourceTransformer merges the resources in META-INF/services -->
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>io.pixelsdb.pixels.worker.vhive.Main</mainClass>
+                                </transformer>
+                            </transformers>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
The jar package created by maven assembly plugin will lack DnsNameResolverProvider in /META-INF/services/io.grpc. So substitue it with maven shade plugin.
Refer to https://github.com/grpc/grpc-java/issues/9829 and https://github.com/grpc/grpc-java/issues/9387