### PR TITLE
[Issue #784] support read int columns as int column vectors

### DIFF
--- a/pixels-cli/src/main/java/io/pixelsdb/pixels/cli/load/PixelsConsumer.java
+++ b/pixels-cli/src/main/java/io/pixelsdb/pixels/cli/load/PixelsConsumer.java
@@ -90,7 +90,7 @@ public class PixelsConsumer extends Consumer
             short replication = Short.parseShort(configFactory.getProperty("block.replication"));
 
             TypeDescription schema = TypeDescription.fromString(schemaStr);
-            VectorizedRowBatch rowBatch = schema.createRowBatchWithHiddenColumn(pixelStride);
+            VectorizedRowBatch rowBatch = schema.createRowBatchWithHiddenColumn(pixelStride, TypeDescription.Mode.NONE);
             ColumnVector[] columnVectors = rowBatch.cols;
 
             BufferedReader reader;

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/TypeDescription.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/TypeDescription.java
@@ -107,6 +107,7 @@ public final class TypeDescription implements Comparable<TypeDescription>, Seria
      * For simplicity and compatibility to {@link java.sql.Time}, we further limit the precision to 3.</p>
      */
     public static final int MAX_TIME_PRECISION = 3;
+
     private static final Pattern UNQUOTED_NAMES = Pattern.compile("^\\w+$");
 
     private static final Logger logger = LogManager.getLogger(TypeDescription.class);
@@ -1166,7 +1167,7 @@ public final class TypeDescription implements Comparable<TypeDescription>, Seria
         return maxId;
     }
 
-    private ColumnVector createColumn(int maxSize, boolean... useEncodedVector)
+    private ColumnVector createColumn(int maxSize, int mode, boolean... useEncodedVector)
     {
         requireNonNull(useEncodedVector, "columnsEncoded should not be null");
         // the length of useEncodedVector is already checked, not need to check again.
@@ -1177,6 +1178,14 @@ public final class TypeDescription implements Comparable<TypeDescription>, Seria
                 return new ByteColumnVector(maxSize);
             case SHORT:
             case INT:
+                if (Mode.match(mode, Mode.CREATE_INT_VECTOR_FOR_INT))
+                {
+                    return new IntColumnVector(maxSize);
+                }
+                else
+                {
+                    return new LongColumnVector(maxSize);
+                }
             case LONG:
                 return new LongColumnVector(maxSize);
             case DATE:
@@ -1212,7 +1221,7 @@ public final class TypeDescription implements Comparable<TypeDescription>, Seria
                 ColumnVector[] fieldVector = new ColumnVector[children.size()];
                 for (int i = 0; i < fieldVector.length; ++i)
                 {
-                    fieldVector[i] = children.get(i).createColumn(maxSize, useEncodedVector[i]);
+                    fieldVector[i] = children.get(i).createColumn(maxSize, mode, useEncodedVector[i]);
                 }
                 return new StructColumnVector(maxSize, fieldVector);
             }
@@ -1223,7 +1232,7 @@ public final class TypeDescription implements Comparable<TypeDescription>, Seria
         }
     }
 
