### PR TITLE
[Issue #636] remove cache schema and table from config file and fix memory leak in cache writer

### DIFF
--- a/pixels-cache/README.md
+++ b/pixels-cache/README.md
@@ -8,14 +8,14 @@ Whereas the cache manager on each worker node listens to the update of the cache
 
 ## How It Works
 The cache plan is stored in etcd and have the following data model:
-1. layout_version -> version: data layout version, incremented each time new data layouts are created.
-2. cache_version -> version: caching version, incremented each time caches are updated.
-3. cache_location_%{version}_%{node_id} -> files: recording the array of files cached on the specified node (cache manager) under the specified caching version.
+1. layout_version -> {schema_name}.{table_name}:{layout_version}: data layout version, updated by the user or program that want to trigger cache loading or replacement. Only increasing layout versions are accepted.
+2. cache_version -> {schema_name}.{table_name}:{layout_version}: cache version, set by the cache coordinator to notify the cache workers for cache loading or replacement when the cache tasks are ready in etcd.
+3. cache_location_{layout_version}_{worker_hostname} -> files: recording the array of files cached on the specified node (cache manager) under the specified caching version.
 
 The cache is read and updated as follows:
 1. When the `layout optimizer` generates a new layout, it writes the new layout (with a new `layout_version`) into Etcd.
-2. The `cache coordinator` constantly checks the value of `layout_version`, once it finds a newer `layout_version`, it allocates a new version of cache plan in Etcd, then updates the `cache_version` to the latest `layout_version`.
-3. Once a cache manager finds a new `cache_version`, it begins to read the new cache plan and finds the new column chunks to be cached by itself, and sets itself as `busy` in Etcd.
+2. The `cache coordinator` monitors the new values of `layout_version`, once it finds a newer `layout_version`, it creates the corresponding cache tasks for each cache worker in Etcd, then updates the `cache_version` to the latest `layout_version`.
+3. The `cache workers` monitor `cache_version`. When a cache worker finds a new `cache_version`, it reads its cache task from `cache_location_{layout_version}_{worker_hostname}` and sets itself to `busy` to avoid concurrent cache updating. After than, the cache worker begins to load or replace the cache content.
 4. When a query comes, Presto/Trino Coordinator checks Etcd for the cache plan, thus find available caches for its query splits.
 5. Each Presto/Trino WorkerNode executes query splits with caching information (whether the column chunks in the query split are cached or not), and calls `PixelsCacheReader` to read the cached column chunks locally (if any).
 

--- a/pixels-cache/README.md
+++ b/pixels-cache/README.md
@@ -68,14 +68,6 @@ sudo mount -t tmpfs -o size=65g tmpfs /mnt/ramfs
 The `size` parameter of the mount command should be larger than or equal to the sum of `cache.size` and `index.size` in
 `PIXELS_HOME/pixels.properties`, but must be smaller than the available physical memory size.
 
-Set up the cache before starting Pixels:
-```bash
-./sbin/reset-cache.sh
-```
-`reset-cache.sh` is only needed for the first time of initializing pixels-cache.
-It initializes some states in etcd for the cache.
-If you have modified the `etcd` hostname and port in `$PIXELS_HOME/pixels.properties`, change the `ENDPOINTS` property
-in `reset-cache.sh` as well.
 
 ## Start Pixels (with cache)
 
@@ -117,14 +109,29 @@ Currently, we only cache the full compact files with the same number of row grou
 If you have modified the `etcd` hostname and port in `$PIXELS_HOME/pixels.properties`, change the `ENDPOINTS` property
 in `load-cache.sh` as well.
 
+## Stop Pixels and clear cache
 To stop Pixels, run:
 ```bash
 ./sbin/stop-pixels.sh
 ```
-on the coordinator node to stop all Pixels daemons in the cluster. Then, run:
+on the coordinator node to stop all Pixels daemons in the cluster.
+
+The cache does not lost when Pixels is stopped. And it can be reused the next time Pixels is started.
+
+To clear the cache and free the memory, run:
 ```bash
 sudo -E ./sbin/unpin-cache.sh
 ```
 on each worker node to release the memory pinned for the cache.
 After than, you can delete the shared-memory files at `cache.location` and `index.location` on each worker node to
 finally release the memory occupied by the cache.
+You can also umount the in-memory file system. This is optional. The in-memory file system will be
+automatically umount when the operating system is restarted.
+
+Then, run:
+```bash
+./sbin/reset-cache.sh
+```
+on any node in the cluster to reset the states related to pixels-cache in etcd.
+If you have modified the `etcd` hostname and port in `$PIXELS_HOME/pixels.properties`, change the `ENDPOINTS` property
+in `reset-cache.sh` as well.

--- a/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsCacheConfig.java
+++ b/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsCacheConfig.java
@@ -25,6 +25,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 /**
  * @author guodong
+ * @author hank
  */
 public class PixelsCacheConfig
 {
@@ -65,16 +66,6 @@ public class PixelsCacheConfig
     public String getStorageScheme()
     {
          return configFactory.getProperty("cache.storage.scheme");
-    }
-
-    public String getSchema()
-    {
-        return configFactory.getProperty("cache.schema");
-    }
-
-    public String getTable()
-    {
-        return configFactory.getProperty("cache.table");
     }
 
     public String getHDFSConfigDir()

--- a/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsCacheUtil.java
+++ b/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsCacheUtil.java
@@ -31,6 +31,9 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
 /**
  * pixels cache header
  * index:
@@ -510,13 +513,23 @@ public class PixelsCacheUtil
         return cacheFile.getLongVolatile(8);
     }
 
-    public static int hashcode(byte[] bytes) {
+    public static int hashcode(byte[] bytes)
+    {
         int var1 = 1;
 
-        for(int var3 = 0; var3 < bytes.length; ++var3) {
-            var1 = 31 * var1 + bytes[var3];
+        for (byte aByte : bytes)
+        {
+            var1 = 31 * var1 + aByte;
         }
 
         return var1;
+    }
+
+    public static String getHostnameFromCacheLocationLiteral(String cacheLocationLiteral)
+    {
+        String[] splits = requireNonNull(cacheLocationLiteral, "cacheLocationLiteral is null").split("_");
+        checkArgument(splits.length > Constants.HOSTNAME_INDEX_IN_CACHE_LOCATION_LITERAL,
+                "invalid cacheLocationLiteral: " + cacheLocationLiteral);
+        return splits[Constants.HOSTNAME_INDEX_IN_CACHE_LOCATION_LITERAL];
     }
 }

--- a/pixels-cache/src/test/java/io/pixelsdb/pixels/cache/BenchmarkCacheIndexReader.java
+++ b/pixels-cache/src/test/java/io/pixelsdb/pixels/cache/BenchmarkCacheIndexReader.java
@@ -189,8 +189,6 @@ public class BenchmarkCacheIndexReader {
         config.addProperty("index.size", String.valueOf(100 * 1024 * 1024)); // 100 MiB
 
         config.addProperty("cache.storage.scheme", "mock"); // 100 MiB
-        config.addProperty("cache.schema", "pixels");
-        config.addProperty("cache.table", "test_mock");
         config.addProperty("heartbeat.lease.ttl.seconds", "20");
         config.addProperty("heartbeat.period.seconds", "10");
         config.addProperty("cache.absolute.balancer.enabled", "false");
@@ -235,8 +233,6 @@ public class BenchmarkCacheIndexReader {
         config.addProperty("index.size", String.valueOf(100 * 1024 * 1024)); // 100 MiB
 
         config.addProperty("cache.storage.scheme", "mock"); // 100 MiB
-        config.addProperty("cache.schema", "pixels");
-        config.addProperty("cache.table", "test_mock");
         config.addProperty("heartbeat.lease.ttl.seconds", "20");
         config.addProperty("heartbeat.period.seconds", "10");
         config.addProperty("cache.absolute.balancer.enabled", "false");
@@ -283,8 +279,6 @@ public class BenchmarkCacheIndexReader {
         config.addProperty("index.size", String.valueOf(100 * 1024 * 1024)); // 100 MiB
 
         config.addProperty("cache.storage.scheme", "mock"); // 100 MiB
-        config.addProperty("cache.schema", "pixels");
-        config.addProperty("cache.table", "test_mock");
         config.addProperty("heartbeat.lease.ttl.seconds", "20");
         config.addProperty("heartbeat.period.seconds", "10");
         config.addProperty("cache.absolute.balancer.enabled", "false");
@@ -346,8 +340,6 @@ public class BenchmarkCacheIndexReader {
         config.addProperty("index.size", String.valueOf(100 * 1024 * 1024)); // 100 MiB
 
         config.addProperty("cache.storage.scheme", "mock"); // 100 MiB
-        config.addProperty("cache.schema", "pixels");
-        config.addProperty("cache.table", "test_mock");
         config.addProperty("heartbeat.lease.ttl.seconds", "20");
         config.addProperty("heartbeat.period.seconds", "10");
         config.addProperty("cache.absolute.balancer.enabled", "false");
@@ -392,8 +384,6 @@ public class BenchmarkCacheIndexReader {
         config.addProperty("index.size", String.valueOf(100 * 1024 * 1024)); // 100 MiB
 
         config.addProperty("cache.storage.scheme", "mock"); // 100 MiB
-        config.addProperty("cache.schema", "pixels");
-        config.addProperty("cache.table", "test_mock");
         config.addProperty("heartbeat.lease.ttl.seconds", "20");
         config.addProperty("heartbeat.period.seconds", "10");
         config.addProperty("cache.absolute.balancer.enabled", "false");
@@ -435,8 +425,6 @@ public class BenchmarkCacheIndexReader {
         config.addProperty("index.size", String.valueOf(100 * 1024 * 1024)); // 100 MiB
 
         config.addProperty("cache.storage.scheme", "mock"); // 100 MiB
-        config.addProperty("cache.schema", "pixels");
-        config.addProperty("cache.table", "test_mock");
         config.addProperty("heartbeat.lease.ttl.seconds", "20");
         config.addProperty("heartbeat.period.seconds", "10");
         config.addProperty("cache.absolute.balancer.enabled", "false");

--- a/pixels-cache/src/test/java/io/pixelsdb/pixels/cache/BenchmarkCacheReader.java
+++ b/pixels-cache/src/test/java/io/pixelsdb/pixels/cache/BenchmarkCacheReader.java
@@ -92,8 +92,6 @@ public class BenchmarkCacheReader {
         config.addProperty("index.size", String.valueOf(100 * 1024 * 1024)); // 100 MiB
 
         config.addProperty("cache.storage.scheme", "mock"); // 100 MiB
-        config.addProperty("cache.schema", "pixels");
-        config.addProperty("cache.table", "test_mock");
         config.addProperty("heartbeat.lease.ttl.seconds", "20");
         config.addProperty("heartbeat.period.seconds", "10");
         config.addProperty("cache.absolute.balancer.enabled", "false");

--- a/pixels-cache/src/test/java/io/pixelsdb/pixels/cache/TestPartitionCacheReader.java
+++ b/pixels-cache/src/test/java/io/pixelsdb/pixels/cache/TestPartitionCacheReader.java
@@ -88,8 +88,6 @@ public class TestPartitionCacheReader {
         config.addProperty("index.size", String.valueOf(100 * 1024 * 1024)); // 100 MiB
 
         config.addProperty("cache.storage.scheme", "mock"); // 100 MiB
-        config.addProperty("cache.schema", "pixels");
-        config.addProperty("cache.table", "test_mock");
         config.addProperty("heartbeat.lease.ttl.seconds", "20");
         config.addProperty("heartbeat.period.seconds", "10");
         config.addProperty("cache.absolute.balancer.enabled", "false");

--- a/pixels-cache/src/test/java/io/pixelsdb/pixels/cache/TestPartitionCacheWriter.java
+++ b/pixels-cache/src/test/java/io/pixelsdb/pixels/cache/TestPartitionCacheWriter.java
@@ -92,8 +92,6 @@ public class TestPartitionCacheWriter {
         config.addProperty("index.size", String.valueOf(100 * 1024 * 1024)); // 100 MiB
 
         config.addProperty("cache.storage.scheme", "mock"); // 100 MiB
-        config.addProperty("cache.schema", "pixels");
-        config.addProperty("cache.table", "test_mock");
         config.addProperty("heartbeat.lease.ttl.seconds", "20");
         config.addProperty("heartbeat.period.seconds", "10");
         config.addProperty("cache.absolute.balancer.enabled", "false");

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/metadata/SchemaTableName.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/metadata/SchemaTableName.java
@@ -21,6 +21,9 @@ package io.pixelsdb.pixels.common.metadata;
 
 import com.google.common.base.Objects;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
 /**
  * @author tao
  * @author hank
@@ -33,8 +36,18 @@ public class SchemaTableName
 
     public SchemaTableName(String schemaName, String tableName)
     {
-        this.schemaName = schemaName;
-        this.tableName = tableName;
+        this.schemaName = requireNonNull(schemaName, "schemaName is null");
+        this.tableName = requireNonNull(tableName, "tableName is null");
+    }
+
+    public SchemaTableName(String schemaTableName)
+    {
+        requireNonNull(schemaTableName, "schemaTableName is null");
+        int dot = schemaTableName.indexOf(".");
+        checkArgument(dot > 0 && dot < schemaTableName.length() - 1,
+                "schemaTableName " + schemaTableName + " is invalid");
+        this.schemaName = schemaTableName.substring(0, dot);
+        this.tableName = schemaTableName.substring(dot + 1);
     }
 
     public String getSchemaName()

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/utils/Constants.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/utils/Constants.java
@@ -42,6 +42,7 @@ public final class Constants
     public static final String LAYOUT_VERSION_LITERAL = "layout_version";
     public static final String CACHE_VERSION_LITERAL = "cache_version";
     public static final String CACHE_LOCATION_LITERAL = "cache_location_";
+    public static final int HOSTNAME_INDEX_IN_CACHE_LOCATION_LITERAL = 3;
     public static final String HEARTBEAT_COORDINATOR_LITERAL = "heartbeat_coordinator_";
     public static final String HEARTBEAT_WORKER_LITERAL = "heartbeat_worker_";
 

--- a/pixels-common/src/main/resources/pixels.properties
+++ b/pixels-common/src/main/resources/pixels.properties
@@ -48,10 +48,6 @@ index.location=/mnt/ramfs/pixels.index
 index.size=1073741824
 # the scheme of the storage system to be cached
 cache.storage.scheme=hdfs
-# which schema to be cached
-cache.schema=pixels
-# which table to be cached
-cache.table=test_105
 # set to true if cache.storage.scheme is a locality sensitive storage such as hdfs
 cache.absolute.balancer.enabled=false
 # set to true to enable pixels-cache

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/writer/TestPixelsWriter.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/writer/TestPixelsWriter.java
@@ -316,16 +316,17 @@ public class TestPixelsWriter
                     .build();
             PixelsRecordReader recordReader = pixelsReader.read(option);
             rowBatch = recordReader.readBatch();
-            LongColumnVector nationkeyVector = (LongColumnVector) rowBatch.cols[0];
+            LongColumnVector nationKeyVector = (LongColumnVector) rowBatch.cols[0];
             BinaryColumnVector nameVector = (BinaryColumnVector) rowBatch.cols[1];
-            LongColumnVector regionkeyVector = (LongColumnVector) rowBatch.cols[2];
+            LongColumnVector regionKeyVector = (LongColumnVector) rowBatch.cols[2];
             BinaryColumnVector commentVector = (BinaryColumnVector) rowBatch.cols[3];
             for (int i = 0; i < rowBatch.size; ++i)
             {
                 String name = new String(nameVector.vector[i], nameVector.start[i], nameVector.lens[i]);
                 String comment = new String(commentVector.vector[i], commentVector.start[i], commentVector.lens[i]);
-                System.out.println(nationkeyVector.vector[i] + ", " + name + ", " + regionkeyVector.vector[i] + ", " + comment);
+                System.out.println(nationKeyVector.vector[i] + ", " + name + ", " + regionKeyVector.vector[i] + ", " + comment);
             }
+            pixelsReader.close();
         }
         catch (IOException e)
         {

--- a/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/cache/CacheCoordinator.java
+++ b/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/cache/CacheCoordinator.java
@@ -33,6 +33,7 @@ import io.pixelsdb.pixels.common.balance.ReplicaBalancer;
 import io.pixelsdb.pixels.common.exception.BalancerException;
 import io.pixelsdb.pixels.common.exception.MetadataException;
 import io.pixelsdb.pixels.common.metadata.MetadataService;
+import io.pixelsdb.pixels.common.metadata.SchemaTableName;
 import io.pixelsdb.pixels.common.metadata.domain.File;
 import io.pixelsdb.pixels.common.metadata.domain.Layout;
 import io.pixelsdb.pixels.common.metadata.domain.Path;
@@ -52,6 +53,8 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.concurrent.CountDownLatch;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 /**
  * CacheCoordinator is responsible for the following tasks:
@@ -96,7 +99,8 @@ public class CacheCoordinator implements Server
                     storage = StorageFactory.Instance().getStorage(cacheConfig.getStorageScheme());
                 }
                 // 2. check version consistency
-                int cacheVersion = 0, layoutVersion = 0;
+                int cacheVersion = -1, layoutVersion = -1;
+                SchemaTableName schemaTableName = null;
                 this.metadataService = MetadataService.Instance();
                 KeyValue cacheVersionKV = EtcdUtil.Instance().getKeyValue(Constants.CACHE_VERSION_LITERAL);
                 if (null != cacheVersionKV)
@@ -104,14 +108,22 @@ public class CacheCoordinator implements Server
                     cacheVersion = Integer.parseInt(cacheVersionKV.getValue().toString(StandardCharsets.UTF_8));
                 }
                 KeyValue layoutVersionKV = EtcdUtil.Instance().getKeyValue(Constants.LAYOUT_VERSION_LITERAL);
-                if (null != layoutVersionKV)
+                if (layoutVersionKV != null)
                 {
-                    layoutVersion = Integer.parseInt(layoutVersionKV.getValue().toString(StandardCharsets.UTF_8));
+                    // Issue #636: get schema and table name from etcd instead of config file.
+                    String value = layoutVersionKV.getValue().toString(StandardCharsets.UTF_8);
+                    String[] splits = value.split(":");
+                    checkArgument(splits.length == 2, "invalid value for key '" +
+                            Constants.LAYOUT_VERSION_LITERAL + "' in etcd: " + value);
+                    schemaTableName = new SchemaTableName(splits[0]);
+                    layoutVersion = Integer.parseInt(splits[1]);
+                    checkArgument(layoutVersion >= 0,
+                            "invalid layout version in etcd: " + layoutVersion);
                 }
-                if (cacheVersion < layoutVersion)
+                if (cacheVersion >= 0 && layoutVersion >= 0 && cacheVersion < layoutVersion)
                 {
                     logger.debug("Current cache version is left behind of current layout version, update the cache...");
-                    updateCachePlan(layoutVersion);
+                    updateCachePlan(schemaTableName, layoutVersion);
                 }
 
                 logger.info("Cache coordinator on is initialized");
@@ -159,11 +171,19 @@ public class CacheCoordinator implements Server
                                 // this coordinator is ready.
                                 logger.debug("Update cache distribution");
                                 // update the cache distribution
-                                int layoutVersion = Integer.parseInt(event.getKeyValue().getValue().toString(StandardCharsets.UTF_8));
-                                updateCachePlan(layoutVersion);
+                                String value = event.getKeyValue().getValue().toString(StandardCharsets.UTF_8);
+                                // Issue #636: get schema and table name from etcd instead of config file.
+                                String[] splits = value.split(":");
+                                checkArgument(splits.length == 2, "invalid value for key '" +
+                                        Constants.LAYOUT_VERSION_LITERAL + "' in etcd: " + value);
+                                SchemaTableName schemaTableName = new SchemaTableName(splits[0]);
+                                int layoutVersion = Integer.parseInt(splits[1]);
+                                checkArgument(layoutVersion >= 0,
+                                        "invalid layout version in etcd: " + layoutVersion);
+                                updateCachePlan(schemaTableName, layoutVersion);
                                 // update cache version, notify cache managers on each node to update cache.
                                 logger.debug("Update cache version to " + layoutVersion);
-                                EtcdUtil.Instance().putKeyValue(Constants.CACHE_VERSION_LITERAL, String.valueOf(layoutVersion));
+                                EtcdUtil.Instance().putKeyValue(Constants.CACHE_VERSION_LITERAL, value);
                             }
                             catch (IOException | MetadataException e)
                             {
@@ -231,9 +251,11 @@ public class CacheCoordinator implements Server
      * 1. for all files, decide which files to cache
      * 2. for each file, decide which node to cache it
      * */
-    private void updateCachePlan(int layoutVersion) throws MetadataException, IOException
+    private void updateCachePlan(SchemaTableName schemaTableName, int layoutVersion)
+            throws MetadataException, IOException
     {
-        Layout layout = metadataService.getLayout(cacheConfig.getSchema(), cacheConfig.getTable(), layoutVersion);
+        Layout layout = metadataService.getLayout(
+                schemaTableName.getSchemaName(), schemaTableName.getTableName(), layoutVersion);
         // select: decide which files to cache
         assert layout != null;
         List<String> filePaths = select(layout);

--- a/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/cache/CacheCoordinator.java
+++ b/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/cache/CacheCoordinator.java
@@ -164,7 +164,8 @@ public class CacheCoordinator implements Server
                                 // update cache version, notify cache managers on each node to update cache.
                                 logger.debug("Update cache version to " + layoutVersion);
                                 EtcdUtil.Instance().putKeyValue(Constants.CACHE_VERSION_LITERAL, String.valueOf(layoutVersion));
-                            } catch (IOException | MetadataException e)
+                            }
+                            catch (IOException | MetadataException e)
                             {
                                 logger.error("Failed to update cache distribution", e);
                             }
@@ -177,10 +178,12 @@ public class CacheCoordinator implements Server
             // Wait for this coordinator to be shutdown
             logger.info("Cache coordinator is running");
             runningLatch.await();
-        } catch (InterruptedException e)
+        }
+        catch (InterruptedException e)
         {
             logger.error("Cache coordinator interrupted when waiting on the running latch", e);
-        } finally
+        }
+        finally
         {
             if (watcher != null)
             {
@@ -209,7 +212,8 @@ public class CacheCoordinator implements Server
             try
             {
                 storage.close();
-            } catch (IOException e)
+            }
+            catch (IOException e)
             {
                 logger.error("Failed to close cache storage while shutting down cache coordinator.", e);
             }
@@ -354,11 +358,13 @@ public class CacheCoordinator implements Server
                             String path = entry.getKey();
                             locationDistribution.addCacheLocation(host, path);
                         }
