### PR TITLE
[Issue #769] add experimental.timestamp.enabled option

### DIFF
--- a/pixels-common/src/main/resources/pixels.properties
+++ b/pixels-common/src/main/resources/pixels.properties
@@ -221,3 +221,4 @@ vm.security.groups=pixels-sg1
 ###### experimental settings ######
 # the rate of free memory in jvm
 experimental.gc.threshold=0.3
+experimental.timestamp.enabled=true


### PR DESCRIPTION
This PR introduces `experimental.timestamp.enabled` option, which is set to true by default. When this option is set to false, the TransService will return an invalid timestamp of -1.

The purpose of this invalid timestamp is to enable the pixels reader to read files that do not contain hidden columns, making it compatible with legacy data format.