### PR TITLE
[Issue #724] update configurations and docs for pixels-cache

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -304,9 +304,9 @@ Then we get three dashboards `Node Exporter` and `JVM Exporter` in Grafana.
 These dashboards can be used to monitor the performance metrics of the instance.
 
 ## Start Pixels
-Enter `PIXELS_HOME`, execute `./sbin/reset-cache.sh` for the first time of starting Pixels if pixels-cache is enabled.
+Enter `PIXELS_HOME`, follow the [pixels-cache document](../pixels-cache/README.md) to configure and start Pixels if pixels-cache is enabled.
 
-Then, start the daemons of Pixels using:
+If pixels-cache is not enabled, directly start the daemons of Pixels using:
 ```bash
 ./sbin/start-pixels.sh
 ```

--- a/pixels-cache/README.md
+++ b/pixels-cache/README.md
@@ -20,6 +20,16 @@ The cache is read and updated as follows:
 5. Each Presto/Trino WorkerNode executes query splits with caching information (whether the column chunks in the query split are cached or not), and calls `PixelsCacheReader` to read the cached column chunks locally (if any).
 
 ## Installation
+
+### Install vmtouch
+Find `vmtouch-1.3.1.tar.xz` in `scripts/tars` under the Pixels source code folder and decompress it to anywhere.
+Enter the decompressed folder, run:
+```bash
+make install
+```
+to build and install vmtouch to the operating system.
+
+### Install Pixels
 Install Pixels following the instructions [HERE](../docs/INSTALL.md), but do not start Pixels before finishing the following configurations.
 
 Check the following settings related to pixels-cache in `$PIXELS_HOME/pixels.properties` on each node:
@@ -53,6 +63,7 @@ heartbeat.period.seconds=10
 The above values are a good default setting for each node to cache up-to 64GB data of table `pixels.test_105` stored on `HDFS`.
 Change the `cache.schema`, `cache.table`, and `cache.storage.scheme` to cache a different table that is stored in a different storage system.
 
+### Mount In-memory File System
 On each worker node, create and mount an in-memory file system with 65GB capacity:
 ```bash
 sudo mkdir -p /mnt/ramfs
@@ -67,7 +78,8 @@ Set up the cache before starting Pixels:
 ```
 `reset-cache.sh` is only needed for the first time of initializing pixels-cache.
 It initializes some states in etcd for the cache.
-If you have modified the `etcd` urls, please change the `ENDPOINTS` property in `reset-cache.sh` as well.
+If you have modified the `etcd` hostname and port in `$PIXELS_HOME/pixels.properties`, change the `ENDPOINTS` property
+in `reset-cache.sh` as well.
 
 ## Start Pixels (with cache)
 
@@ -89,12 +101,16 @@ On each worker node, pin the cache in memory using:
 ```bash
 sudo -E ./sbin/pin-cache.sh
 ```
+Modify `CACHE_PATH` if it is not consistent with the mount point of the in-memory file system storing
+the cache and index files.
 
 Then create a new data layout for the cached table, and update `layout_version` of the cached table in etcd to trigger 
 cache loading or replacement:
 ```bash
 ./sbin/load-cache.sh {layout-version}
 ```
+If you have modified the `etcd` hostname and port in `$PIXELS_HOME/pixels.properties`, change the `ENDPOINTS` property
+in `load-cache.sh` as well.
 
 To stop Pixels, run:
 ```bash

--- a/pixels-cache/README.md
+++ b/pixels-cache/README.md
@@ -70,16 +70,22 @@ If you have modified the `etcd` urls, please change the `ENDPOINTS` property in 
 
 ## Start Pixels (with Cache)
 
-Instead of starting all Pixels daemons on the same (single) node using `$PIXELS_HOME/sbin/start-pixels.sh`,
-start the `PixelsCoordinator` daemon that hosts cache coordinator on the master node,
-and start the `PixelsWorker` daemon that hosts cache manager on each worker node.
+Enter `PIXELS_HOME` and start all Pixels daemons using:
+```bash
+./sbin/start-pixels.sh
+```
+If starting the daemons in a cluster of multiple nodes, set the hostnames of the worker nodes in `$PIXELS_HOME/sbin/workers`
+and run `start-pixels.sh` on the coordinator node.
 
 On each worker node, pin the cache in memory using:
 ```bash
-sudo ./sbin/pin-cache.sh
+sudo -E ./sbin/pin-cache.sh
 ```
 
-Then create a new data layout for the cached table, and update `layout_version` in Etcd to trigger cache building or replacement.
+Then create a new data layout for the cached table, and update `layout_version` in Etcd to trigger cache building or replacement:
+```bash
+./sbin/load-cache.sh {layout-version}
+```
 
-To stop Pixels, run `$PIXELS_HOME/sbin/stop-pixels.sh` to stop Pixels daemons on each node, and run `$PIXELS_HOME/sbin/unpin-cache.sh` to release the memory that is
-pinned by the cache on each worker node.
+To stop Pixels, run `./sbin/stop-pixels.sh` to stop all Pixels daemons on the coordinator node, 
+and run `sudo -E ./sbin/unpin-cache.sh` to release the memory pinned for the cache on each worker node.

--- a/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsCacheConfig.java
+++ b/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsCacheConfig.java
@@ -84,7 +84,7 @@ public class PixelsCacheConfig
 
     public int getNodeLeaseTTL()
     {
-        int ttl = Integer.parseInt(configFactory.getProperty("lease.ttl.seconds"));
+        int ttl = Integer.parseInt(configFactory.getProperty("heartbeat.lease.ttl.seconds"));
         int heartbeat = Integer.parseInt(configFactory.getProperty("heartbeat.period.seconds"));
         checkArgument(ttl > heartbeat);
         return ttl;

--- a/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsCacheWriter.java
+++ b/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsCacheWriter.java
@@ -350,7 +350,7 @@ public class PixelsCacheWriter
         radix.removeAll();
         long currCacheOffset = PixelsCacheUtil.CACHE_DATA_OFFSET;
         boolean enableAbsoluteBalancer = Boolean.parseBoolean(
-                ConfigFactory.Instance().getProperty("enable.absolute.balancer"));
+                ConfigFactory.Instance().getProperty("cache.absolute.balancer.enabled"));
         int rowGroupNumInLayout = compact.getNumRowGroupInFile();
         outer_loop:
         for (String file : files)
@@ -530,7 +530,7 @@ public class PixelsCacheWriter
         logger.debug("Start cache append...");
         List<PixelsCacheEntry> newIdxes = new ArrayList<>();
         boolean enableAbsoluteBalancer = Boolean.parseBoolean(
-                ConfigFactory.Instance().getProperty("enable.absolute.balancer"));
+                ConfigFactory.Instance().getProperty("cache.absolute.balancer.enabled"));
         outer_loop:
         for (String file : files)
         {

--- a/pixels-cache/src/test/java/io/pixelsdb/pixels/cache/BenchmarkCacheIndexReader.java
+++ b/pixels-cache/src/test/java/io/pixelsdb/pixels/cache/BenchmarkCacheIndexReader.java
@@ -191,9 +191,9 @@ public class BenchmarkCacheIndexReader {
         config.addProperty("cache.storage.scheme", "mock"); // 100 MiB
         config.addProperty("cache.schema", "pixels");
         config.addProperty("cache.table", "test_mock");
-        config.addProperty("lease.ttl.seconds", "20");
+        config.addProperty("heartbeat.lease.ttl.seconds", "20");
         config.addProperty("heartbeat.period.seconds", "10");
-        config.addProperty("enable.absolute.balancer", "false");
+        config.addProperty("cache.absolute.balancer.enabled", "false");
         config.addProperty("cache.enabled", "true");
         config.addProperty("enabled.storage.schemes", "mock");
         PixelsCacheConfig cacheConfig = new PixelsCacheConfig();
@@ -237,9 +237,9 @@ public class BenchmarkCacheIndexReader {
         config.addProperty("cache.storage.scheme", "mock"); // 100 MiB
         config.addProperty("cache.schema", "pixels");
         config.addProperty("cache.table", "test_mock");
-        config.addProperty("lease.ttl.seconds", "20");
+        config.addProperty("heartbeat.lease.ttl.seconds", "20");
         config.addProperty("heartbeat.period.seconds", "10");
-        config.addProperty("enable.absolute.balancer", "false");
+        config.addProperty("cache.absolute.balancer.enabled", "false");
         config.addProperty("cache.enabled", "true");
         config.addProperty("enabled.storage.schemes", "mock");
         PixelsCacheConfig cacheConfig = new PixelsCacheConfig();
@@ -285,9 +285,9 @@ public class BenchmarkCacheIndexReader {
         config.addProperty("cache.storage.scheme", "mock"); // 100 MiB
         config.addProperty("cache.schema", "pixels");
         config.addProperty("cache.table", "test_mock");
-        config.addProperty("lease.ttl.seconds", "20");
+        config.addProperty("heartbeat.lease.ttl.seconds", "20");
         config.addProperty("heartbeat.period.seconds", "10");
-        config.addProperty("enable.absolute.balancer", "false");
+        config.addProperty("cache.absolute.balancer.enabled", "false");
         config.addProperty("cache.enabled", "true");
         config.addProperty("enabled.storage.schemes", "mock");
         PixelsCacheConfig cacheConfig = new PixelsCacheConfig();
@@ -348,9 +348,9 @@ public class BenchmarkCacheIndexReader {
         config.addProperty("cache.storage.scheme", "mock"); // 100 MiB
         config.addProperty("cache.schema", "pixels");
         config.addProperty("cache.table", "test_mock");
-        config.addProperty("lease.ttl.seconds", "20");
+        config.addProperty("heartbeat.lease.ttl.seconds", "20");
         config.addProperty("heartbeat.period.seconds", "10");
-        config.addProperty("enable.absolute.balancer", "false");
+        config.addProperty("cache.absolute.balancer.enabled", "false");
         config.addProperty("cache.enabled", "true");
         config.addProperty("enabled.storage.schemes", "mock");
         PixelsCacheConfig cacheConfig = new PixelsCacheConfig();
@@ -394,9 +394,9 @@ public class BenchmarkCacheIndexReader {
         config.addProperty("cache.storage.scheme", "mock"); // 100 MiB
         config.addProperty("cache.schema", "pixels");
         config.addProperty("cache.table", "test_mock");
-        config.addProperty("lease.ttl.seconds", "20");
+        config.addProperty("heartbeat.lease.ttl.seconds", "20");
         config.addProperty("heartbeat.period.seconds", "10");
-        config.addProperty("enable.absolute.balancer", "false");
+        config.addProperty("cache.absolute.balancer.enabled", "false");
         config.addProperty("cache.enabled", "true");
         config.addProperty("enabled.storage.schemes", "mock");
         PixelsCacheConfig cacheConfig = new PixelsCacheConfig();
@@ -437,9 +437,9 @@ public class BenchmarkCacheIndexReader {
         config.addProperty("cache.storage.scheme", "mock"); // 100 MiB
         config.addProperty("cache.schema", "pixels");
         config.addProperty("cache.table", "test_mock");
-        config.addProperty("lease.ttl.seconds", "20");
+        config.addProperty("heartbeat.lease.ttl.seconds", "20");
         config.addProperty("heartbeat.period.seconds", "10");
-        config.addProperty("enable.absolute.balancer", "false");
+        config.addProperty("cache.absolute.balancer.enabled", "false");
         config.addProperty("cache.enabled", "true");
         config.addProperty("enabled.storage.schemes", "mock");
         PixelsCacheConfig cacheConfig = new PixelsCacheConfig();

--- a/pixels-cache/src/test/java/io/pixelsdb/pixels/cache/BenchmarkCacheReader.java
+++ b/pixels-cache/src/test/java/io/pixelsdb/pixels/cache/BenchmarkCacheReader.java
@@ -94,9 +94,9 @@ public class BenchmarkCacheReader {
         config.addProperty("cache.storage.scheme", "mock"); // 100 MiB
         config.addProperty("cache.schema", "pixels");
         config.addProperty("cache.table", "test_mock");
-        config.addProperty("lease.ttl.seconds", "20");
+        config.addProperty("heartbeat.lease.ttl.seconds", "20");
         config.addProperty("heartbeat.period.seconds", "10");
-        config.addProperty("enable.absolute.balancer", "false");
+        config.addProperty("cache.absolute.balancer.enabled", "false");
         config.addProperty("cache.enabled", "true");
         config.addProperty("enabled.storage.schemes", "mock");
 

--- a/pixels-cache/src/test/java/io/pixelsdb/pixels/cache/TestPartitionCacheReader.java
+++ b/pixels-cache/src/test/java/io/pixelsdb/pixels/cache/TestPartitionCacheReader.java
@@ -90,9 +90,9 @@ public class TestPartitionCacheReader {
         config.addProperty("cache.storage.scheme", "mock"); // 100 MiB
         config.addProperty("cache.schema", "pixels");
         config.addProperty("cache.table", "test_mock");
-        config.addProperty("lease.ttl.seconds", "20");
+        config.addProperty("heartbeat.lease.ttl.seconds", "20");
         config.addProperty("heartbeat.period.seconds", "10");
-        config.addProperty("enable.absolute.balancer", "false");
+        config.addProperty("cache.absolute.balancer.enabled", "false");
         config.addProperty("cache.enabled", "true");
         config.addProperty("enabled.storage.schemes", "mock");
 

--- a/pixels-cache/src/test/java/io/pixelsdb/pixels/cache/TestPartitionCacheWriter.java
+++ b/pixels-cache/src/test/java/io/pixelsdb/pixels/cache/TestPartitionCacheWriter.java
@@ -94,9 +94,9 @@ public class TestPartitionCacheWriter {
         config.addProperty("cache.storage.scheme", "mock"); // 100 MiB
         config.addProperty("cache.schema", "pixels");
         config.addProperty("cache.table", "test_mock");
-        config.addProperty("lease.ttl.seconds", "20");
+        config.addProperty("heartbeat.lease.ttl.seconds", "20");
         config.addProperty("heartbeat.period.seconds", "10");
-        config.addProperty("enable.absolute.balancer", "false");
+        config.addProperty("cache.absolute.balancer.enabled", "false");
         config.addProperty("cache.enabled", "true");
         config.addProperty("enabled.storage.schemes", "mock");
 

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/balance/AbsoluteBalancer.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/balance/AbsoluteBalancer.java
@@ -28,6 +28,8 @@ import java.util.*;
 import static java.util.Objects.requireNonNull;
 
 /**
+ * Ensure the allocation of file paths to nodes is absolutely balanced while ensuring the data
+ * locality at best effort.
  * @author hank
  * @create 2019-07-28
  */
@@ -104,7 +106,7 @@ public class AbsoluteBalancer extends Balancer
 
         boolean balanced = false;
 
-        while (balanced == false)
+        while (!balanced)
         {
             // we try to move elements from peaks to valleys.
             if (peak.isEmpty() || valley.isEmpty())
@@ -140,9 +142,9 @@ public class AbsoluteBalancer extends Balancer
             balanced = this.isBalanced();
         }
 
-        if (peak.isEmpty() == false && balanced == false)
+        if (!peak.isEmpty() && !balanced)
         {
-            if (valley.isEmpty() == false)
+            if (!valley.isEmpty())
             {
                 throw new BalancerException("vally is not empty in the final balancing stage.");
             }
@@ -155,7 +157,7 @@ public class AbsoluteBalancer extends Balancer
                 }
             }
 
-            while (balanced == false)
+            while (!balanced)
             {
                 // we try to move elements from peaks to valleys.
                 if (peak.isEmpty() || valley.isEmpty())

--- a/pixels-common/src/main/resources/pixels.properties
+++ b/pixels-common/src/main/resources/pixels.properties
@@ -52,16 +52,18 @@ cache.storage.scheme=hdfs
 cache.schema=pixels
 # which table to be cached
 cache.table=test_105
-# lease ttl must be larger than heartbeat period
-lease.ttl.seconds=20
-# heartbeat period must be larger than 0
-heartbeat.period.seconds=10
-# set to false if storage.scheme is S3
-enable.absolute.balancer=false
+# set to true if cache.storage.scheme is a locality sensitive storage such as hdfs
+cache.absolute.balancer.enabled=false
 # set to true to enable pixels-cache
 cache.enabled=false
 # set to true to read cache without memory copy
 cache.read.direct=false
+
+###### pixels-heartbeat settings ######
+# heartbeat lease ttl must be larger than heartbeat period
+heartbeat.lease.ttl.seconds=20
+# heartbeat period must be larger than 0
+heartbeat.period.seconds=10
 
 ###### storage engine settings ######
 

--- a/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/cache/CacheCoordinator.java
+++ b/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/cache/CacheCoordinator.java
@@ -339,7 +339,7 @@ public class CacheCoordinator implements Server
             if (replicaBalancer.isBalanced())
             {
                 boolean enableAbsolute = Boolean.parseBoolean(
-                        ConfigFactory.Instance().getProperty("enable.absolute.balancer"));
+                        ConfigFactory.Instance().getProperty("cache.absolute.balancer.enabled"));
                 if (enableAbsolute)
                 {
                     Balancer absoluteBalancer = new AbsoluteBalancer();

--- a/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/heartbeat/HeartbeatConfig.java
+++ b/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/heartbeat/HeartbeatConfig.java
@@ -37,7 +37,7 @@ public class HeartbeatConfig
 
     public int getNodeLeaseTTL()
     {
-        int ttl = Integer.parseInt(configFactory.getProperty("lease.ttl.seconds"));
+        int ttl = Integer.parseInt(configFactory.getProperty("heartbeat.lease.ttl.seconds"));
         int heartbeat = Integer.parseInt(configFactory.getProperty("heartbeat.period.seconds"));
         checkArgument(ttl > heartbeat);
         return ttl;

--- a/scripts/bin/start-vmtouch.sh
+++ b/scripts/bin/start-vmtouch.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-echo "Start vmtouch."
-
 NUMA_INTERLEAVE=""
 if type numactl >/dev/null 2>&1; then
   NUMA_INTERLEAVE="numactl --interleave=all"
@@ -13,3 +11,5 @@ CACHE_PATH="/mnt/ramfs"
 
 ${NUMA_INTERLEAVE} vmtouch -vt ${CACHE_PATH}/pixels.*
 ${NUMA_INTERLEAVE} vmtouch -dl ${CACHE_PATH}
+
+echo "vmtouch is up and running."

--- a/scripts/bin/stop-vmtouch.sh
+++ b/scripts/bin/stop-vmtouch.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-echo "Stop vmtouch."
-
 kill $(pidof vmtouch)
+
+echo "vmtouch is stopped."


### PR DESCRIPTION
1. rename `lease.ttl.seconds` and `enable.absolute.balancer` to `heartbeat.lease.ttl.seconds` and `cache.absolute.balancer.enabled`, respectively.
2. Revise the document for pixels cache, add vmtouch installation, and make it consistent with the code.
3. minor revision of the code and scripts.