-                    } else
+                    }
+                    else
                     {
                         throw new BalancerException("absolute balancer failed to balance paths");
                     }
-                } else
+                }
+                else
                 {
                     Map<String, HostAddress> balanced = replicaBalancer.getAll();
                     for (Map.Entry<String, HostAddress> entry : balanced.entrySet())
@@ -368,7 +374,8 @@ public class CacheCoordinator implements Server
                         locationDistribution.addCacheLocation(host, path);
                     }
                 }
-            } else
+            }
+            else
             {
                 throw new BalancerException("replica balancer failed to balance paths");
             }

--- a/scripts/sbin/reset-cache.sh
+++ b/scripts/sbin/reset-cache.sh
@@ -14,6 +14,6 @@ rm /mnt/ramfs/pixels.cache && rm /mnt/ramfs/pixels.index
 export ETCDCTL_API=3
 HOST_1=localhost
 ENDPOINTS=$HOST_1:2379
-etcdctl --endpoints=$ENDPOINTS put cache_version 0
-etcdctl --endpoints=$ENDPOINTS put layout_version 0
+etcdctl --endpoints=$ENDPOINTS del cache_version
+etcdctl --endpoints=$ENDPOINTS del layout_version
 etcdctl --endpoints=$ENDPOINTS del --prefix cache_location_


### PR DESCRIPTION
1. Now, the cache schema and table names are specified in the layout_version and cache_version values.
2. Close PixelsPhysicalReader in PixelsCacheWriter to release the off-heap buffers allocated for localFs.
3. Revise the pixels cache document.