-    public VectorizedRowBatch createRowBatch(int maxSize, boolean... useEncodedVector)
+    public VectorizedRowBatch createRowBatch(int maxSize, int mode, boolean... useEncodedVector)
     {
         VectorizedRowBatch result;
         if (category == Category.STRUCT)
@@ -1235,7 +1244,7 @@ public final class TypeDescription implements Comparable<TypeDescription>, Seria
             for (int i = 0; i < result.cols.length; ++i)
             {
                 String fieldName = fieldNames.get(i);
-                ColumnVector cv = children.get(i).createColumn(maxSize,
+                ColumnVector cv = children.get(i).createColumn(maxSize, mode,
                         useEncodedVector.length != 0 && useEncodedVector[i]);
                 int originId = columnNames.indexOf(fieldName);
                 if (originId >= 0)
@@ -1255,7 +1264,8 @@ public final class TypeDescription implements Comparable<TypeDescription>, Seria
             checkArgument(useEncodedVector.length == 0 || useEncodedVector.length == 1,
                     "for null structure type, there can be only 0 or 1 elements in useEncodedVector");
             result = new VectorizedRowBatch(1, maxSize);
-            result.cols[0] = createColumn(maxSize, useEncodedVector.length == 1 && useEncodedVector[0]);
+            result.cols[0] = createColumn(maxSize, mode,
+                    useEncodedVector.length == 1 && useEncodedVector[0]);
         }
         result.reset();
         return result;
@@ -1263,10 +1273,10 @@ public final class TypeDescription implements Comparable<TypeDescription>, Seria
 
     public VectorizedRowBatch createRowBatch()
     {
-        return createRowBatch(VectorizedRowBatch.DEFAULT_SIZE);
+        return createRowBatch(VectorizedRowBatch.DEFAULT_SIZE, Mode.NONE);
     }
 
-    public VectorizedRowBatch createRowBatchWithHiddenColumn(int maxSize, boolean... useEncodedVector)
+    public VectorizedRowBatch createRowBatchWithHiddenColumn(int maxSize, int mode, boolean... useEncodedVector)
     {
         VectorizedRowBatch result;
         if (category == Category.STRUCT)
@@ -1279,7 +1289,7 @@ public final class TypeDescription implements Comparable<TypeDescription>, Seria
             for (int i = 0; i < result.cols.length - 1; ++i)
             {
                 String fieldName = fieldNames.get(i);
-                ColumnVector cv = children.get(i).createColumn(maxSize,
+                ColumnVector cv = children.get(i).createColumn(maxSize, mode,
                         useEncodedVector.length != 0 && useEncodedVector[i]);
                 int originId = columnNames.indexOf(fieldName);
                 if (originId >= 0)
@@ -1301,7 +1311,8 @@ public final class TypeDescription implements Comparable<TypeDescription>, Seria
             checkArgument(useEncodedVector.length == 0 || useEncodedVector.length == 1,
                     "for null structure type, there can be only 0 or 1 elements in useEncodedVector");
             result = new VectorizedRowBatch(2, maxSize);
-            result.cols[0] = createColumn(maxSize, useEncodedVector.length == 1 && useEncodedVector[0]);
+            result.cols[0] = createColumn(maxSize, mode,
+                    useEncodedVector.length == 1 && useEncodedVector[0]);
             result.cols[1] = new LongColumnVector(maxSize);
         }
         result.reset();
@@ -1310,7 +1321,7 @@ public final class TypeDescription implements Comparable<TypeDescription>, Seria
 
     public VectorizedRowBatch createRowBatchWithHiddenColumn()
     {
-        return createRowBatchWithHiddenColumn(VectorizedRowBatch.DEFAULT_SIZE);
+        return createRowBatchWithHiddenColumn(VectorizedRowBatch.DEFAULT_SIZE, Mode.NONE);
     }
 
     /**
@@ -1600,6 +1611,23 @@ public final class TypeDescription implements Comparable<TypeDescription>, Seria
                 prev = next;
             }
             return prev.findSubtype(goal);
+        }
+    }
+
+    /**
+     * The type related modes used when creating column vectors and row batches.
+     */
+    public static final class Mode
+    {
+        public static final int NONE = 0;
+        /**
+         * Create {@link IntColumnVector} for INT type.
+         */
+        public static final int CREATE_INT_VECTOR_FOR_INT = 0x01;
+
+        public static boolean match(int mode1, int mode2)
+        {
+            return (mode1 & mode2) != 0;
         }
     }
 }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/ByteColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/ByteColumnReader.java
@@ -72,6 +72,7 @@ public class ByteColumnReader extends ColumnReader
                      int offset, int size, int pixelStride, final int vectorIndex,
                      ColumnVector vector, PixelsProto.ColumnChunkIndex chunkIndex)
     {
+        throw new UnsupportedOperationException("Not implemented yet.");
     }
 
     /**

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/ColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/ColumnReader.java
@@ -55,7 +55,7 @@ public abstract class ColumnReader implements Closeable
      */
     int isNullSkipBits = 0;
 
-    public static ColumnReader newColumnReader(TypeDescription type)
+    public static ColumnReader newColumnReader(TypeDescription type, PixelsReaderOption option)
     {
         switch (type.getCategory())
         {
@@ -65,6 +65,14 @@ public abstract class ColumnReader implements Closeable
                 return new ByteColumnReader(type);
             case SHORT:
             case INT:
+                if (option.isReadIntColumnAsIntVector())
+                {
+                    return new IntColumnReader(type);
+                }
+                else
+                {
+                    return new LongColumnReader(type);
+                }
             case LONG:
                 return new LongColumnReader(type);
             case DOUBLE:

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/ColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/ColumnReader.java
@@ -66,7 +66,7 @@ public abstract class ColumnReader implements Closeable
             case SHORT:
             case INT:
             case LONG:
-                return new IntegerColumnReader(type);
+                return new LongColumnReader(type);
             case DOUBLE:
                 return new DoubleColumnReader(type);
             case DECIMAL: // Issue #196: precision and scale are passed through type.

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/IntColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/IntColumnReader.java
@@ -1,0 +1,353 @@
+/*
+ * Copyright 2024 PixelsDB.
+ *
+ * This file is part of Pixels.
+ *
+ * Pixels is free software: you can redistribute it and/or modify
+ * it under the terms of the Affero GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * Pixels is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Affero GNU General Public License for more details.
+ *
+ * You should have received a copy of the Affero GNU General Public
+ * License along with Pixels.  If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package io.pixelsdb.pixels.core.reader;
+
+import io.pixelsdb.pixels.core.PixelsProto;
+import io.pixelsdb.pixels.core.TypeDescription;
+import io.pixelsdb.pixels.core.encoding.RunLenIntDecoder;
+import io.pixelsdb.pixels.core.utils.BitUtils;
+import io.pixelsdb.pixels.core.utils.Bitmap;
+import io.pixelsdb.pixels.core.utils.ByteBufferInputStream;
+import io.pixelsdb.pixels.core.vector.ColumnVector;
+import io.pixelsdb.pixels.core.vector.IntColumnVector;
+import io.pixelsdb.pixels.core.vector.LongColumnVector;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Arrays;
+
+/**
+ * This is the column reader for integer (int32) columns.
+ * In some query engines (e.g., Trino 405 and Presto 0.279), the integer column should be read into long[]
+ * (i.e., {@link LongColumnVector}) in memory. In this case, the integer column should be read by
+ * {@link LongColumnReader} instead of {@link IntColumnReader}.
+ *
+ * However, in some other query engines (e.g., Trino 466), the integer column should be read into int[]
+ * (i.e., {@link IntColumnVector}) by {@link IntColumnReader}.
+ * @author hank
+ * @create 2024-12-02
+ */
+public class IntColumnReader extends ColumnReader
+{
+    private RunLenIntDecoder decoder;
+    private ByteBuffer inputBuffer;
+    private InputStream inputStream;
+
+    IntColumnReader(TypeDescription type)
+    {
+        super(type);
+    }
+
+    /**
+     * Closes this column reader and releases any resources associated
+     * with it. If the column reader is already closed then invoking this
+     * method has no effect.
+     * <p>
+     * <p> As noted in {@link AutoCloseable#close()}, cases where the
+     * close may fail require careful attention. It is strongly advised
+     * to relinquish the underlying resources and to internally
+     * <em>mark</em> the {@code Closeable} as closed, prior to throwing
+     * the {@code IOException}.
+     *
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    public void close() throws IOException
+    {
+        if (this.decoder != null)
+        {
+            // inputStream is closed inside decoder.close();
+            this.decoder.close();
+            this.decoder = null;
+        }
+        this.inputBuffer = null;
+    }
+
+    /**
+     * Read input buffer.
+     *
+     * @param input    input buffer
+     * @param encoding encoding type
+     * @param offset   starting reading offset of values
+     * @param size     number of values to read
+     * @param pixelStride the stride (number of rows) in a pixels.
+     * @param vectorIndex the index from where we start reading values into the vector
+     * @param vector   vector to read values into
+     * @param chunkIndex the metadata of the column chunk to read.
+     */
+    @Override
+    public void read(ByteBuffer input, PixelsProto.ColumnEncoding encoding,
+                     int offset, int size, int pixelStride, final int vectorIndex,
+                     ColumnVector vector, PixelsProto.ColumnChunkIndex chunkIndex) throws IOException
+    {
+        IntColumnVector columnVector = (IntColumnVector) vector;
+        boolean decoding = encoding.getKind().equals(PixelsProto.ColumnEncoding.Kind.RUNLENGTH);
+        boolean nullsPadding = chunkIndex.hasNullsPadding() && chunkIndex.getNullsPadding();
+        boolean littleEndian = chunkIndex.hasLittleEndian() && chunkIndex.getLittleEndian();
+        // if read from start, init the stream and decoder
+        if (offset == 0)
+        {
+            if (inputStream != null)
+            {
+                inputStream.close();
+            }
+            this.inputBuffer = input;
+            this.inputBuffer.order(littleEndian ? ByteOrder.LITTLE_ENDIAN : ByteOrder.BIG_ENDIAN);
+            inputStream = new ByteBufferInputStream(inputBuffer, inputBuffer.position(), inputBuffer.limit());
+            decoder = new RunLenIntDecoder(inputStream, true);
+            // isNull
+            isNullOffset = inputBuffer.position() + chunkIndex.getIsNullOffset();
+            isNullSkipBits = 0;
+            // re-init
+            hasNull = true;
+            elementIndex = 0;
+        }
+
+        // read without copying the de-compacted content and isNull
+        int numLeft = size, numToRead, bytesToDeCompact;
+        for (int i = vectorIndex; numLeft > 0; )
+        {
+            if (elementIndex / pixelStride < (elementIndex + numLeft) / pixelStride)
+            {
+                // read to the end of the current pixel
+                numToRead = pixelStride - elementIndex % pixelStride;
+            } else
+            {
+                numToRead = numLeft;
+            }
+            bytesToDeCompact = (numToRead + isNullSkipBits) / 8;
+            // read isNull
+            int pixelId = elementIndex / pixelStride;
+            hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
+            if (hasNull)
+            {
+                BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead,
+                        inputBuffer, isNullOffset, isNullSkipBits, littleEndian);
+                isNullOffset += bytesToDeCompact;
+                isNullSkipBits = (numToRead + isNullSkipBits) % 8;
+                columnVector.noNulls = false;
+            } else
+            {
+                Arrays.fill(columnVector.isNull, i, i + numToRead, false);
+            }
+            // read content
+            if (decoding)
+            {
+                for (int j = i; j < i + numToRead; ++j)
+                {
+                    if (!(hasNull && columnVector.isNull[j]))
+                    {
+                        columnVector.vector[j] = (int) decoder.next();
+                    }
+                }
+            } else
+            {
+                if (nullsPadding)
+                {
+                    for (int j = i; j < i + numToRead; ++j)
+                    {
+                        columnVector.vector[j] = inputBuffer.getInt();
+                    }
+                } else
+                {
+                    for (int j = i; j < i + numToRead; ++j)
+                    {
+                        if (!(hasNull && columnVector.isNull[j]))
+                        {
+                            columnVector.vector[j] = inputBuffer.getInt();
+                        }
+                    }
+                }
+            }
+            // update variables
+            numLeft -= numToRead;
+            elementIndex += numToRead;
+            i += numToRead;
+        }
+    }
+
+    /**
+     * Read selected values from input buffer.
+     *
+     * @param input    input buffer
+     * @param encoding encoding type
+     * @param offset   starting reading offset of values
+     * @param size     number of values to read
+     * @param pixelStride the stride (number of rows) in a pixels.
+     * @param vectorIndex the index from where we start reading values into the vector
+     * @param vector   vector to read values into
+     * @param chunkIndex the metadata of the column chunk to read.
+     * @param selected whether the value is selected, use the vectorIndex as the 0 offset of the selected
+     * @throws IOException
+     */
+    @Override
+    public void readSelected(ByteBuffer input, PixelsProto.ColumnEncoding encoding,
+                             int offset, int size, int pixelStride, final int vectorIndex,
+                             ColumnVector vector, PixelsProto.ColumnChunkIndex chunkIndex, Bitmap selected) throws IOException
+    {
+        IntColumnVector columnVector = (IntColumnVector) vector;
+        boolean decoding = encoding.getKind().equals(PixelsProto.ColumnEncoding.Kind.RUNLENGTH);
+        boolean nullsPadding = chunkIndex.hasNullsPadding() && chunkIndex.getNullsPadding();
+        boolean littleEndian = chunkIndex.hasLittleEndian() && chunkIndex.getLittleEndian();
+        // if read from start, init the stream and decoder
+        if (offset == 0)
+        {
+            if (inputStream != null)
+            {
+                inputStream.close();
+            }
+            this.inputBuffer = input;
+            this.inputBuffer.order(littleEndian ? ByteOrder.LITTLE_ENDIAN : ByteOrder.BIG_ENDIAN);
+            inputStream = new ByteBufferInputStream(inputBuffer, inputBuffer.position(), inputBuffer.limit());
+            decoder = new RunLenIntDecoder(inputStream, true);
+            // isNull
+            isNullOffset = inputBuffer.position() + chunkIndex.getIsNullOffset();
+            isNullSkipBits = 0;
+            // re-init
+            hasNull = true;
+            elementIndex = 0;
+        }
+
+        // read without copying the de-compacted content and isNull
+        int numLeft = size, numToRead, bytesToDeCompact, vectorWriteIndex = vectorIndex;
+        boolean[] isNull = null;
+        if (decoding || !nullsPadding)
+        {
+            isNull = new boolean[size];
+        }
+        for (int i = vectorIndex; numLeft > 0; )
+        {
+            if (elementIndex / pixelStride < (elementIndex + numLeft) / pixelStride)
+            {
+                // read to the end of the current pixel
+                numToRead = pixelStride - elementIndex % pixelStride;
+            } else
+            {
+                numToRead = numLeft;
+            }
+            bytesToDeCompact = (numToRead + isNullSkipBits) / 8;
+
+            // read isNull
+            int pixelId = elementIndex / pixelStride;
+            hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
+            if (hasNull)
+            {
+                if (!decoding && nullsPadding)
+                {
+                    // read isNull directly into the vector of the column chunk
+                    BitUtils.bitWiseDeCompact(columnVector.isNull, vectorWriteIndex, numToRead, inputBuffer,
+                            isNullOffset, isNullSkipBits, littleEndian, selected, i - vectorIndex);
+                }
+                else
+                {
+                    // need to keep isNull for later use
+                    BitUtils.bitWiseDeCompact(isNull, i - vectorIndex, numToRead, inputBuffer,
+                            isNullOffset, isNullSkipBits, littleEndian);
+                    // update columnVector.isNull
+                    int k = vectorWriteIndex;
+                    for (int j = i; j < i + numToRead; ++j)
+                    {
+                        if (selected.get(j - vectorIndex))
+                        {
+                            columnVector.isNull[k++] = isNull[j - vectorIndex];
+                        }
+                    }
+                }
+                isNullOffset += bytesToDeCompact;
+                isNullSkipBits = (numToRead + isNullSkipBits) % 8;
+                columnVector.noNulls = false;
+            }
+            else
+            {
+                if (decoding || !nullsPadding)
+                {
+                    Arrays.fill(isNull, i - vectorIndex, i - vectorIndex + numToRead, false);
+                }
+                // update columnVector.isNull later to avoid bitmap unnecessary traversal
+            }
+
+            // read content
+            int originalVectorWriteIndex = vectorWriteIndex;
+            if (decoding)
+            {
+                for (int j = i; j < i + numToRead; ++j)
+                {
+                    if (!(hasNull && isNull[j - vectorIndex]))
+                    {
+                        int value = (int) decoder.next();
+                        if (selected.get(j - vectorIndex))
+                        {
+                            columnVector.vector[vectorWriteIndex++] = value;
+                        }
+                    }
+                    else if (selected.get(j - vectorIndex))
+                    {
+                        vectorWriteIndex++;
+                    }
+                }
+            }
+            else
+            {
+                if (nullsPadding)
+                {
+                    for (int j = i; j < i + numToRead; ++j)
+                    {
+                        int value = inputBuffer.getInt();
+                        if (selected.get(j - vectorIndex))
+                        {
+                            columnVector.vector[vectorWriteIndex++] = value;
+                        }
+                    }
+                }
+                else
+                {
+                    for (int j = i; j < i + numToRead; ++j)
+                    {
+                        int value = inputBuffer.getInt();
+                        if (!(hasNull && isNull[j]))
+                        {
+                            if (selected.get(j - vectorIndex))
+                            {
+                                columnVector.vector[vectorWriteIndex++] = value;
+                            }
+                        }
+                        else if (selected.get(j - vectorIndex))
+                        {
+                            vectorWriteIndex++;
+                        }
+                    }
+                }
+            }
+
+            // update columnVector.isNull if has no nulls
+            if (!hasNull)
+            {
+                Arrays.fill(columnVector.isNull, originalVectorWriteIndex, vectorWriteIndex, false);
+            }
+
+            // update variables
+            numLeft -= numToRead;
+            elementIndex += numToRead;
+            i += numToRead;
+        }
+    }
+}

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/LongColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/LongColumnReader.java
@@ -39,7 +39,7 @@ import java.util.Arrays;
  * @create 2017-12-06
  * @update 2023-08-21: support nulls padding
  */
-public class IntegerColumnReader extends ColumnReader
+public class LongColumnReader extends ColumnReader
 {
     private RunLenIntDecoder decoder;
     private ByteBuffer inputBuffer;
@@ -50,7 +50,7 @@ public class IntegerColumnReader extends ColumnReader
      */
     private boolean isLong = false;
 
-    IntegerColumnReader(TypeDescription type)
+    LongColumnReader(TypeDescription type)
     {
         super(type);
     }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/PixelsReaderOption.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/PixelsReaderOption.java
@@ -33,6 +33,7 @@ public class PixelsReaderOption
     private boolean skipCorruptRecords = false;
     private boolean tolerantSchemaEvolution = true;    // this may lead to column missing due to schema evolution
     private boolean enableEncodedColumnVector = false; // whether read encoded column vectors directly when possible
+    private boolean readIntColumnAsIntVector = false; // whether read int32 columns as int32 column vectors
     private long transId = -1L;
     private long timestamp = -1L; // -1 means no need to consider the timestamp when reading data
     private int rgStart = 0;
@@ -141,5 +142,15 @@ public class PixelsReaderOption
     public boolean isEnableEncodedColumnVector()
     {
         return enableEncodedColumnVector;
+    }
+
+    public void readIntColumnAsIntVector(boolean readIntColumnAsIntVector)
+    {
+        this.readIntColumnAsIntVector = readIntColumnAsIntVector;
+    }
+
+    public boolean isReadIntColumnAsIntVector()
+    {
+        return readIntColumnAsIntVector;
     }
 }

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/PixelsRecordReaderImpl.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/PixelsRecordReaderImpl.java
@@ -269,12 +269,13 @@ public class PixelsRecordReaderImpl implements PixelsRecordReader
         for (int i = 0; i < resultColumns.length; i++)
         {
             int index = resultColumns[i];
-            readers[i] = ColumnReader.newColumnReader(columnSchemas.get(index));
+            readers[i] = ColumnReader.newColumnReader(columnSchemas.get(index), option);
         }
         if (this.shouldReadTimestamp)
         {
             // create reader for the hidden timestamp column
-            readers[readers.length - 1] = ColumnReader.newColumnReader(new TypeDescription(TypeDescription.Category.LONG));
+            readers[readers.length - 1] = ColumnReader.newColumnReader(
+                    new TypeDescription(TypeDescription.Category.LONG), option);
         }
 
         // create result vectorized row batch

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/PixelsRecordReaderStreamImpl.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/PixelsRecordReaderStreamImpl.java
@@ -244,7 +244,7 @@ public class PixelsRecordReaderStreamImpl implements PixelsRecordReader
         for (int i = 0; i < resultColumns.length; i++)
         {
             int index = resultColumns[i];
-            readers[i] = ColumnReader.newColumnReader(columnSchemas.get(index));
+            readers[i] = ColumnReader.newColumnReader(columnSchemas.get(index), option);
         }
 
         // create result vectorized row batch

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/TestColumnVector.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/TestColumnVector.java
@@ -85,13 +85,15 @@ public class TestColumnVector
         int testNum = 1000_000;
         String mockSchema = "struct<a:int,b:double,c:string,d:timestamp>";
 
-        VectorizedRowBatch srcRowBatch = TypeDescription.fromString(mockSchema).createRowBatch(testNum);
+        VectorizedRowBatch srcRowBatch = TypeDescription.fromString(mockSchema).createRowBatch(
+                testNum, TypeDescription.Mode.NONE);
         LongColumnVector src0 = (LongColumnVector) srcRowBatch.cols[0];
         DoubleColumnVector src1 = (DoubleColumnVector) srcRowBatch.cols[1];
         BinaryColumnVector src2 = (BinaryColumnVector) srcRowBatch.cols[2];
         TimestampColumnVector src3 = (TimestampColumnVector) srcRowBatch.cols[3];
 
-        VectorizedRowBatch dstRowBatch = TypeDescription.fromString(mockSchema).createRowBatch(testNum);
+        VectorizedRowBatch dstRowBatch = TypeDescription.fromString(mockSchema).createRowBatch(
+                testNum, TypeDescription.Mode.NONE);
         LongColumnVector dst0 = (LongColumnVector) dstRowBatch.cols[0];
         DoubleColumnVector dst1 = (DoubleColumnVector) dstRowBatch.cols[1];
         BinaryColumnVector dst2 = (BinaryColumnVector) dstRowBatch.cols[2];

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestIntegerColumnReader.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestIntegerColumnReader.java
@@ -73,7 +73,7 @@ public class TestIntegerColumnReader
         byte[] content = columnWriter.getColumnChunkContent();
         PixelsProto.ColumnChunkIndex chunkIndex = columnWriter.getColumnChunkIndex().build();
         PixelsProto.ColumnEncoding encoding = columnWriter.getColumnChunkEncoding().build();
-        IntegerColumnReader columnReader = new IntegerColumnReader(TypeDescription.createInt());
+        LongColumnReader columnReader = new LongColumnReader(TypeDescription.createInt());
         LongColumnVector longColumnVector1 = new LongColumnVector(22);
         columnReader.read(ByteBuffer.wrap(content), encoding, 0, 22,
                 10, 0, longColumnVector1, chunkIndex);
@@ -126,7 +126,7 @@ public class TestIntegerColumnReader
         byte[] content = columnWriter.getColumnChunkContent();
         PixelsProto.ColumnChunkIndex chunkIndex = columnWriter.getColumnChunkIndex().build();
         PixelsProto.ColumnEncoding encoding = columnWriter.getColumnChunkEncoding().build();
-        IntegerColumnReader columnReader = new IntegerColumnReader(TypeDescription.createLong());
+        LongColumnReader columnReader = new LongColumnReader(TypeDescription.createLong());
         LongColumnVector longColumnVector1 = new LongColumnVector(22);
         columnReader.read(ByteBuffer.wrap(content), encoding, 0, 22,
                 10, 0, longColumnVector1, chunkIndex);

--- a/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/aggregation/Aggregator.java
+++ b/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/aggregation/Aggregator.java
@@ -192,7 +192,7 @@ public class Aggregator
 
     public boolean writeAggrOutput(PixelsWriter pixelsWriter) throws IOException
     {
-        VectorizedRowBatch outputRowBatch = this.outputSchema.createRowBatch(this.batchSize);
+        VectorizedRowBatch outputRowBatch = this.outputSchema.createRowBatch(this.batchSize, TypeDescription.Mode.NONE);
         if (partition)
         {
             for (int hash = 0; hash < this.numPartitions; ++hash)

--- a/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/join/Joiner.java
+++ b/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/join/Joiner.java
@@ -209,7 +209,7 @@ public class Joiner
         requireNonNull(largeBatch, "largeBatch is null");
         checkArgument(largeBatch.size > 0, "largeBatch is empty");
         List<VectorizedRowBatch> result = new LinkedList<>();
-        VectorizedRowBatch joinedRowBatch = this.joinedSchema.createRowBatch(largeBatch.maxSize);
+        VectorizedRowBatch joinedRowBatch = this.joinedSchema.createRowBatch(largeBatch.maxSize, TypeDescription.Mode.NONE);
         Tuple.Builder builder = new Tuple.Builder(largeBatch, this.largeKeyColumnIds, this.largeProjection);
         while (builder.hasNext())
         {
@@ -228,7 +228,7 @@ public class Joiner
                         if (joinedRowBatch.isFull())
                         {
                             result.add(joinedRowBatch);
-                            joinedRowBatch = this.joinedSchema.createRowBatch(largeBatch.maxSize);
+                            joinedRowBatch = this.joinedSchema.createRowBatch(largeBatch.maxSize, TypeDescription.Mode.NONE);
                         }
                         joined.writeTo(joinedRowBatch);
                         break;
@@ -252,7 +252,7 @@ public class Joiner
                     if (joinedRowBatch.isFull())
                     {
                         result.add(joinedRowBatch);
-                        joinedRowBatch = this.joinedSchema.createRowBatch(largeBatch.maxSize);
+                        joinedRowBatch = this.joinedSchema.createRowBatch(largeBatch.maxSize, TypeDescription.Mode.NONE);
                     }
                     joined.writeTo(joinedRowBatch);
                     smallHead = smallHead.next;
@@ -286,7 +286,7 @@ public class Joiner
                 leftOuterTuples.add(small);
             }
         }
-        VectorizedRowBatch leftOuterBatch = this.joinedSchema.createRowBatch(batchSize);
+        VectorizedRowBatch leftOuterBatch = this.joinedSchema.createRowBatch(batchSize, TypeDescription.Mode.NONE);
         for (Tuple small : leftOuterTuples)
         {
             if (leftOuterBatch.isFull())
@@ -332,7 +332,7 @@ public class Joiner
                 leftOuterTuples.add(small);
             }
         }
-        VectorizedRowBatch leftOuterBatch = this.joinedSchema.createRowBatch(batchSize);
+        VectorizedRowBatch leftOuterBatch = this.joinedSchema.createRowBatch(batchSize, TypeDescription.Mode.NONE);
         for (Tuple small : leftOuterTuples)
         {
             if (leftOuterBatch.isFull())

--- a/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/join/Partitioner.java
+++ b/pixels-executor/src/main/java/io/pixelsdb/pixels/executor/join/Partitioner.java
@@ -83,7 +83,7 @@ public class Partitioner
         this.selectedArrayIndexes = new int[numPartition];
         for (int i = 0; i < numPartition; ++i)
         {
-            this.rowBatches[i] = schema.createRowBatch(batchSize);
+            this.rowBatches[i] = schema.createRowBatch(batchSize, TypeDescription.Mode.NONE);
             this.selectedArrays[i] = new int[batchSize];
             this.selectedArrayIndexes[i] = 0;
         }
@@ -127,14 +127,14 @@ public class Partitioner
             if (freeSlots == 0)
             {
                 output.put(hash, rowBatches[hash]);
-                rowBatches[hash] = schema.createRowBatch(batchSize);
+                rowBatches[hash] = schema.createRowBatch(batchSize, TypeDescription.Mode.NONE);
                 rowBatches[hash].addSelected(selected, 0, selectedLength, input);
             }
             else if (freeSlots <= selectedLength)
             {
                 rowBatches[hash].addSelected(selected, 0, freeSlots, input);
                 output.put(hash, rowBatches[hash]);
-                rowBatches[hash] = schema.createRowBatch(batchSize);
+                rowBatches[hash] = schema.createRowBatch(batchSize, TypeDescription.Mode.NONE);
                 if (freeSlots < selectedLength)
                 {
                     rowBatches[hash].addSelected(selected, freeSlots, selectedLength - freeSlots, input);


### PR DESCRIPTION
This is for the compatability of Trino 466.
Closes #784.