### PR TITLE
[Issue #775] add ssd arrays support for pixelsScan

### DIFF
--- a/cpp/PixelsScanFunction.cpp
+++ b/cpp/PixelsScanFunction.cpp
@@ -132,7 +132,7 @@ unique_ptr<FunctionData> PixelsScanFunction::PixelsScanBind(
 	}
     auto multi_file_reader= MultiFileReader::CreateDefault("PixelsScan");
 
-    auto file_list=multi_file_reader->CreateFileList(context,input.inputs[0]);
+    auto file_list=multi_file_reader->CreateFileList(context,input.inputs[0],duckdb::FileGlobOptions::ALLOW_EMPTY);
 
     auto files=file_list->GetPaths();
     // parse *


### PR DESCRIPTION
Support for SSD arrays.
In the case of SSD arrays, each of the 8 tables in TPC-H will be split into 24 partitions (since the number of SSD arrays is 24). However, note that some tables are too small to be split(such as nation.tbl, it actually needn't to be spilt), so a question arises: some paths (*.pxl) may be empty.