### PR TITLE
[Issue #715] fix the worker hostnames in the cache plan

### DIFF
--- a/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsCacheWriter.java
+++ b/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsCacheWriter.java
@@ -235,14 +235,16 @@ public class PixelsCacheWriter
         {
             // get the caching file list
             String key = Constants.CACHE_LOCATION_LITERAL + version + "_" + host;
+            logger.info("pixels cache writer get cache plan, key=" + key);
             KeyValue keyValue = etcdUtil.getKeyValue(key);
             if (keyValue == null)
             {
-                logger.debug("Found no allocated files. No updates are needed. " + key);
+                logger.info("Found no allocated files. No updates are needed. " + key);
                 return 0;
             }
             String fileStr = keyValue.getValue().toString(StandardCharsets.UTF_8);
             String[] files = fileStr.split(";");
+            logger.info("files to cache: " + fileStr);
             return internalUpdateAll(version, layout, files);
         }
         catch (IOException e)
@@ -313,8 +315,7 @@ public class PixelsCacheWriter
         flushIndex();
     }
 
-    private int internalUpdateAll(int version, Layout layout, String[] files)
-            throws IOException
+    private int internalUpdateAll(int version, Layout layout, String[] files) throws IOException
     {
         int status = 0;
         // get the new caching layout
@@ -332,7 +333,8 @@ public class PixelsCacheWriter
              *    wait for the readCount to be cleared (become zero).
              */
             PixelsCacheUtil.beginIndexWrite(indexFile);
-        } catch (InterruptedException e)
+        }
+        catch (InterruptedException e)
         {
             status = -1;
             logger.error("Failed to get write permission on index.", e);

--- a/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsCacheWriter.java
+++ b/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsCacheWriter.java
@@ -235,16 +235,14 @@ public class PixelsCacheWriter
         {
             // get the caching file list
             String key = Constants.CACHE_LOCATION_LITERAL + version + "_" + host;
-            logger.info("pixels cache writer get cache plan, key=" + key);
             KeyValue keyValue = etcdUtil.getKeyValue(key);
             if (keyValue == null)
             {
-                logger.info("Found no allocated files. No updates are needed. " + key);
+                logger.warn("Found no allocated files, no updates are performed, key=" + key);
                 return 0;
             }
             String fileStr = keyValue.getValue().toString(StandardCharsets.UTF_8);
             String[] files = fileStr.split(";");
-            logger.info("files to cache: " + fileStr);
             return internalUpdateAll(version, layout, files);
         }
         catch (IOException e)
@@ -367,8 +365,11 @@ public class PixelsCacheWriter
             PixelsPhysicalReader pixelsPhysicalReader = new PixelsPhysicalReader(storage, file);
             if(pixelsPhysicalReader.getRowGroupNum() < rowGroupNumInLayout)
             {
-                // TODO: Now the strategy for handling incomplete files is discarding them directly. This may lead to certain column chunks not being read into the cache as expected.
-                logger.warn(rowGroupNumInLayout + " row groups are required for cache, but only " + pixelsPhysicalReader.getRowGroupNum() + " row groups are found in " + file + ". This file will be ignored.");
+                // TODO: Now the strategy for handling incomplete files is discarding them directly.
+                //  This may lead to certain column chunks not being read into the cache as expected.
+                logger.warn(rowGroupNumInLayout + " row groups are required for cache, but only " +
+                        pixelsPhysicalReader.getRowGroupNum() + " row groups are found in " +
+                        file + ". This file will be ignored.");
                 continue;
             }
             int physicalLen;
@@ -397,7 +398,8 @@ public class PixelsCacheWriter
                     byte[] columnChunk = pixelsPhysicalReader.read(physicalOffset, physicalLen);
                     cacheFile.setBytes(currCacheOffset, columnChunk);
                     logger.debug(
-                            "Cache write: " + file + "-" + rowGroupId + "-" + columnId + ", offset: " + currCacheOffset + ", length: " + columnChunk.length);
+                            "Cache write: " + file + "-" + rowGroupId + "-" + columnId + ", offset: " +
+                                    currCacheOffset + ", length: " + columnChunk.length);
                     currCacheOffset += physicalLen;
                 }
             }
@@ -463,11 +465,15 @@ public class PixelsCacheWriter
             PixelsPhysicalReader physicalReader = new PixelsPhysicalReader(storage, file);
             if(physicalReader.getRowGroupNum() < rowGroupNumInLayout)
             {
-                // TODO: Now the strategy for handling incomplete files is discarding them directly. This may lead to certain column chunks not being read into the cache as expected.
-                logger.warn(rowGroupNumInLayout + " row groups are required for cache, but only " + physicalReader.getRowGroupNum() + " row groups are found in " + file + ". This file was ignored before.");
+                // TODO: Now the strategy for handling incomplete files is discarding them directly.
+                //  This may lead to certain column chunks not being read into the cache as expected.
+                logger.warn(rowGroupNumInLayout + " row groups are required for cache, but only " +
+                        physicalReader.getRowGroupNum() + " row groups are found in " +
+                        file + ". This file was ignored before.");
                 continue;
             }
-            // TODO: in case of block id was changed, the survived column chunks in this block can not survive in the cache update.
+            // TODO: in case of block id was changed,
+            //  the survived column chunks in this block can not survive in the cache update.
             // This problem only affects the efficiency, but it is better to resolve it.
             long blockId = physicalReader.getCurrentBlockId();
             for (String survivedColumnChunk : survivedColumnChunks)
@@ -543,8 +549,11 @@ public class PixelsCacheWriter
             PixelsPhysicalReader pixelsPhysicalReader = new PixelsPhysicalReader(storage, file);
             if(pixelsPhysicalReader.getRowGroupNum() < rowGroupNumInLayout)
             {
-                // TODO: Now the strategy for handling incomplete files is discarding them directly. This may lead to certain column chunks not being read into the cache as expected.
-                logger.warn(rowGroupNumInLayout + " row groups are required for cache, but only " + pixelsPhysicalReader.getRowGroupNum() + " row groups are found in " + file + ". This file will be ignored.");
+                // TODO: Now the strategy for handling incomplete files is discarding them directly.
+                //  This may lead to certain column chunks not being read into the cache as expected.
+                logger.warn(rowGroupNumInLayout + " row groups are required for cache, but only " +
+                        pixelsPhysicalReader.getRowGroupNum() + " row groups are found in " +
+                        file + ". This file will be ignored.");
                 continue;
             }
             int physicalLen;

--- a/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/cache/CacheCoordinator.java
+++ b/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/cache/CacheCoordinator.java
@@ -297,8 +297,7 @@ public class CacheCoordinator implements Server
             HostAddress node = nodes[i];
             Set<String> files = cacheLocationDistribution.getCacheDistributionByLocation(node.toString());
             String key = Constants.CACHE_LOCATION_LITERAL + layoutVersion + "_" + node;
-            logger.info(files.size() + " files are allocated to " + node + " at version" + layoutVersion);
-            logger.info("coordinator put cache plan, key=" + key + ", value=" + String.join(";", files));
+            logger.debug(files.size() + " files are allocated to " + node + " at layout version" + layoutVersion);
             EtcdUtil.Instance().putKeyValue(key, String.join(";", files));
         }
     }

--- a/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/cache/CacheCoordinator.java
+++ b/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/cache/CacheCoordinator.java
@@ -249,7 +249,7 @@ public class CacheCoordinator implements Server
                     NodeStatus.READY.StatusCode)
             {
                 hosts[hostIndex++] = HostAddress.fromString(node.getKey()
-                        .toString(StandardCharsets.UTF_8).substring(5));
+                        .toString(StandardCharsets.UTF_8).substring(Constants.HEARTBEAT_WORKER_LITERAL.length()));
             }
         }
         allocate(paths, hosts, hostIndex, layoutVersion);

--- a/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/cache/CacheCoordinator.java
+++ b/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/cache/CacheCoordinator.java
@@ -297,7 +297,8 @@ public class CacheCoordinator implements Server
             HostAddress node = nodes[i];
             Set<String> files = cacheLocationDistribution.getCacheDistributionByLocation(node.toString());
             String key = Constants.CACHE_LOCATION_LITERAL + layoutVersion + "_" + node;
-            logger.debug(files.size() + " files are allocated to " + node + " at version" + layoutVersion);
+            logger.info(files.size() + " files are allocated to " + node + " at version" + layoutVersion);
+            logger.info("coordinator put cache plan, key=" + key + ", value=" + String.join(";", files));
             EtcdUtil.Instance().putKeyValue(key, String.join(";", files));
         }
     }

--- a/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/cache/CacheWorker.java
+++ b/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/cache/CacheWorker.java
@@ -151,12 +151,12 @@ public class CacheWorker implements Server
             int status = 0;
             if (cacheWriter.isCacheEmpty())
             {
-                logger.info("update all...");
+                logger.debug("Cache update all for layout version " + version);
                 status = cacheWriter.updateAll(version, matchedLayout);
             }
             else
             {
-                logger.info("update incremental...");
+                logger.debug("Cache update incremental for layout version " + version);
                 status = cacheWriter.updateIncremental(version, matchedLayout);
             }
             cacheStatus.set(status);
@@ -197,11 +197,12 @@ public class CacheWorker implements Server
                             if (cacheStatus.get() == CacheWorkerStatus.READY.StatusCode)
                             {
                                 // Ready to update the local cache.
-                                logger.info("Cache version update detected, new global version is (" + version + ").");
+                                logger.debug("Cache version update detected, new global version is (" + version + ").");
                                 if (version > localCacheVersion)
                                 {
                                     // The new version is newer, update the local cache.
-                                    logger.info("New global version is greater than the local version, update the local cache.");
+                                    logger.debug("New global cache version " + version + " is greater than the local version " +
+                                            localCacheVersion + ", update the local cache.");
                                     try
                                     {
                                         updateLocalCache(version);
@@ -212,12 +213,13 @@ public class CacheWorker implements Server
                                 }
                                 else
                                 {
-                                    logger.info("new global version " + version + " is equal to or less than the local version " + localCacheVersion);
+                                    logger.debug("New global cache version " + version + " is equal to or less than the local version " +
+                                            localCacheVersion);
                                 }
                             } else if (cacheStatus.get() == CacheWorkerStatus.UPDATING.StatusCode)
                             {
                                 // The local cache is updating, ignore the new version.
-                                logger.info("The local cache is updating for version (" + localCacheVersion + "), " +
+                                logger.warn("The local cache is updating for version (" + localCacheVersion + "), " +
                                         "ignore the new cache version (" + version + ").");
                             } else
                             {

--- a/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/cache/CacheWorker.java
+++ b/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/cache/CacheWorker.java
@@ -140,8 +140,7 @@ public class CacheWorker implements Server
         }
     }
 
-    private void updateLocalCache(int version)
-            throws MetadataException
+    private void updateLocalCache(int version) throws MetadataException
     {
         Layout matchedLayout = metadataService.getLayout(cacheConfig.getSchema(), cacheConfig.getTable(), version);
         if (matchedLayout != null)
@@ -152,10 +151,12 @@ public class CacheWorker implements Server
             int status = 0;
             if (cacheWriter.isCacheEmpty())
             {
+                logger.info("update all...");
                 status = cacheWriter.updateAll(version, matchedLayout);
             }
             else
             {
+                logger.info("update incremental...");
                 status = cacheWriter.updateIncremental(version, matchedLayout);
             }
             cacheStatus.set(status);
@@ -196,11 +197,11 @@ public class CacheWorker implements Server
                             if (cacheStatus.get() == CacheWorkerStatus.READY.StatusCode)
                             {
                                 // Ready to update the local cache.
-                                logger.debug("Cache version update detected, new global version is (" + version + ").");
+                                logger.info("Cache version update detected, new global version is (" + version + ").");
                                 if (version > localCacheVersion)
                                 {
                                     // The new version is newer, update the local cache.
-                                    logger.debug("New global version is greater than the local version, update the local cache.");
+                                    logger.info("New global version is greater than the local version, update the local cache.");
                                     try
                                     {
                                         updateLocalCache(version);
@@ -209,10 +210,14 @@ public class CacheWorker implements Server
                                         logger.error("Failed to update local cache.", e);
                                     }
                                 }
+                                else
+                                {
+                                    logger.info("new global version " + version + " is equal to or less than the local version " + localCacheVersion);
+                                }
                             } else if (cacheStatus.get() == CacheWorkerStatus.UPDATING.StatusCode)
                             {
                                 // The local cache is updating, ignore the new version.
-                                logger.warn("The local cache is updating for version (" + localCacheVersion + "), " +
+                                logger.info("The local cache is updating for version (" + localCacheVersion + "), " +
                                         "ignore the new cache version (" + version + ").");
                             } else
                             {


### PR DESCRIPTION
This issue is not due to the heartbeat service problem. It is caused by the wrong worker node hostnames in the CacheCoordinator.updateCachePlan().