### PR TITLE
[Issue #789] fix aligning bitmap read to pixel boundary; fix readSelected of Int, Long, and String

### DIFF
--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/DateColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/DateColumnReader.java
@@ -138,7 +138,7 @@ public class DateColumnReader extends ColumnReader
                 BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead,
                         inputBuffer, isNullOffset, isNullSkipBits, littleEndian);
                 isNullOffset += bytesToDeCompact;
-                isNullSkipBits =  endOfPixel ? 0 : (numToRead + isNullSkipBits) % 8;
+                isNullSkipBits = endOfPixel ? 0 : (numToRead + isNullSkipBits) % 8;
                 columnVector.noNulls = false;
             }
             else

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/DateColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/DateColumnReader.java
@@ -115,18 +115,21 @@ public class DateColumnReader extends ColumnReader
         boolean decoding = encoding.getKind().equals(PixelsProto.ColumnEncoding.Kind.RUNLENGTH);
         // read without copying the de-compacted content and isNull
         int numLeft = size, numToRead, bytesToDeCompact;
+        boolean endOfPixel;
         for (int i = vectorIndex; numLeft > 0;)
         {
             if (elementIndex / pixelStride < (elementIndex + numLeft) / pixelStride)
             {
                 // read to the end of the current pixel
                 numToRead = pixelStride - elementIndex % pixelStride;
+                endOfPixel = true;
             }
             else
             {
                 numToRead = numLeft;
+                endOfPixel = false;
             }
-            bytesToDeCompact = (numToRead + isNullSkipBits) / 8;
+            bytesToDeCompact = (numToRead + isNullSkipBits + (endOfPixel ? 7 : 0)) / 8;
             // read isNull
             int pixelId = elementIndex / pixelStride;
             hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
@@ -135,7 +138,7 @@ public class DateColumnReader extends ColumnReader
                 BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead,
                         inputBuffer, isNullOffset, isNullSkipBits, littleEndian);
                 isNullOffset += bytesToDeCompact;
-                isNullSkipBits = (numToRead + isNullSkipBits) % 8;
+                isNullSkipBits =  endOfPixel ? 0 : (numToRead + isNullSkipBits) % 8;
                 columnVector.noNulls = false;
             }
             else
@@ -222,6 +225,7 @@ public class DateColumnReader extends ColumnReader
         // read without copying the de-compacted content and isNull
         int numLeft = size, numToRead, bytesToDeCompact, vectorWriteIndex = vectorIndex;
         boolean[] isNull = null;
+        boolean endOfPixel;
         if (decoding || !nullsPadding)
         {
             isNull = new boolean[size];
@@ -232,12 +236,14 @@ public class DateColumnReader extends ColumnReader
             {
                 // read to the end of the current pixel
                 numToRead = pixelStride - elementIndex % pixelStride;
+                endOfPixel = true;
             }
             else
             {
                 numToRead = numLeft;
+                endOfPixel = false;
             }
-            bytesToDeCompact = (numToRead + isNullSkipBits) / 8;
+            bytesToDeCompact = (numToRead + isNullSkipBits + (endOfPixel ? 7 : 0)) / 8;
             // read isNull
             int pixelId = elementIndex / pixelStride;
             hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
@@ -265,7 +271,7 @@ public class DateColumnReader extends ColumnReader
                     }
                 }
                 isNullOffset += bytesToDeCompact;
-                isNullSkipBits = (numToRead + isNullSkipBits) % 8;
+                isNullSkipBits = endOfPixel ? 0 : (numToRead + isNullSkipBits) % 8;
                 columnVector.noNulls = false;
             }
             else

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/DecimalColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/DecimalColumnReader.java
@@ -111,18 +111,21 @@ public class DecimalColumnReader extends ColumnReader
 
         // read without copying the de-compacted content and isNull
         int numLeft = size, numToRead, bytesToDeCompact;
+        boolean endOfPixel;
         for (int i = vectorIndex; numLeft > 0; )
         {
             if (elementIndex / pixelStride < (elementIndex + numLeft) / pixelStride)
             {
                 // read to the end of the current pixel
                 numToRead = pixelStride - elementIndex % pixelStride;
+                endOfPixel = true;
             }
             else
             {
                 numToRead = numLeft;
+                endOfPixel = false;
             }
-            bytesToDeCompact = (numToRead + isNullSkipBits) / 8;
+            bytesToDeCompact = (numToRead + isNullSkipBits + (endOfPixel ? 7 : 0)) / 8;
             // read isNull
             int pixelId = elementIndex / pixelStride;
             hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
@@ -131,7 +134,7 @@ public class DecimalColumnReader extends ColumnReader
                 BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead,
                         inputBuffer, isNullOffset, isNullSkipBits, littleEndian);
                 isNullOffset += bytesToDeCompact;
-                isNullSkipBits = (numToRead + isNullSkipBits) % 8;
+                isNullSkipBits =  endOfPixel ? 0 : (numToRead + isNullSkipBits) % 8;
                 columnVector.noNulls = false;
             }
             else
@@ -209,6 +212,7 @@ public class DecimalColumnReader extends ColumnReader
         // read without copying the de-compacted content and isNull
         int numLeft = size, numToRead, bytesToDeCompact, vectorWriteIndex = vectorIndex;
         boolean[] isNull = null;
+        boolean endOfPixel;
         if (!nullsPadding)
         {
             isNull = new boolean[size];
@@ -219,12 +223,14 @@ public class DecimalColumnReader extends ColumnReader
             {
                 // read to the end of the current pixel
                 numToRead = pixelStride - elementIndex % pixelStride;
+                endOfPixel = true;
             }
             else
             {
                 numToRead = numLeft;
+                endOfPixel = false;
             }
-            bytesToDeCompact = (numToRead + isNullSkipBits) / 8;
+            bytesToDeCompact = (numToRead + isNullSkipBits + (endOfPixel ? 7 : 0)) / 8;
 
             // read isNull
             int pixelId = elementIndex / pixelStride;
@@ -253,7 +259,7 @@ public class DecimalColumnReader extends ColumnReader
                     }
                 }
                 isNullOffset += bytesToDeCompact;
-                isNullSkipBits = (numToRead + isNullSkipBits) % 8;
+                isNullSkipBits = endOfPixel ? 0 : (numToRead + isNullSkipBits) % 8;
                 columnVector.noNulls = false;
             }
             else

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/DoubleColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/DoubleColumnReader.java
@@ -102,18 +102,21 @@ public class DoubleColumnReader extends ColumnReader
 
         // read without copying the de-compacted content and isNull
         int numLeft = size, numToRead, bytesToDeCompact;
+        boolean endOfPixel;
         for (int i = vectorIndex; numLeft > 0; )
         {
             if (elementIndex / pixelStride < (elementIndex + numLeft) / pixelStride)
             {
                 // read to the end of the current pixel
                 numToRead = pixelStride - elementIndex % pixelStride;
+                endOfPixel = true;
             }
             else
             {
                 numToRead = numLeft;
+                endOfPixel = false;
             }
-            bytesToDeCompact = (numToRead + isNullSkipBits) / 8;
+            bytesToDeCompact = (numToRead + isNullSkipBits + (endOfPixel ? 7 : 0)) / 8;
             // read isNull
             int pixelId = elementIndex / pixelStride;
             hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
@@ -122,7 +125,7 @@ public class DoubleColumnReader extends ColumnReader
                 BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead,
                         inputBuffer, isNullOffset, isNullSkipBits, littleEndian);
                 isNullOffset += bytesToDeCompact;
-                isNullSkipBits = (numToRead + isNullSkipBits) % 8;
+                isNullSkipBits = endOfPixel ? 0 : (numToRead + isNullSkipBits) % 8;
                 columnVector.noNulls = false;
             }
             else
@@ -194,6 +197,7 @@ public class DoubleColumnReader extends ColumnReader
         // read without copying the de-compacted content and isNull
         int numLeft = size, numToRead, bytesToDeCompact, vectorWriteIndex = vectorIndex;
         boolean[] isNull = null;
+        boolean endOfPixel;
         if (!nullsPadding)
         {
             isNull = new boolean[size];
@@ -204,13 +208,14 @@ public class DoubleColumnReader extends ColumnReader
             {
                 // read to the end of the current pixel
                 numToRead = pixelStride - elementIndex % pixelStride;
+                endOfPixel = true;
             }
             else
             {
                 numToRead = numLeft;
+                endOfPixel = false;
             }
-            bytesToDeCompact = (numToRead + isNullSkipBits) / 8;
-
+            bytesToDeCompact = (numToRead + isNullSkipBits + (endOfPixel ? 7 : 0)) / 8;
             // read isNull
             int pixelId = elementIndex / pixelStride;
             hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
@@ -238,7 +243,7 @@ public class DoubleColumnReader extends ColumnReader
                     }
                 }
                 isNullOffset += bytesToDeCompact;
-                isNullSkipBits = (numToRead + isNullSkipBits) % 8;
+                isNullSkipBits = endOfPixel ? 0 : (numToRead + isNullSkipBits) % 8;
                 columnVector.noNulls = false;
             }
             else

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/IntColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/IntColumnReader.java
@@ -124,18 +124,21 @@ public class IntColumnReader extends ColumnReader
 
         // read without copying the de-compacted content and isNull
         int numLeft = size, numToRead, bytesToDeCompact;
+        boolean endOfPixel;
         for (int i = vectorIndex; numLeft > 0; )
         {
             if (elementIndex / pixelStride < (elementIndex + numLeft) / pixelStride)
             {
                 // read to the end of the current pixel
                 numToRead = pixelStride - elementIndex % pixelStride;
+                endOfPixel = true;
             }
             else
             {
                 numToRead = numLeft;
+                endOfPixel = false;
             }
-            bytesToDeCompact = (numToRead + isNullSkipBits) / 8;
+            bytesToDeCompact = (numToRead + isNullSkipBits + (endOfPixel ? 7 : 0)) / 8;
             // read isNull
             int pixelId = elementIndex / pixelStride;
             hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
@@ -144,7 +147,7 @@ public class IntColumnReader extends ColumnReader
                 BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead,
                         inputBuffer, isNullOffset, isNullSkipBits, littleEndian);
                 isNullOffset += bytesToDeCompact;
-                isNullSkipBits = (numToRead + isNullSkipBits) % 8;
+                isNullSkipBits =  endOfPixel ? 0 : (numToRead + isNullSkipBits) % 8;
                 columnVector.noNulls = false;
             }
             else
@@ -234,6 +237,7 @@ public class IntColumnReader extends ColumnReader
         // read without copying the de-compacted content and isNull
         int numLeft = size, numToRead, bytesToDeCompact, vectorWriteIndex = vectorIndex;
         boolean[] isNull = null;
+        boolean endOfPixel;
         if (decoding || !nullsPadding)
         {
             isNull = new boolean[size];
@@ -244,12 +248,14 @@ public class IntColumnReader extends ColumnReader
             {
                 // read to the end of the current pixel
                 numToRead = pixelStride - elementIndex % pixelStride;
+                endOfPixel = true;
             }
             else
             {
                 numToRead = numLeft;
+                endOfPixel = false;
             }
-            bytesToDeCompact = (numToRead + isNullSkipBits) / 8;
+            bytesToDeCompact = (numToRead + isNullSkipBits + (endOfPixel ? 7 : 0)) / 8;
 
             // read isNull
             int pixelId = elementIndex / pixelStride;
@@ -278,7 +284,7 @@ public class IntColumnReader extends ColumnReader
                     }
                 }
                 isNullOffset += bytesToDeCompact;
-                isNullSkipBits = (numToRead + isNullSkipBits) % 8;
+                isNullSkipBits = endOfPixel ? 0 : (numToRead + isNullSkipBits) % 8;
                 columnVector.noNulls = false;
             }
             else
@@ -327,9 +333,9 @@ public class IntColumnReader extends ColumnReader
                 {
                     for (int j = i; j < i + numToRead; ++j)
                     {
-                        int value = inputBuffer.getInt();
                         if (!(hasNull && isNull[j]))
                         {
+                            int value = inputBuffer.getInt();
                             if (selected.get(j - vectorIndex))
                             {
                                 columnVector.vector[vectorWriteIndex++] = value;

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/StringColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/StringColumnReader.java
@@ -187,17 +187,21 @@ public class StringColumnReader extends ColumnReader
                 // we get bytes here to reduce memory copies and avoid creating many small byte arrays
                 byte[] buffer = dictContentBuf.array();
                 int numLeft = size, numToRead, bytesToDeCompact;
+                boolean endOfPixel;
                 for (int i = vectorIndex; numLeft > 0;)
                 {
                     if (elementIndex / pixelStride < (elementIndex + numLeft) / pixelStride)
                     {
                         // read to the end of the current pixel
                         numToRead = pixelStride - elementIndex % pixelStride;
-                    } else
+                        endOfPixel = true;
+                    }
+                    else
                     {
                         numToRead = numLeft;
+                        endOfPixel = false;
                     }
-                    bytesToDeCompact = (numToRead + isNullSkipBits) / 8;
+                    bytesToDeCompact = (numToRead + isNullSkipBits + (endOfPixel ? 7 : 0)) / 8;
                     // read isNull
                     int pixelId = elementIndex / pixelStride;
                     hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
@@ -206,12 +210,14 @@ public class StringColumnReader extends ColumnReader
                         BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead,
                                 inputBuffer, isNullOffset, isNullSkipBits, littleEndian);
                         isNullOffset += bytesToDeCompact;
-                        isNullSkipBits = (numToRead + isNullSkipBits) % 8;
+                        isNullSkipBits = endOfPixel ? 0 : (numToRead + isNullSkipBits) % 8;
                         columnVector.noNulls = false;
-                    } else
+                    }
+                    else
                     {
                         Arrays.fill(columnVector.isNull, i, i + numToRead, false);
                     }
+                    // read content
                     for (int j = i; j < i + numToRead; ++j)
                     {
                         if (hasNull && columnVector.isNull[j])
@@ -247,17 +253,21 @@ public class StringColumnReader extends ColumnReader
                         "dictionaries in the column vector and the input buffer are inconsistent");
 
                 int numLeft = size, numToRead, bytesToDeCompact;
+                boolean endOfPixel;
                 for (int i = vectorIndex; numLeft > 0;)
                 {
                     if (elementIndex / pixelStride < (elementIndex + numLeft) / pixelStride)
                     {
                         // read to the end of the current pixel
                         numToRead = pixelStride - elementIndex % pixelStride;
-                    } else
+                        endOfPixel = true;
+                    }
+                    else
                     {
                         numToRead = numLeft;
+                        endOfPixel = false;
                     }
-                    bytesToDeCompact = (numToRead + isNullSkipBits) / 8;
+                    bytesToDeCompact = (numToRead + isNullSkipBits + (endOfPixel ? 7 : 0)) / 8;
                     // read isNull
                     int pixelId = elementIndex / pixelStride;
                     hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
@@ -266,12 +276,14 @@ public class StringColumnReader extends ColumnReader
                         BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead,
                                 inputBuffer, isNullOffset, isNullSkipBits, littleEndian);
                         isNullOffset += bytesToDeCompact;
-                        isNullSkipBits = (numToRead + isNullSkipBits) % 8;
+                        isNullSkipBits = endOfPixel ? 0 : (numToRead + isNullSkipBits) % 8;
                         columnVector.noNulls = false;
-                    } else
+                    }
+                    else
                     {
                         Arrays.fill(columnVector.isNull, i, i + numToRead, false);
                     }
+                    // read content
                     for (int j = i; j < i + numToRead; ++j)
                     {
                         if (hasNull && columnVector.isNull[j])
@@ -306,17 +318,21 @@ public class StringColumnReader extends ColumnReader
             // we get bytes here to reduce memory copies and avoid creating many small byte arrays.
             byte[] buffer = contentBuf.array();
             int numLeft = size, numToRead, bytesToDeCompact;
+            boolean endOfPixel;
             for (int i = vectorIndex; numLeft > 0;)
             {
                 if (elementIndex / pixelStride < (elementIndex + numLeft) / pixelStride)
                 {
                     // read to the end of the current pixel
                     numToRead = pixelStride - elementIndex % pixelStride;
-                } else
+                    endOfPixel = true;
+                }
+                else
                 {
                     numToRead = numLeft;
+                    endOfPixel = false;
                 }
-                bytesToDeCompact = (numToRead + isNullSkipBits) / 8;
+                bytesToDeCompact = (numToRead + isNullSkipBits + (endOfPixel ? 7 : 0)) / 8;
                 // read isNull
                 int pixelId = elementIndex / pixelStride;
                 hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
@@ -325,12 +341,14 @@ public class StringColumnReader extends ColumnReader
                     BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead,
                             inputBuffer, isNullOffset, isNullSkipBits, littleEndian);
                     isNullOffset += bytesToDeCompact;
-                    isNullSkipBits = (numToRead + isNullSkipBits) % 8;
+                    isNullSkipBits = endOfPixel ? 0 : (numToRead + isNullSkipBits) % 8;
                     columnVector.noNulls = false;
-                } else
+                }
+                else
                 {
                     Arrays.fill(columnVector.isNull, i, i + numToRead, false);
                 }
+                // read content
                 for (int j = i; j < i + numToRead; ++j)
                 {
                     if (hasNull && columnVector.isNull[j])
@@ -419,17 +437,21 @@ public class StringColumnReader extends ColumnReader
                 byte[] buffer = dictContentBuf.array();
                 int numLeft = size, numToRead, bytesToDeCompact, vectorWriteIndex = vectorIndex;
                 boolean[] isNull = new boolean[size];
+                boolean endOfPixel;
                 for (int i = vectorIndex; numLeft > 0;)
                 {
                     if (elementIndex / pixelStride < (elementIndex + numLeft) / pixelStride)
                     {
                         // read to the end of the current pixel
                         numToRead = pixelStride - elementIndex % pixelStride;
-                    } else
+                        endOfPixel = true;
+                    }
+                    else
                     {
                         numToRead = numLeft;
+                        endOfPixel = false;
                     }
-                    bytesToDeCompact = (numToRead + isNullSkipBits) / 8;
+                    bytesToDeCompact = (numToRead + isNullSkipBits + (endOfPixel ? 7 : 0)) / 8;
 
                     // read isNull
                     int pixelId = elementIndex / pixelStride;
@@ -448,7 +470,7 @@ public class StringColumnReader extends ColumnReader
                             }
                         }
                         isNullOffset += bytesToDeCompact;
-                        isNullSkipBits = (numToRead + isNullSkipBits) % 8;
+                        isNullSkipBits = endOfPixel ? 0 : (numToRead + isNullSkipBits) % 8;
                         columnVector.noNulls = false;
                     }
                     else
@@ -509,17 +531,21 @@ public class StringColumnReader extends ColumnReader
 
                 int numLeft = size, numToRead, bytesToDeCompact, vectorWriteIndex = vectorIndex;
                 boolean[] isNull = new boolean[size];
+                boolean endOfPixel;
                 for (int i = vectorIndex; numLeft > 0;)
                 {
                     if (elementIndex / pixelStride < (elementIndex + numLeft) / pixelStride)
                     {
                         // read to the end of the current pixel
                         numToRead = pixelStride - elementIndex % pixelStride;
-                    } else
+                        endOfPixel = true;
+                    }
+                    else
                     {
                         numToRead = numLeft;
+                        endOfPixel = false;
                     }
-                    bytesToDeCompact = (numToRead + isNullSkipBits) / 8;
+                    bytesToDeCompact = (numToRead + isNullSkipBits + (endOfPixel ? 7 : 0)) / 8;
 
                     // read isNull
                     int pixelId = elementIndex / pixelStride;
@@ -538,7 +564,7 @@ public class StringColumnReader extends ColumnReader
                             }
                         }
                         isNullOffset += bytesToDeCompact;
-                        isNullSkipBits = (numToRead + isNullSkipBits) % 8;
+                        isNullSkipBits = endOfPixel ? 0 : (numToRead + isNullSkipBits) % 8;
                         columnVector.noNulls = false;
                     }
                     else
@@ -599,24 +625,28 @@ public class StringColumnReader extends ColumnReader
             byte[] buffer = contentBuf.array();
             int numLeft = size, numToRead, bytesToDeCompact, vectorWriteIndex = vectorIndex;
             boolean[] isNull = new boolean[size];
+            boolean endOfPixel;
             for (int i = vectorIndex; numLeft > 0;)
             {
                 if (elementIndex / pixelStride < (elementIndex + numLeft) / pixelStride)
                 {
                     // read to the end of the current pixel
                     numToRead = pixelStride - elementIndex % pixelStride;
-                } else
+                    endOfPixel = true;
+                }
+                else
                 {
                     numToRead = numLeft;
+                    endOfPixel = false;
                 }
-                bytesToDeCompact = (numToRead + isNullSkipBits) / 8;
+                bytesToDeCompact = (numToRead + isNullSkipBits + (endOfPixel ? 7 : 0)) / 8;
 
                 // read isNull
                 int pixelId = elementIndex / pixelStride;
                 hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
                 if (hasNull)
                 {
-                    BitUtils.bitWiseDeCompact(columnVector.isNull, vectorWriteIndex, numToRead, inputBuffer,
+                    BitUtils.bitWiseDeCompact(isNull, i - vectorIndex, numToRead, inputBuffer,
                             isNullOffset, isNullSkipBits, littleEndian);
                     // update columnVector.isNull
                     int k = vectorWriteIndex;
@@ -624,11 +654,11 @@ public class StringColumnReader extends ColumnReader
                     {
                         if (selected.get(j - vectorIndex))
                         {
-                            columnVector.isNull[k++] = columnVector.isNull[j - vectorIndex];
+                            columnVector.isNull[k++] = isNull[j - vectorIndex];
                         }
                     }
                     isNullOffset += bytesToDeCompact;
-                    isNullSkipBits = (numToRead + isNullSkipBits) % 8;
+                    isNullSkipBits = endOfPixel ? 0 : (numToRead + isNullSkipBits) % 8;
                     columnVector.noNulls = false;
                 }
                 else

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/TimestampColumnReader.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/TimestampColumnReader.java
@@ -115,18 +115,21 @@ public class TimestampColumnReader extends ColumnReader
 
         // read without copying the de-compacted content and isNull
         int numLeft = size, numToRead, bytesToDeCompact;
+        boolean endOfPixel;
         for (int i = vectorIndex; numLeft > 0;)
         {
             if (elementIndex / pixelStride < (elementIndex + numLeft) / pixelStride)
             {
                 // read to the end of the current pixel
                 numToRead = pixelStride - elementIndex % pixelStride;
+                endOfPixel = true;
             }
             else
             {
                 numToRead = numLeft;
+                endOfPixel = false;
             }
-            bytesToDeCompact = (numToRead + isNullSkipBits) / 8;
+            bytesToDeCompact = (numToRead + isNullSkipBits + (endOfPixel ? 7 : 0)) / 8;
             // read isNull
             int pixelId = elementIndex / pixelStride;
             hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
@@ -135,7 +138,7 @@ public class TimestampColumnReader extends ColumnReader
                 BitUtils.bitWiseDeCompact(columnVector.isNull, i, numToRead,
                         inputBuffer, isNullOffset, isNullSkipBits, littleEndian);
                 isNullOffset += bytesToDeCompact;
-                isNullSkipBits = (numToRead + isNullSkipBits) % 8;
+                isNullSkipBits = endOfPixel ? 0 : (numToRead + isNullSkipBits) % 8;
                 columnVector.noNulls = false;
             }
             else
@@ -222,6 +225,7 @@ public class TimestampColumnReader extends ColumnReader
         // read without copying the de-compacted content and isNull
         int numLeft = size, numToRead, bytesToDeCompact, vectorWriteIndex = vectorIndex;
         boolean[] isNull = null;
+        boolean endOfPixel;
         if (decoding || !nullsPadding)
         {
             isNull = new boolean[size];
@@ -232,13 +236,14 @@ public class TimestampColumnReader extends ColumnReader
             {
                 // read to the end of the current pixel
                 numToRead = pixelStride - elementIndex % pixelStride;
+                endOfPixel = true;
             }
             else
             {
                 numToRead = numLeft;
+                endOfPixel = false;
             }
-            bytesToDeCompact = (numToRead + isNullSkipBits) / 8;
-
+            bytesToDeCompact = (numToRead + isNullSkipBits + (endOfPixel ? 7 : 0)) / 8;
             // read isNull
             int pixelId = elementIndex / pixelStride;
             hasNull = chunkIndex.getPixelStatistics(pixelId).getStatistic().getHasNull();
@@ -266,7 +271,7 @@ public class TimestampColumnReader extends ColumnReader
                     }
                 }
                 isNullOffset += bytesToDeCompact;
-                isNullSkipBits = (numToRead + isNullSkipBits) % 8;
+                isNullSkipBits = endOfPixel ? 0 : (numToRead + isNullSkipBits) % 8;
                 columnVector.noNulls = false;
             }
             else

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestBooleanColumnReader.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestBooleanColumnReader.java
@@ -73,6 +73,8 @@ public class TestBooleanColumnReader
         byteColumnVector.add(true);
         columnWriter.write(byteColumnVector, numRows);
         columnWriter.flush();
+        columnWriter.close();
+
         byte[] content = columnWriter.getColumnChunkContent();
         PixelsProto.ColumnChunkIndex chunkIndex = columnWriter.getColumnChunkIndex().build();
         PixelsProto.ColumnEncoding encoding = columnWriter.getColumnChunkEncoding().build();
@@ -80,6 +82,8 @@ public class TestBooleanColumnReader
         ByteColumnVector byteColumnVector1 = new ByteColumnVector(numRows);
         columnReader.read(ByteBuffer.wrap(content), encoding, 0, numRows,
                 pixelsStride, 0, byteColumnVector1, chunkIndex);
+        columnReader.close();
+
         for (int i = 0; i < numRows; ++i)
         {
             assert byteColumnVector1.noNulls == byteColumnVector.noNulls;
@@ -126,6 +130,8 @@ public class TestBooleanColumnReader
         byteColumnVector.add(true);
         columnWriter.write(byteColumnVector, numRows);
         columnWriter.flush();
+        columnWriter.close();
+
         byte[] content = columnWriter.getColumnChunkContent();
         PixelsProto.ColumnChunkIndex chunkIndex = columnWriter.getColumnChunkIndex().build();
         PixelsProto.ColumnEncoding encoding = columnWriter.getColumnChunkEncoding().build();
@@ -133,6 +139,8 @@ public class TestBooleanColumnReader
         ByteColumnVector byteColumnVector1 = new ByteColumnVector(numRows);
         columnReader.read(ByteBuffer.wrap(content), encoding, 0, numRows,
                 pixelsStride, 0, byteColumnVector1, chunkIndex);
+        columnReader.close();
+
         for (int i = 0; i < numRows; ++i)
         {
             assert byteColumnVector1.noNulls == byteColumnVector.noNulls;
@@ -179,6 +187,8 @@ public class TestBooleanColumnReader
         byteColumnVector.add(true);
         columnWriter.write(byteColumnVector, numRows);
         columnWriter.flush();
+        columnWriter.close();
+
         byte[] content = columnWriter.getColumnChunkContent();
         PixelsProto.ColumnChunkIndex chunkIndex = columnWriter.getColumnChunkIndex().build();
         PixelsProto.ColumnEncoding encoding = columnWriter.getColumnChunkEncoding().build();
@@ -190,6 +200,8 @@ public class TestBooleanColumnReader
         selected.clear(20);
         columnReader.readSelected(ByteBuffer.wrap(content), encoding, 0, numRows,
                 pixelsStride, 0, byteColumnVector1, chunkIndex, selected);
+        columnReader.close();
+
         for (int i = 0, j = 0; i < numRows; ++i)
         {
             if (i % 10 != 0)
@@ -243,6 +255,7 @@ public class TestBooleanColumnReader
         ByteColumnVector targetVector = new ByteColumnVector(numBatches*numRows);
         columnReader.read(ByteBuffer.wrap(content), encoding, 0, numBatches*numRows,
                 10000, 0, targetVector, chunkIndex);
+        columnReader.close();
 
         for (int i = 0; i < numBatches*numRows; i++)
         {
@@ -293,12 +306,14 @@ public class TestBooleanColumnReader
         PixelsProto.ColumnEncoding encoding = columnWriter.getColumnChunkEncoding().build();
         BooleanColumnReader columnReader = new BooleanColumnReader(TypeDescription.createBoolean());
         ByteColumnVector targetVector = new ByteColumnVector(numBatches*numRows);
-        columnReader.read(ByteBuffer.wrap(content), encoding, 0, 123,
+        ByteBuffer buffer = ByteBuffer.wrap(content);
+        columnReader.read(buffer, encoding, 0, 123,
                 10000, 0, targetVector, chunkIndex);
-        columnReader.read(ByteBuffer.wrap(content), encoding, 123, 456,
+        columnReader.read(buffer, encoding, 123, 456,
                 10000, 123, targetVector, chunkIndex);
-        columnReader.read(ByteBuffer.wrap(content), encoding, 123+456, numBatches*numRows-123-456,
+        columnReader.read(buffer, encoding, 123+456, numBatches*numRows-123-456,
                 10000, 123+456, targetVector, chunkIndex);
+        columnReader.close();
 
         for (int i = 0; i < numBatches*numRows; i++)
         {

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestBooleanColumnReader.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestBooleanColumnReader.java
@@ -41,7 +41,7 @@ public class TestBooleanColumnReader
     public void test() throws IOException
     {
         PixelsWriterOption writerOption = new PixelsWriterOption()
-                .pixelStride(10).byteOrder(ByteOrder.LITTLE_ENDIAN)
+                .pixelStride(8).byteOrder(ByteOrder.LITTLE_ENDIAN)
                 .encodingLevel(EncodingLevel.EL0).nullsPadding(true);
         BooleanColumnWriter columnWriter = new BooleanColumnWriter(
                 TypeDescription.createBoolean(), writerOption);
@@ -62,7 +62,7 @@ public class TestBooleanColumnReader
         byteColumnVector.add(true);
         byteColumnVector.add(false);
         byteColumnVector.add(false);
-        byteColumnVector.add(false);
+        byteColumnVector.addNull();
         byteColumnVector.add(false);
         byteColumnVector.add(true);
         byteColumnVector.add(false);
@@ -76,7 +76,60 @@ public class TestBooleanColumnReader
         BooleanColumnReader columnReader = new BooleanColumnReader(TypeDescription.createBoolean());
         ByteColumnVector byteColumnVector1 = new ByteColumnVector(22);
         columnReader.read(ByteBuffer.wrap(content), encoding, 0, 22,
-                10, 0, byteColumnVector1, chunkIndex);
+                8, 0, byteColumnVector1, chunkIndex);
+        for (int i = 0; i < 22; ++i)
+        {
+            if (!byteColumnVector1.noNulls && byteColumnVector1.isNull[i])
+            {
+                assert !byteColumnVector.noNulls && byteColumnVector.isNull[i];
+            }
+            else
+            {
+                assert byteColumnVector1.vector[i] == byteColumnVector.vector[i];
+            }
+        }
+    }
+
+    @Test
+    public void testWithoutNullsPadding() throws IOException
+    {
+        PixelsWriterOption writerOption = new PixelsWriterOption()
+                .pixelStride(8).byteOrder(ByteOrder.LITTLE_ENDIAN)
+                .encodingLevel(EncodingLevel.EL0).nullsPadding(false);
+        BooleanColumnWriter columnWriter = new BooleanColumnWriter(
+                TypeDescription.createBoolean(), writerOption);
+        ByteColumnVector byteColumnVector = new ByteColumnVector(22);
+        byteColumnVector.add(false);
+        byteColumnVector.add(false);
+        byteColumnVector.add(false);
+        byteColumnVector.add(true);
+        byteColumnVector.addNull();
+        byteColumnVector.add(false);
+        byteColumnVector.add(true);
+        byteColumnVector.add(true);
+        byteColumnVector.addNull();
+        byteColumnVector.add(false);
+        byteColumnVector.add(false);
+        byteColumnVector.add(false);
+        byteColumnVector.add(false);
+        byteColumnVector.add(true);
+        byteColumnVector.add(false);
+        byteColumnVector.add(false);
+        byteColumnVector.addNull();
+        byteColumnVector.add(false);
+        byteColumnVector.add(true);
+        byteColumnVector.add(false);
+        byteColumnVector.add(false);
+        byteColumnVector.add(true);
+        columnWriter.write(byteColumnVector, 22);
+        columnWriter.flush();
+        byte[] content = columnWriter.getColumnChunkContent();
+        PixelsProto.ColumnChunkIndex chunkIndex = columnWriter.getColumnChunkIndex().build();
+        PixelsProto.ColumnEncoding encoding = columnWriter.getColumnChunkEncoding().build();
+        BooleanColumnReader columnReader = new BooleanColumnReader(TypeDescription.createBoolean());
+        ByteColumnVector byteColumnVector1 = new ByteColumnVector(22);
+        columnReader.read(ByteBuffer.wrap(content), encoding, 0, 22,
+                8, 0, byteColumnVector1, chunkIndex);
         for (int i = 0; i < 22; ++i)
         {
             if (!byteColumnVector1.noNulls && byteColumnVector1.isNull[i])

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestBooleanColumnReader.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestBooleanColumnReader.java
@@ -214,16 +214,16 @@ public class TestBooleanColumnReader
     @Test
     public void testLarge() throws IOException
     {
-        int batchNum = 15;
-        int rowNum = 1024;
+        int numBatches = 15;
+        int numRows = 1024;
         PixelsWriterOption writerOption = new PixelsWriterOption()
                 .pixelStride(10000).byteOrder(ByteOrder.LITTLE_ENDIAN)
                 .encodingLevel(EncodingLevel.EL0).nullsPadding(true);
         BooleanColumnWriter columnWriter = new BooleanColumnWriter(
                 TypeDescription.createBoolean(), writerOption);
 
-        ByteColumnVector originVector = new ByteColumnVector(rowNum);
-        for (int j = 0; j < rowNum; j++)
+        ByteColumnVector originVector = new ByteColumnVector(numRows);
+        for (int j = 0; j < numRows; j++)
         {
             if (j % 100 == 0)
             {
@@ -235,9 +235,9 @@ public class TestBooleanColumnReader
             }
         }
 
-        for (int i = 0; i < batchNum; i++)
+        for (int i = 0; i < numBatches; i++)
         {
-            columnWriter.write(originVector, rowNum);
+            columnWriter.write(originVector, numRows);
         }
         columnWriter.flush();
         columnWriter.close();
@@ -246,16 +246,16 @@ public class TestBooleanColumnReader
         PixelsProto.ColumnChunkIndex chunkIndex = columnWriter.getColumnChunkIndex().build();
         PixelsProto.ColumnEncoding encoding = columnWriter.getColumnChunkEncoding().build();
         BooleanColumnReader columnReader = new BooleanColumnReader(TypeDescription.createBoolean());
-        ByteColumnVector targetVector = new ByteColumnVector(batchNum*rowNum);
-        columnReader.read(ByteBuffer.wrap(content), encoding, 0, batchNum*rowNum,
+        ByteColumnVector targetVector = new ByteColumnVector(numBatches*numRows);
+        columnReader.read(ByteBuffer.wrap(content), encoding, 0, numBatches*numRows,
                 10000, 0, targetVector, chunkIndex);
 
-        for (int i = 0; i < batchNum*rowNum; i++)
+        for (int i = 0; i < numBatches*numRows; i++)
         {
-            assert targetVector.isNull[i] == originVector.isNull[i%rowNum];
+            assert targetVector.isNull[i] == originVector.isNull[i%numRows];
             if (!targetVector.isNull[i])
             {
-                assert targetVector.vector[i] == originVector.vector[i % rowNum];
+                assert targetVector.vector[i] == originVector.vector[i % numRows];
             }
         }
     }
@@ -266,16 +266,16 @@ public class TestBooleanColumnReader
     @Test
     public void testLargeFragmented() throws IOException
     {
-        int batchNum = 15;
-        int rowNum = 1024;
+        int numBatches = 15;
+        int numRows = 1024;
         PixelsWriterOption writerOption = new PixelsWriterOption()
                 .pixelStride(10000).byteOrder(ByteOrder.LITTLE_ENDIAN)
                 .encodingLevel(EncodingLevel.EL0).nullsPadding(true);
         BooleanColumnWriter columnWriter = new BooleanColumnWriter(
                 TypeDescription.createBoolean(), writerOption);
 
-        ByteColumnVector originVector = new ByteColumnVector(rowNum);
-        for (int j = 0; j < rowNum; j++)
+        ByteColumnVector originVector = new ByteColumnVector(numRows);
+        for (int j = 0; j < numRows; j++)
         {
             if (j % 100 == 0)
             {
@@ -287,9 +287,9 @@ public class TestBooleanColumnReader
             }
         }
 
-        for (int i = 0; i < batchNum; i++)
+        for (int i = 0; i < numBatches; i++)
         {
-            columnWriter.write(originVector, rowNum);
+            columnWriter.write(originVector, numRows);
         }
         columnWriter.flush();
         columnWriter.close();
@@ -298,20 +298,20 @@ public class TestBooleanColumnReader
         PixelsProto.ColumnChunkIndex chunkIndex = columnWriter.getColumnChunkIndex().build();
         PixelsProto.ColumnEncoding encoding = columnWriter.getColumnChunkEncoding().build();
         BooleanColumnReader columnReader = new BooleanColumnReader(TypeDescription.createBoolean());
-        ByteColumnVector targetVector = new ByteColumnVector(batchNum*rowNum);
+        ByteColumnVector targetVector = new ByteColumnVector(numBatches*numRows);
         columnReader.read(ByteBuffer.wrap(content), encoding, 0, 123,
                 10000, 0, targetVector, chunkIndex);
         columnReader.read(ByteBuffer.wrap(content), encoding, 123, 456,
                 10000, 123, targetVector, chunkIndex);
-        columnReader.read(ByteBuffer.wrap(content), encoding, 123+456, batchNum*rowNum-123-456,
+        columnReader.read(ByteBuffer.wrap(content), encoding, 123+456, numBatches*numRows-123-456,
                 10000, 123+456, targetVector, chunkIndex);
 
-        for (int i = 0; i < batchNum*rowNum; i++)
+        for (int i = 0; i < numBatches*numRows; i++)
         {
-            assert targetVector.isNull[i] == originVector.isNull[i%rowNum];
+            assert targetVector.isNull[i] == originVector.isNull[i%numRows];
             if (!targetVector.isNull[i])
             {
-                assert targetVector.vector[i] == originVector.vector[i % rowNum];
+                assert targetVector.vector[i] == originVector.vector[i % numRows];
             }
         }
     }

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestBooleanColumnReader.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestBooleanColumnReader.java
@@ -82,11 +82,9 @@ public class TestBooleanColumnReader
                 pixelsStride, 0, byteColumnVector1, chunkIndex);
         for (int i = 0; i < numRows; ++i)
         {
-            if (!byteColumnVector1.noNulls && byteColumnVector1.isNull[i])
-            {
-                assert !byteColumnVector.noNulls && byteColumnVector.isNull[i];
-            }
-            else
+            assert byteColumnVector1.noNulls == byteColumnVector.noNulls;
+            assert byteColumnVector1.isNull[i] == byteColumnVector.isNull[i];
+            if (byteColumnVector.noNulls || !byteColumnVector.isNull[i])
             {
                 assert byteColumnVector1.vector[i] == byteColumnVector.vector[i];
             }
@@ -137,11 +135,9 @@ public class TestBooleanColumnReader
                 pixelsStride, 0, byteColumnVector1, chunkIndex);
         for (int i = 0; i < numRows; ++i)
         {
-            if (!byteColumnVector1.noNulls && byteColumnVector1.isNull[i])
-            {
-                assert !byteColumnVector.noNulls && byteColumnVector.isNull[i];
-            }
-            else
+            assert byteColumnVector1.noNulls == byteColumnVector.noNulls;
+            assert byteColumnVector1.isNull[i] == byteColumnVector.isNull[i];
+            if (byteColumnVector.noNulls || !byteColumnVector.isNull[i])
             {
                 assert byteColumnVector1.vector[i] == byteColumnVector.vector[i];
             }
@@ -198,11 +194,9 @@ public class TestBooleanColumnReader
         {
             if (i % 10 != 0)
             {
-                if (!byteColumnVector1.noNulls && byteColumnVector1.isNull[j])
-                {
-                    assert !byteColumnVector.noNulls && byteColumnVector.isNull[i];
-                }
-                else
+                assert byteColumnVector1.noNulls == byteColumnVector.noNulls;
+                assert byteColumnVector1.isNull[j] == byteColumnVector.isNull[i];
+                if (byteColumnVector.noNulls || !byteColumnVector.isNull[i])
                 {
                     assert byteColumnVector1.vector[j] == byteColumnVector.vector[i];
                 }
@@ -253,7 +247,7 @@ public class TestBooleanColumnReader
         for (int i = 0; i < numBatches*numRows; i++)
         {
             assert targetVector.isNull[i] == originVector.isNull[i%numRows];
-            if (!targetVector.isNull[i])
+            if (targetVector.noNulls || !targetVector.isNull[i])
             {
                 assert targetVector.vector[i] == originVector.vector[i % numRows];
             }
@@ -309,7 +303,7 @@ public class TestBooleanColumnReader
         for (int i = 0; i < numBatches*numRows; i++)
         {
             assert targetVector.isNull[i] == originVector.isNull[i%numRows];
-            if (!targetVector.isNull[i])
+            if (targetVector.noNulls || !targetVector.isNull[i])
             {
                 assert targetVector.vector[i] == originVector.vector[i % numRows];
             }

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestBooleanColumnReader.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestBooleanColumnReader.java
@@ -65,7 +65,7 @@ public class TestBooleanColumnReader
         byteColumnVector.add(true);
         byteColumnVector.add(false);
         byteColumnVector.add(false);
-        byteColumnVector.add(false);
+        byteColumnVector.addNull();
         byteColumnVector.add(false);
         byteColumnVector.add(true);
         byteColumnVector.add(false);

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestDateColumnReader.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestDateColumnReader.java
@@ -82,6 +82,8 @@ public class TestDateColumnReader
         DateColumnVector dateColumnVector1 = new DateColumnVector(numRows);
         columnReader.read(ByteBuffer.wrap(content), encoding, 0, numRows,
                 pixelsStride, 0, dateColumnVector1, chunkIndex);
+        columnReader.close();
+
         for (int i = 0; i < numRows; ++i)
         {
             assert dateColumnVector1.noNulls == dateColumnVector.noNulls;
@@ -137,6 +139,8 @@ public class TestDateColumnReader
         DateColumnVector dateColumnVector1 = new DateColumnVector(numRows);
         columnReader.read(ByteBuffer.wrap(content), encoding, 0, numRows,
                 pixelsStride, 0, dateColumnVector1, chunkIndex);
+        columnReader.close();
+
         for (int i = 0; i < numRows; ++i)
         {
             assert dateColumnVector1.noNulls == dateColumnVector.noNulls;
@@ -196,6 +200,8 @@ public class TestDateColumnReader
         selected.clear(20);
         columnReader.readSelected(ByteBuffer.wrap(content), encoding, 0, numRows,
                 pixelsStride, 0, dateColumnVector1, chunkIndex, selected);
+        columnReader.close();
+
         for (int i = 0, j = 0; i < numRows; ++i)
         {
             if (i % 10 != 0)
@@ -249,6 +255,7 @@ public class TestDateColumnReader
         DateColumnVector targetVector = new DateColumnVector(numBatches*numRows);
         columnReader.read(ByteBuffer.wrap(content), encoding, 0, numBatches*numRows,
                 10000, 0, targetVector, chunkIndex);
+        columnReader.close();
 
         for (int i = 0; i < numBatches*numRows; i++)
         {
@@ -299,12 +306,14 @@ public class TestDateColumnReader
         PixelsProto.ColumnEncoding encoding = columnWriter.getColumnChunkEncoding().build();
         DateColumnReader columnReader = new DateColumnReader(TypeDescription.createDate());
         DateColumnVector targetVector = new DateColumnVector(numBatches*numRows);
-        columnReader.read(ByteBuffer.wrap(content), encoding, 0, 123,
+        ByteBuffer buffer = ByteBuffer.wrap(content);
+        columnReader.read(buffer, encoding, 0, 123,
                 10000, 0, targetVector, chunkIndex);
-        columnReader.read(ByteBuffer.wrap(content), encoding, 123, 456,
+        columnReader.read(buffer, encoding, 123, 456,
                 10000, 123, targetVector, chunkIndex);
-        columnReader.read(ByteBuffer.wrap(content), encoding, 123+456, numBatches*numRows-123-456,
+        columnReader.read(buffer, encoding, 123+456, numBatches*numRows-123-456,
                 10000, 123+456, targetVector, chunkIndex);
+        columnReader.close();
 
         for (int i = 0; i < numBatches*numRows; i++)
         {

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestDateColumnReader.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestDateColumnReader.java
@@ -194,7 +194,7 @@ public class TestDateColumnReader
         PixelsProto.ColumnEncoding encoding = columnWriter.getColumnChunkEncoding().build();
         DateColumnReader columnReader = new DateColumnReader(TypeDescription.createDate());
         DateColumnVector dateColumnVector1 = new DateColumnVector(numRows);
-        Bitmap selected = new Bitmap(22, true);
+        Bitmap selected = new Bitmap(numRows, true);
         selected.clear(0);
         selected.clear(10);
         selected.clear(20);
@@ -220,16 +220,16 @@ public class TestDateColumnReader
     @Test
     public void testLarge() throws IOException
     {
-        int batchNum = 15;
-        int rowNum = 1024;
+        int numBatches = 15;
+        int numRows = 1024;
         PixelsWriterOption writerOption = new PixelsWriterOption()
                 .pixelStride(10000).byteOrder(ByteOrder.LITTLE_ENDIAN)
                 .encodingLevel(EncodingLevel.EL0).nullsPadding(true);
         DateColumnWriter columnWriter = new DateColumnWriter(
                 TypeDescription.createDate(), writerOption);
 
-        DateColumnVector originVector = new DateColumnVector(rowNum);
-        for (int j = 0; j < rowNum; j++)
+        DateColumnVector originVector = new DateColumnVector(numRows);
+        for (int j = 0; j < numRows; j++)
         {
             if (j % 100 == 0)
             {
@@ -241,9 +241,9 @@ public class TestDateColumnReader
             }
         }
 
-        for (int i = 0; i < batchNum; i++)
+        for (int i = 0; i < numBatches; i++)
         {
-            columnWriter.write(originVector, rowNum);
+            columnWriter.write(originVector, numRows);
         }
         columnWriter.flush();
         columnWriter.close();
@@ -252,16 +252,16 @@ public class TestDateColumnReader
         PixelsProto.ColumnChunkIndex chunkIndex = columnWriter.getColumnChunkIndex().build();
         PixelsProto.ColumnEncoding encoding = columnWriter.getColumnChunkEncoding().build();
         DateColumnReader columnReader = new DateColumnReader(TypeDescription.createDate());
-        DateColumnVector targetVector = new DateColumnVector(batchNum*rowNum);
-        columnReader.read(ByteBuffer.wrap(content), encoding, 0, batchNum*rowNum,
+        DateColumnVector targetVector = new DateColumnVector(numBatches*numRows);
+        columnReader.read(ByteBuffer.wrap(content), encoding, 0, numBatches*numRows,
                 10000, 0, targetVector, chunkIndex);
 
-        for (int i = 0; i < batchNum*rowNum; i++)
+        for (int i = 0; i < numBatches*numRows; i++)
         {
-            assert targetVector.isNull[i] == originVector.isNull[i%rowNum];
+            assert targetVector.isNull[i] == originVector.isNull[i%numRows];
             if (!targetVector.isNull[i])
             {
-                assert targetVector.dates[i] == originVector.dates[i % rowNum];
+                assert targetVector.dates[i] == originVector.dates[i % numRows];
             }
         }
     }
@@ -272,16 +272,16 @@ public class TestDateColumnReader
     @Test
     public void testLargeFragmented() throws IOException
     {
-        int batchNum = 15;
-        int rowNum = 1024;
+        int numBatches = 15;
+        int numRows = 1024;
         PixelsWriterOption writerOption = new PixelsWriterOption()
                 .pixelStride(10000).byteOrder(ByteOrder.LITTLE_ENDIAN)
                 .encodingLevel(EncodingLevel.EL0).nullsPadding(true);
         DateColumnWriter columnWriter = new DateColumnWriter(
                 TypeDescription.createDate(), writerOption);
 
-        DateColumnVector originVector = new DateColumnVector(rowNum);
-        for (int j = 0; j < rowNum; j++)
+        DateColumnVector originVector = new DateColumnVector(numRows);
+        for (int j = 0; j < numRows; j++)
         {
             if (j % 100 == 0)
             {
@@ -293,9 +293,9 @@ public class TestDateColumnReader
             }
         }
 
-        for (int i = 0; i < batchNum; i++)
+        for (int i = 0; i < numBatches; i++)
         {
-            columnWriter.write(originVector, rowNum);
+            columnWriter.write(originVector, numRows);
         }
         columnWriter.flush();
         columnWriter.close();
@@ -304,20 +304,20 @@ public class TestDateColumnReader
         PixelsProto.ColumnChunkIndex chunkIndex = columnWriter.getColumnChunkIndex().build();
         PixelsProto.ColumnEncoding encoding = columnWriter.getColumnChunkEncoding().build();
         DateColumnReader columnReader = new DateColumnReader(TypeDescription.createDate());
-        DateColumnVector targetVector = new DateColumnVector(batchNum*rowNum);
+        DateColumnVector targetVector = new DateColumnVector(numBatches*numRows);
         columnReader.read(ByteBuffer.wrap(content), encoding, 0, 123,
                 10000, 0, targetVector, chunkIndex);
         columnReader.read(ByteBuffer.wrap(content), encoding, 123, 456,
                 10000, 123, targetVector, chunkIndex);
-        columnReader.read(ByteBuffer.wrap(content), encoding, 123+456, batchNum*rowNum-123-456,
+        columnReader.read(ByteBuffer.wrap(content), encoding, 123+456, numBatches*numRows-123-456,
                 10000, 123+456, targetVector, chunkIndex);
 
-        for (int i = 0; i < batchNum*rowNum; i++)
+        for (int i = 0; i < numBatches*numRows; i++)
         {
-            assert targetVector.isNull[i] == originVector.isNull[i%rowNum];
+            assert targetVector.isNull[i] == originVector.isNull[i%numRows];
             if (!targetVector.isNull[i])
             {
-                assert targetVector.dates[i] == originVector.dates[i % rowNum];
+                assert targetVector.dates[i] == originVector.dates[i % numRows];
             }
         }
     }

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestDateColumnReader.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestDateColumnReader.java
@@ -84,11 +84,9 @@ public class TestDateColumnReader
                 pixelsStride, 0, dateColumnVector1, chunkIndex);
         for (int i = 0; i < numRows; ++i)
         {
-            if (!dateColumnVector1.noNulls && dateColumnVector1.isNull[i])
-            {
-                assert !dateColumnVector.noNulls && dateColumnVector.isNull[i];
-            }
-            else
+            assert dateColumnVector1.noNulls == dateColumnVector.noNulls;
+            assert dateColumnVector1.isNull[i] == dateColumnVector.isNull[i];
+            if (dateColumnVector.noNulls || !dateColumnVector.isNull[i])
             {
                 assert dateColumnVector1.dates[i] == dateColumnVector.dates[i];
             }
@@ -141,11 +139,9 @@ public class TestDateColumnReader
                 pixelsStride, 0, dateColumnVector1, chunkIndex);
         for (int i = 0; i < numRows; ++i)
         {
-            if (!dateColumnVector1.noNulls && dateColumnVector1.isNull[i])
-            {
-                assert !dateColumnVector.noNulls && dateColumnVector.isNull[i];
-            }
-            else
+            assert dateColumnVector1.noNulls == dateColumnVector.noNulls;
+            assert dateColumnVector1.isNull[i] == dateColumnVector.isNull[i];
+            if (dateColumnVector.noNulls || !dateColumnVector.isNull[i])
             {
                 assert dateColumnVector1.dates[i] == dateColumnVector.dates[i];
             }
@@ -204,11 +200,9 @@ public class TestDateColumnReader
         {
             if (i % 10 != 0)
             {
-                if (!dateColumnVector1.noNulls && dateColumnVector1.isNull[j])
-                {
-                    assert !dateColumnVector.noNulls && dateColumnVector.isNull[i];
-                }
-                else
+                assert dateColumnVector1.noNulls == dateColumnVector.noNulls;
+                assert dateColumnVector1.isNull[j] == dateColumnVector.isNull[i];
+                if (dateColumnVector.noNulls || !dateColumnVector.isNull[i])
                 {
                     assert dateColumnVector1.dates[j] == dateColumnVector.dates[i];
                 }
@@ -259,7 +253,7 @@ public class TestDateColumnReader
         for (int i = 0; i < numBatches*numRows; i++)
         {
             assert targetVector.isNull[i] == originVector.isNull[i%numRows];
-            if (!targetVector.isNull[i])
+            if (targetVector.noNulls || !targetVector.isNull[i])
             {
                 assert targetVector.dates[i] == originVector.dates[i % numRows];
             }
@@ -315,7 +309,7 @@ public class TestDateColumnReader
         for (int i = 0; i < numBatches*numRows; i++)
         {
             assert targetVector.isNull[i] == originVector.isNull[i%numRows];
-            if (!targetVector.isNull[i])
+            if (targetVector.noNulls || !targetVector.isNull[i])
             {
                 assert targetVector.dates[i] == originVector.dates[i % numRows];
             }

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestDateColumnReader.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestDateColumnReader.java
@@ -22,6 +22,7 @@ package io.pixelsdb.pixels.core.reader;
 import io.pixelsdb.pixels.core.PixelsProto;
 import io.pixelsdb.pixels.core.TypeDescription;
 import io.pixelsdb.pixels.core.encoding.EncodingLevel;
+import io.pixelsdb.pixels.core.utils.Bitmap;
 import io.pixelsdb.pixels.core.vector.DateColumnVector;
 import io.pixelsdb.pixels.core.writer.DateColumnWriter;
 import io.pixelsdb.pixels.core.writer.PixelsWriterOption;
@@ -38,14 +39,16 @@ import java.nio.ByteOrder;
 public class TestDateColumnReader
 {
     @Test
-    public void test() throws IOException
+    public void testNullsPadding() throws IOException
     {
+        int pixelsStride = 10;
+        int numRows = 22;
         PixelsWriterOption writerOption = new PixelsWriterOption()
-                .pixelStride(10).byteOrder(ByteOrder.LITTLE_ENDIAN)
+                .pixelStride(pixelsStride).byteOrder(ByteOrder.LITTLE_ENDIAN)
                 .encodingLevel(EncodingLevel.EL0).nullsPadding(true);
         DateColumnWriter columnWriter = new DateColumnWriter(
                 TypeDescription.createDate(), writerOption);
-        DateColumnVector dateColumnVector = new DateColumnVector(22);
+        DateColumnVector dateColumnVector = new DateColumnVector(numRows);
         dateColumnVector.add(100);
         dateColumnVector.add(103);
         dateColumnVector.add(106);
@@ -68,16 +71,18 @@ public class TestDateColumnReader
         dateColumnVector.add(65656565);
         dateColumnVector.add(3434);
         dateColumnVector.add(54578);
-        columnWriter.write(dateColumnVector, 22);
+        columnWriter.write(dateColumnVector, numRows);
         columnWriter.flush();
+        columnWriter.close();
+
         byte[] content = columnWriter.getColumnChunkContent();
         PixelsProto.ColumnChunkIndex chunkIndex = columnWriter.getColumnChunkIndex().build();
         PixelsProto.ColumnEncoding encoding = columnWriter.getColumnChunkEncoding().build();
         DateColumnReader columnReader = new DateColumnReader(TypeDescription.createDate());
-        DateColumnVector dateColumnVector1 = new DateColumnVector(22);
-        columnReader.read(ByteBuffer.wrap(content), encoding, 0, 22,
-                10, 0, dateColumnVector1, chunkIndex);
-        for (int i = 0; i < 22; ++i)
+        DateColumnVector dateColumnVector1 = new DateColumnVector(numRows);
+        columnReader.read(ByteBuffer.wrap(content), encoding, 0, numRows,
+                pixelsStride, 0, dateColumnVector1, chunkIndex);
+        for (int i = 0; i < numRows; ++i)
         {
             if (!dateColumnVector1.noNulls && dateColumnVector1.isNull[i])
             {
@@ -86,6 +91,128 @@ public class TestDateColumnReader
             else
             {
                 assert dateColumnVector1.dates[i] == dateColumnVector.dates[i];
+            }
+        }
+    }
+
+    @Test
+    public void testWithoutNullsPadding() throws IOException
+    {
+        int pixelsStride = 10;
+        int numRows = 22;
+        PixelsWriterOption writerOption = new PixelsWriterOption()
+                .pixelStride(pixelsStride).byteOrder(ByteOrder.LITTLE_ENDIAN)
+                .encodingLevel(EncodingLevel.EL0).nullsPadding(false);
+        DateColumnWriter columnWriter = new DateColumnWriter(
+                TypeDescription.createDate(), writerOption);
+        DateColumnVector dateColumnVector = new DateColumnVector(numRows);
+        dateColumnVector.add(100);
+        dateColumnVector.add(103);
+        dateColumnVector.add(106);
+        dateColumnVector.add(34);
+        dateColumnVector.addNull();
+        dateColumnVector.add(54);
+        dateColumnVector.add(55);
+        dateColumnVector.add(67);
+        dateColumnVector.addNull();
+        dateColumnVector.add(34);
+        dateColumnVector.add(555);
+        dateColumnVector.add(565);
+        dateColumnVector.add(234);
+        dateColumnVector.add(675);
+        dateColumnVector.add(235);
+        dateColumnVector.add(32434);
+        dateColumnVector.addNull();
+        dateColumnVector.add(6);
+        dateColumnVector.add(7);
+        dateColumnVector.add(65656565);
+        dateColumnVector.add(3434);
+        dateColumnVector.add(54578);
+        columnWriter.write(dateColumnVector, numRows);
+        columnWriter.flush();
+        columnWriter.close();
+
+        byte[] content = columnWriter.getColumnChunkContent();
+        PixelsProto.ColumnChunkIndex chunkIndex = columnWriter.getColumnChunkIndex().build();
+        PixelsProto.ColumnEncoding encoding = columnWriter.getColumnChunkEncoding().build();
+        DateColumnReader columnReader = new DateColumnReader(TypeDescription.createDate());
+        DateColumnVector dateColumnVector1 = new DateColumnVector(numRows);
+        columnReader.read(ByteBuffer.wrap(content), encoding, 0, numRows,
+                pixelsStride, 0, dateColumnVector1, chunkIndex);
+        for (int i = 0; i < numRows; ++i)
+        {
+            if (!dateColumnVector1.noNulls && dateColumnVector1.isNull[i])
+            {
+                assert !dateColumnVector.noNulls && dateColumnVector.isNull[i];
+            }
+            else
+            {
+                assert dateColumnVector1.dates[i] == dateColumnVector.dates[i];
+            }
+        }
+    }
+
+    @Test
+    public void testSelected() throws IOException
+    {
+        int pixelsStride = 10;
+        int numRows = 22;
+        PixelsWriterOption writerOption = new PixelsWriterOption()
+                .pixelStride(pixelsStride).byteOrder(ByteOrder.LITTLE_ENDIAN)
+                .encodingLevel(EncodingLevel.EL0).nullsPadding(true);
+        DateColumnWriter columnWriter = new DateColumnWriter(
+                TypeDescription.createDate(), writerOption);
+        DateColumnVector dateColumnVector = new DateColumnVector(numRows);
+        dateColumnVector.add(100);
+        dateColumnVector.add(103);
+        dateColumnVector.add(106);
+        dateColumnVector.add(34);
+        dateColumnVector.addNull();
+        dateColumnVector.add(54);
+        dateColumnVector.add(55);
+        dateColumnVector.add(67);
+        dateColumnVector.addNull();
+        dateColumnVector.add(34);
+        dateColumnVector.add(555);
+        dateColumnVector.add(565);
+        dateColumnVector.add(234);
+        dateColumnVector.add(675);
+        dateColumnVector.add(235);
+        dateColumnVector.add(32434);
+        dateColumnVector.addNull();
+        dateColumnVector.add(6);
+        dateColumnVector.add(7);
+        dateColumnVector.add(65656565);
+        dateColumnVector.add(3434);
+        dateColumnVector.add(54578);
+        columnWriter.write(dateColumnVector, 22);
+        columnWriter.flush();
+        columnWriter.close();
+
+        byte[] content = columnWriter.getColumnChunkContent();
+        PixelsProto.ColumnChunkIndex chunkIndex = columnWriter.getColumnChunkIndex().build();
+        PixelsProto.ColumnEncoding encoding = columnWriter.getColumnChunkEncoding().build();
+        DateColumnReader columnReader = new DateColumnReader(TypeDescription.createDate());
+        DateColumnVector dateColumnVector1 = new DateColumnVector(numRows);
+        Bitmap selected = new Bitmap(22, true);
+        selected.clear(0);
+        selected.clear(10);
+        selected.clear(20);
+        columnReader.readSelected(ByteBuffer.wrap(content), encoding, 0, numRows,
+                pixelsStride, 0, dateColumnVector1, chunkIndex, selected);
+        for (int i = 0, j = 0; i < numRows; ++i)
+        {
+            if (i % 10 != 0)
+            {
+                if (!dateColumnVector1.noNulls && dateColumnVector1.isNull[j])
+                {
+                    assert !dateColumnVector.noNulls && dateColumnVector.isNull[i];
+                }
+                else
+                {
+                    assert dateColumnVector1.dates[j] == dateColumnVector.dates[i];
+                }
+                j++;
             }
         }
     }
@@ -128,6 +255,62 @@ public class TestDateColumnReader
         DateColumnVector targetVector = new DateColumnVector(batchNum*rowNum);
         columnReader.read(ByteBuffer.wrap(content), encoding, 0, batchNum*rowNum,
                 10000, 0, targetVector, chunkIndex);
+
+        for (int i = 0; i < batchNum*rowNum; i++)
+        {
+            assert targetVector.isNull[i] == originVector.isNull[i%rowNum];
+            if (!targetVector.isNull[i])
+            {
+                assert targetVector.dates[i] == originVector.dates[i % rowNum];
+            }
+        }
+    }
+
+    /**
+     * Test reading into column vectors with a run-length smaller than pixels stride.
+     */
+    @Test
+    public void testLargeFragmented() throws IOException
+    {
+        int batchNum = 15;
+        int rowNum = 1024;
+        PixelsWriterOption writerOption = new PixelsWriterOption()
+                .pixelStride(10000).byteOrder(ByteOrder.LITTLE_ENDIAN)
+                .encodingLevel(EncodingLevel.EL0).nullsPadding(true);
+        DateColumnWriter columnWriter = new DateColumnWriter(
+                TypeDescription.createDate(), writerOption);
+
+        DateColumnVector originVector = new DateColumnVector(rowNum);
+        for (int j = 0; j < rowNum; j++)
+        {
+            if (j % 100 == 0)
+            {
+                originVector.addNull();
+            }
+            else
+            {
+                originVector.add(1000);
+            }
+        }
+
+        for (int i = 0; i < batchNum; i++)
+        {
+            columnWriter.write(originVector, rowNum);
+        }
+        columnWriter.flush();
+        columnWriter.close();
+
+        byte[] content = columnWriter.getColumnChunkContent();
+        PixelsProto.ColumnChunkIndex chunkIndex = columnWriter.getColumnChunkIndex().build();
+        PixelsProto.ColumnEncoding encoding = columnWriter.getColumnChunkEncoding().build();
+        DateColumnReader columnReader = new DateColumnReader(TypeDescription.createDate());
+        DateColumnVector targetVector = new DateColumnVector(batchNum*rowNum);
+        columnReader.read(ByteBuffer.wrap(content), encoding, 0, 123,
+                10000, 0, targetVector, chunkIndex);
+        columnReader.read(ByteBuffer.wrap(content), encoding, 123, 456,
+                10000, 123, targetVector, chunkIndex);
+        columnReader.read(ByteBuffer.wrap(content), encoding, 123+456, batchNum*rowNum-123-456,
+                10000, 123+456, targetVector, chunkIndex);
 
         for (int i = 0; i < batchNum*rowNum; i++)
         {

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestDateColumnReader.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestDateColumnReader.java
@@ -65,7 +65,7 @@ public class TestDateColumnReader
         dateColumnVector.add(675);
         dateColumnVector.add(235);
         dateColumnVector.add(32434);
-        dateColumnVector.add(3);
+        dateColumnVector.addNull();
         dateColumnVector.add(6);
         dateColumnVector.add(7);
         dateColumnVector.add(65656565);

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestDecimalColumnReader.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestDecimalColumnReader.java
@@ -42,7 +42,7 @@ public class TestDecimalColumnReader
     public void testNullsPadding() throws IOException
     {
         int pixelsStride = 10;
-        int numRows = 10;
+        int numRows = 22;
         PixelsWriterOption writerOption = new PixelsWriterOption()
                 .pixelStride(pixelsStride).byteOrder(ByteOrder.LITTLE_ENDIAN)
                 .encodingLevel(EncodingLevel.EL0).nullsPadding(true);
@@ -65,7 +65,7 @@ public class TestDecimalColumnReader
         decimalColumnVector.add(675.34);
         decimalColumnVector.add(235.58);
         decimalColumnVector.add(32434.68);
-        decimalColumnVector.add(3.58);
+        decimalColumnVector.addNull();
         decimalColumnVector.add(6.66);
         decimalColumnVector.add(7.77);
         decimalColumnVector.add(65656565.20);
@@ -99,7 +99,7 @@ public class TestDecimalColumnReader
     public void testWithoutNullsPadding() throws IOException
     {
         int pixelsStride = 10;
-        int numRows = 10;
+        int numRows = 22;
         PixelsWriterOption writerOption = new PixelsWriterOption()
                 .pixelStride(pixelsStride).byteOrder(ByteOrder.LITTLE_ENDIAN)
                 .encodingLevel(EncodingLevel.EL0).nullsPadding(false);
@@ -122,7 +122,7 @@ public class TestDecimalColumnReader
         decimalColumnVector.add(675.34);
         decimalColumnVector.add(235.58);
         decimalColumnVector.add(32434.68);
-        decimalColumnVector.add(3.58);
+        decimalColumnVector.addNull();
         decimalColumnVector.add(6.66);
         decimalColumnVector.add(7.77);
         decimalColumnVector.add(65656565.20);
@@ -156,7 +156,7 @@ public class TestDecimalColumnReader
     public void testSelected() throws IOException
     {
         int pixelsStride = 10;
-        int numRows = 10;
+        int numRows = 22;
         PixelsWriterOption writerOption = new PixelsWriterOption()
                 .pixelStride(pixelsStride).byteOrder(ByteOrder.LITTLE_ENDIAN)
                 .encodingLevel(EncodingLevel.EL0).nullsPadding(true);
@@ -179,7 +179,7 @@ public class TestDecimalColumnReader
         decimalColumnVector.add(675.34);
         decimalColumnVector.add(235.58);
         decimalColumnVector.add(32434.68);
-        decimalColumnVector.add(3.58);
+        decimalColumnVector.addNull();
         decimalColumnVector.add(6.66);
         decimalColumnVector.add(7.77);
         decimalColumnVector.add(65656565.20);

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestDecimalColumnReader.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestDecimalColumnReader.java
@@ -84,11 +84,9 @@ public class TestDecimalColumnReader
                 pixelsStride, 0, decimalColumnVector1, chunkIndex);
         for (int i = 0; i < numRows; ++i)
         {
-            if (!decimalColumnVector.noNulls && decimalColumnVector.isNull[i])
-            {
-                assert !decimalColumnVector1.noNulls && decimalColumnVector1.isNull[i];
-            }
-            else
+            assert decimalColumnVector1.noNulls == decimalColumnVector.noNulls;
+            assert decimalColumnVector1.isNull[i] == decimalColumnVector.isNull[i];
+            if (decimalColumnVector.noNulls || !decimalColumnVector.isNull[i])
             {
                 assert decimalColumnVector1.vector[i] == decimalColumnVector.vector[i];
             }
@@ -141,11 +139,9 @@ public class TestDecimalColumnReader
                 pixelsStride, 0, decimalColumnVector1, chunkIndex);
         for (int i = 0; i < numRows; ++i)
         {
-            if (!decimalColumnVector.noNulls && decimalColumnVector.isNull[i])
-            {
-                assert !decimalColumnVector1.noNulls && decimalColumnVector1.isNull[i];
-            }
-            else
+            assert decimalColumnVector1.noNulls == decimalColumnVector.noNulls;
+            assert decimalColumnVector1.isNull[i] == decimalColumnVector.isNull[i];
+            if (decimalColumnVector.noNulls || !decimalColumnVector.isNull[i])
             {
                 assert decimalColumnVector1.vector[i] == decimalColumnVector.vector[i];
             }
@@ -204,11 +200,9 @@ public class TestDecimalColumnReader
         {
             if (i % 10 != 0)
             {
-                if (!decimalColumnVector.noNulls && decimalColumnVector.isNull[i])
-                {
-                    assert !decimalColumnVector1.noNulls && decimalColumnVector1.isNull[j];
-                }
-                else
+                assert decimalColumnVector1.noNulls == decimalColumnVector.noNulls;
+                assert decimalColumnVector1.isNull[j] == decimalColumnVector.isNull[i];
+                if (decimalColumnVector.noNulls || !decimalColumnVector.isNull[i])
                 {
                     assert decimalColumnVector1.vector[j] == decimalColumnVector.vector[i];
                 }
@@ -260,7 +254,7 @@ public class TestDecimalColumnReader
         {
             int j = i % numRows;
             assert targetVector.isNull[i] == originVector.isNull[j];
-            if (!targetVector.isNull[i])
+            if (targetVector.noNulls || !targetVector.isNull[i])
             {
                 assert originVector.vector[j] == targetVector.vector[i];
             }
@@ -317,7 +311,7 @@ public class TestDecimalColumnReader
         {
             int j = i % numRows;
             assert targetVector.isNull[i] == originVector.isNull[j];
-            if (!targetVector.isNull[i])
+            if (targetVector.noNulls || !targetVector.isNull[i])
             {
                 assert originVector.vector[j] == targetVector.vector[i];
             }

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestDecimalColumnReader.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestDecimalColumnReader.java
@@ -84,9 +84,9 @@ public class TestDecimalColumnReader
                 pixelsStride, 0, decimalColumnVector1, chunkIndex);
         for (int i = 0; i < numRows; ++i)
         {
-            if (!decimalColumnVector1.noNulls && decimalColumnVector1.isNull[i])
+            if (!decimalColumnVector.noNulls && decimalColumnVector.isNull[i])
             {
-                assert !decimalColumnVector.noNulls && decimalColumnVector.isNull[i];
+                assert !decimalColumnVector1.noNulls && decimalColumnVector1.isNull[i];
             }
             else
             {
@@ -141,9 +141,9 @@ public class TestDecimalColumnReader
                 pixelsStride, 0, decimalColumnVector1, chunkIndex);
         for (int i = 0; i < numRows; ++i)
         {
-            if (!decimalColumnVector1.noNulls && decimalColumnVector1.isNull[i])
+            if (!decimalColumnVector.noNulls && decimalColumnVector.isNull[i])
             {
-                assert !decimalColumnVector.noNulls && decimalColumnVector.isNull[i];
+                assert !decimalColumnVector1.noNulls && decimalColumnVector1.isNull[i];
             }
             else
             {
@@ -198,15 +198,15 @@ public class TestDecimalColumnReader
         selected.clear(0);
         selected.clear(10);
         selected.clear(20);
-        columnReader.readSelected(ByteBuffer.wrap(content), encoding, 0, numRows,
+        columnReader.readSelected(ByteBuffer.wrap(content), encoding, 0, 22,
                 pixelsStride, 0, decimalColumnVector1, chunkIndex, selected);
         for (int i = 0, j = 0; i < numRows; ++i)
         {
             if (i % 10 != 0)
             {
-                if (!decimalColumnVector1.noNulls && decimalColumnVector1.isNull[j])
+                if (!decimalColumnVector.noNulls && decimalColumnVector.isNull[i])
                 {
-                    assert !decimalColumnVector.noNulls && decimalColumnVector.isNull[i];
+                    assert !decimalColumnVector1.noNulls && decimalColumnVector1.isNull[j];
                 }
                 else
                 {

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestDecimalColumnReader.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestDecimalColumnReader.java
@@ -82,6 +82,8 @@ public class TestDecimalColumnReader
         DecimalColumnVector decimalColumnVector1 = new DecimalColumnVector(numRows, 15, 2);
         columnReader.read(ByteBuffer.wrap(content), encoding, 0, numRows,
                 pixelsStride, 0, decimalColumnVector1, chunkIndex);
+        columnReader.close();
+
         for (int i = 0; i < numRows; ++i)
         {
             assert decimalColumnVector1.noNulls == decimalColumnVector.noNulls;
@@ -137,6 +139,8 @@ public class TestDecimalColumnReader
         DecimalColumnVector decimalColumnVector1 = new DecimalColumnVector(numRows, 15, 2);
         columnReader.read(ByteBuffer.wrap(content), encoding, 0, numRows,
                 pixelsStride, 0, decimalColumnVector1, chunkIndex);
+        columnReader.close();
+
         for (int i = 0; i < numRows; ++i)
         {
             assert decimalColumnVector1.noNulls == decimalColumnVector.noNulls;
@@ -196,6 +200,8 @@ public class TestDecimalColumnReader
         selected.clear(20);
         columnReader.readSelected(ByteBuffer.wrap(content), encoding, 0, 22,
                 pixelsStride, 0, decimalColumnVector1, chunkIndex, selected);
+        columnReader.close();
+
         for (int i = 0, j = 0; i < numRows; ++i)
         {
             if (i % 10 != 0)
@@ -249,6 +255,7 @@ public class TestDecimalColumnReader
         DecimalColumnVector targetVector = new DecimalColumnVector(numBatches*numRows, 15, 2);
         columnReader.read(ByteBuffer.wrap(content), encoding, 0, numBatches*numRows,
                 10000, 0, targetVector, chunkIndex);
+        columnReader.close();
 
         for (int i = 0; i < numBatches*numRows; i++)
         {
@@ -300,12 +307,14 @@ public class TestDecimalColumnReader
         PixelsProto.ColumnEncoding encoding = columnWriter.getColumnChunkEncoding().build();
         DecimalColumnReader columnReader = new DecimalColumnReader(TypeDescription.createDecimal(15, 2));
         DecimalColumnVector targetVector = new DecimalColumnVector(numBatches*numRows, 15, 2);
-        columnReader.read(ByteBuffer.wrap(content), encoding, 0, 123,
+        ByteBuffer buffer = ByteBuffer.wrap(content);
+        columnReader.read(buffer, encoding, 0, 123,
                 10000, 0, targetVector, chunkIndex);
-        columnReader.read(ByteBuffer.wrap(content), encoding, 123, 456,
+        columnReader.read(buffer, encoding, 123, 456,
                 10000, 123, targetVector, chunkIndex);
-        columnReader.read(ByteBuffer.wrap(content), encoding, 123+456, numBatches*numRows-123-456,
+        columnReader.read(buffer, encoding, 123+456, numBatches*numRows-123-456,
                 10000, 123+456, targetVector, chunkIndex);
+        columnReader.close();
 
         for (int i = 0; i < numBatches*numRows; i++)
         {

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestDoubleColumnReader.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestDoubleColumnReader.java
@@ -84,9 +84,9 @@ public class TestDoubleColumnReader
                 pixelsStride, 0, doubleColumnVector1, chunkIndex);
         for (int i = 0; i < numRows; ++i)
         {
-            if (!doubleColumnVector1.noNulls && doubleColumnVector1.isNull[i])
+            if (!doubleColumnVector.noNulls && doubleColumnVector.isNull[i])
             {
-                assert !doubleColumnVector.noNulls && doubleColumnVector.isNull[i];
+                assert !doubleColumnVector1.noNulls && doubleColumnVector1.isNull[i];
             }
             else
             {
@@ -141,11 +141,9 @@ public class TestDoubleColumnReader
                 pixelsStride, 0, doubleColumnVector1, chunkIndex);
         for (int i = 0; i < numRows; ++i)
         {
-            if (!doubleColumnVector1.noNulls && doubleColumnVector1.isNull[i])
-            {
-                assert !doubleColumnVector.noNulls && doubleColumnVector.isNull[i];
-            }
-            else
+            assert doubleColumnVector1.noNulls == doubleColumnVector.noNulls;
+            assert doubleColumnVector1.isNull[i] == doubleColumnVector.isNull[i];
+            if (doubleColumnVector.noNulls || !doubleColumnVector.isNull[i])
             {
                 assert doubleColumnVector1.vector[i] == doubleColumnVector.vector[i];
             }

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestDoubleColumnReader.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestDoubleColumnReader.java
@@ -82,6 +82,8 @@ public class TestDoubleColumnReader
         DoubleColumnVector doubleColumnVector1 = new DoubleColumnVector(numRows);
         columnReader.read(ByteBuffer.wrap(content), encoding, 0, numRows,
                 pixelsStride, 0, doubleColumnVector1, chunkIndex);
+        columnReader.close();
+
         for (int i = 0; i < numRows; ++i)
         {
             assert doubleColumnVector1.noNulls == doubleColumnVector.noNulls;
@@ -137,6 +139,8 @@ public class TestDoubleColumnReader
         DoubleColumnVector doubleColumnVector1 = new DoubleColumnVector(numRows);
         columnReader.read(ByteBuffer.wrap(content), encoding, 0, numRows,
                 pixelsStride, 0, doubleColumnVector1, chunkIndex);
+        columnReader.close();
+
         for (int i = 0; i < numRows; ++i)
         {
             assert doubleColumnVector1.noNulls == doubleColumnVector.noNulls;
@@ -196,6 +200,8 @@ public class TestDoubleColumnReader
         selected.clear(20);
         columnReader.readSelected(ByteBuffer.wrap(content), encoding, 0, numRows,
                 pixelsStride, 0, doubleColumnVector1, chunkIndex, selected);
+        columnReader.close();
+
         for (int i = 0, j = 0; i < numRows; ++i)
         {
             if (i % 10 != 0)
@@ -249,6 +255,7 @@ public class TestDoubleColumnReader
         DoubleColumnVector targetVector = new DoubleColumnVector(numBatches*numRows);
         columnReader.read(ByteBuffer.wrap(content), encoding, 0, numBatches*numRows,
                 10000, 0, targetVector, chunkIndex);
+        columnReader.close();
 
         for (int i = 0; i < numBatches*numRows; i++)
         {
@@ -296,12 +303,14 @@ public class TestDoubleColumnReader
         PixelsProto.ColumnEncoding encoding = columnWriter.getColumnChunkEncoding().build();
         DoubleColumnReader columnReader = new DoubleColumnReader(TypeDescription.createDouble());
         DoubleColumnVector targetVector = new DoubleColumnVector(numBatches*numRows);
-        columnReader.read(ByteBuffer.wrap(content), encoding, 0, 123,
+        ByteBuffer buffer = ByteBuffer.wrap(content);
+        columnReader.read(buffer, encoding, 0, 123,
                 10000, 0, targetVector, chunkIndex);
-        columnReader.read(ByteBuffer.wrap(content), encoding, 123, 456,
+        columnReader.read(buffer, encoding, 123, 456,
                 10000, 123, targetVector, chunkIndex);
-        columnReader.read(ByteBuffer.wrap(content), encoding, 123+456, numBatches*numRows-123-456,
+        columnReader.read(buffer, encoding, 123+456, numBatches*numRows-123-456,
                 10000, 123+456, targetVector, chunkIndex);
+        columnReader.close();
 
         for (int i = 0; i < numBatches*numRows; i++)
         {

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestDoubleColumnReader.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestDoubleColumnReader.java
@@ -267,6 +267,9 @@ public class TestDoubleColumnReader
         }
     }
 
+    /**
+     * Test reading into column vectors with a run-length smaller than pixels stride.
+     */
     @Test
     public void testLargeFragmented() throws IOException
     {

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestDoubleColumnReader.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestDoubleColumnReader.java
@@ -38,7 +38,7 @@ import java.nio.ByteOrder;
 public class TestDoubleColumnReader
 {
     @Test
-    public void test() throws IOException
+    public void testNullsPadding() throws IOException
     {
         PixelsWriterOption writerOption = new PixelsWriterOption()
                 .pixelStride(10).byteOrder(ByteOrder.LITTLE_ENDIAN)
@@ -70,6 +70,8 @@ public class TestDoubleColumnReader
         doubleColumnVector.add(54578.22);
         columnWriter.write(doubleColumnVector, 22);
         columnWriter.flush();
+        columnWriter.close();
+
         byte[] content = columnWriter.getColumnChunkContent();
         PixelsProto.ColumnChunkIndex chunkIndex = columnWriter.getColumnChunkIndex().build();
         PixelsProto.ColumnEncoding encoding = columnWriter.getColumnChunkEncoding().build();

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestDoubleColumnReader.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestDoubleColumnReader.java
@@ -65,7 +65,7 @@ public class TestDoubleColumnReader
         doubleColumnVector.add(675.34);
         doubleColumnVector.add(235.58);
         doubleColumnVector.add(32434.68);
-        doubleColumnVector.add(3.58);
+        doubleColumnVector.addNull(); // or add(3.58);
         doubleColumnVector.add(6.66);
         doubleColumnVector.add(7.77);
         doubleColumnVector.add(65656565.20);
@@ -84,11 +84,9 @@ public class TestDoubleColumnReader
                 pixelsStride, 0, doubleColumnVector1, chunkIndex);
         for (int i = 0; i < numRows; ++i)
         {
-            if (!doubleColumnVector.noNulls && doubleColumnVector.isNull[i])
-            {
-                assert !doubleColumnVector1.noNulls && doubleColumnVector1.isNull[i];
-            }
-            else
+            assert doubleColumnVector1.noNulls == doubleColumnVector.noNulls;
+            assert doubleColumnVector1.isNull[i] == doubleColumnVector.isNull[i];
+            if (doubleColumnVector.noNulls || !doubleColumnVector.isNull[i])
             {
                 assert doubleColumnVector1.vector[i] == doubleColumnVector.vector[i];
             }
@@ -202,10 +200,9 @@ public class TestDoubleColumnReader
         {
             if (i % 10 != 0)
             {
-                if (!doubleColumnVector1.noNulls && doubleColumnVector1.isNull[j])
-                {
-                    assert !doubleColumnVector.noNulls && doubleColumnVector.isNull[i];
-                } else
+                assert doubleColumnVector1.noNulls == doubleColumnVector.noNulls;
+                assert doubleColumnVector1.isNull[j] == doubleColumnVector.isNull[i];
+                if (doubleColumnVector.noNulls || !doubleColumnVector.isNull[i])
                 {
                     assert doubleColumnVector1.vector[j] == doubleColumnVector.vector[i];
                 }
@@ -256,7 +253,7 @@ public class TestDoubleColumnReader
         for (int i = 0; i < numBatches*numRows; i++)
         {
             assert targetVector.isNull[i] == originVector.isNull[i%numRows];
-            if (!targetVector.isNull[i])
+            if (targetVector.noNulls || !targetVector.isNull[i])
             {
                 assert targetVector.vector[i] == originVector.vector[i % numRows];
             }
@@ -309,7 +306,7 @@ public class TestDoubleColumnReader
         for (int i = 0; i < numBatches*numRows; i++)
         {
             assert targetVector.isNull[i] == originVector.isNull[i%numRows];
-            if (!targetVector.isNull[i])
+            if (targetVector.noNulls || !targetVector.isNull[i])
             {
                 assert targetVector.vector[i] == originVector.vector[i % numRows];
             }

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestDoubleColumnReader.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestDoubleColumnReader.java
@@ -22,6 +22,7 @@ package io.pixelsdb.pixels.core.reader;
 import io.pixelsdb.pixels.core.PixelsProto;
 import io.pixelsdb.pixels.core.TypeDescription;
 import io.pixelsdb.pixels.core.encoding.EncodingLevel;
+import io.pixelsdb.pixels.core.utils.Bitmap;
 import io.pixelsdb.pixels.core.vector.DoubleColumnVector;
 import io.pixelsdb.pixels.core.writer.DoubleColumnWriter;
 import io.pixelsdb.pixels.core.writer.PixelsWriterOption;
@@ -152,18 +153,82 @@ public class TestDoubleColumnReader
     }
 
     @Test
+    public void testSelected() throws IOException
+    {
+        int pixelsStride = 10;
+        int numRows = 22;
+        PixelsWriterOption writerOption = new PixelsWriterOption()
+                .pixelStride(pixelsStride).byteOrder(ByteOrder.LITTLE_ENDIAN)
+                .encodingLevel(EncodingLevel.EL0).nullsPadding(true);
+        DoubleColumnWriter columnWriter = new DoubleColumnWriter(
+                TypeDescription.createDouble(), writerOption);
+        DoubleColumnVector doubleColumnVector = new DoubleColumnVector(numRows);
+        doubleColumnVector.add(100.22);
+        doubleColumnVector.add(103.32);
+        doubleColumnVector.add(106.43);
+        doubleColumnVector.add(34.10);
+        doubleColumnVector.addNull();
+        doubleColumnVector.add(54.09);
+        doubleColumnVector.add(55.00);
+        doubleColumnVector.add(67.23);
+        doubleColumnVector.addNull();
+        doubleColumnVector.add(34.58);
+        doubleColumnVector.add(555.98);
+        doubleColumnVector.add(565.76);
+        doubleColumnVector.add(234.11);
+        doubleColumnVector.add(675.34);
+        doubleColumnVector.add(235.58);
+        doubleColumnVector.add(32434.68);
+        doubleColumnVector.addNull();
+        doubleColumnVector.add(6.66);
+        doubleColumnVector.add(7.77);
+        doubleColumnVector.add(65656565.20);
+        doubleColumnVector.add(3434.11);
+        doubleColumnVector.add(54578.22);
+        columnWriter.write(doubleColumnVector, numRows);
+        columnWriter.flush();
+        columnWriter.close();
+
+        byte[] content = columnWriter.getColumnChunkContent();
+        PixelsProto.ColumnChunkIndex chunkIndex = columnWriter.getColumnChunkIndex().build();
+        PixelsProto.ColumnEncoding encoding = columnWriter.getColumnChunkEncoding().build();
+        DoubleColumnReader columnReader = new DoubleColumnReader(TypeDescription.createDouble());
+        DoubleColumnVector doubleColumnVector1 = new DoubleColumnVector(numRows);
+        Bitmap selected = new Bitmap(numRows, true);
+        selected.clear(0);
+        selected.clear(10);
+        selected.clear(20);
+        columnReader.readSelected(ByteBuffer.wrap(content), encoding, 0, numRows,
+                pixelsStride, 0, doubleColumnVector1, chunkIndex, selected);
+        for (int i = 0, j = 0; i < numRows; ++i)
+        {
+            if (i % 10 != 0)
+            {
+                if (!doubleColumnVector1.noNulls && doubleColumnVector1.isNull[j])
+                {
+                    assert !doubleColumnVector.noNulls && doubleColumnVector.isNull[i];
+                } else
+                {
+                    assert doubleColumnVector1.vector[j] == doubleColumnVector.vector[i];
+                }
+                j++;
+            }
+        }
+    }
+
+    @Test
     public void testLarge() throws IOException
     {
-        int batchNum = 15;
-        int rowNum = 1024;
+        int numBatches = 15;
+        int numRows = 1024;
         PixelsWriterOption writerOption = new PixelsWriterOption()
                 .pixelStride(10000).byteOrder(ByteOrder.LITTLE_ENDIAN)
                 .encodingLevel(EncodingLevel.EL0).nullsPadding(true);
         DoubleColumnWriter columnWriter = new DoubleColumnWriter(
                 TypeDescription.createDouble(), writerOption);
 
-        DoubleColumnVector originVector = new DoubleColumnVector(rowNum);
-        for (int j = 0; j < rowNum; j++)
+        DoubleColumnVector originVector = new DoubleColumnVector(numRows);
+        for (int j = 0; j < numRows; j++)
         {
             if (j % 100 == 0)
             {
@@ -175,9 +240,9 @@ public class TestDoubleColumnReader
             }
         }
 
-        for (int i = 0; i < batchNum; i++)
+        for (int i = 0; i < numBatches; i++)
         {
-            columnWriter.write(originVector, rowNum);
+            columnWriter.write(originVector, numRows);
         }
         columnWriter.flush();
         columnWriter.close();
@@ -186,16 +251,69 @@ public class TestDoubleColumnReader
         PixelsProto.ColumnChunkIndex chunkIndex = columnWriter.getColumnChunkIndex().build();
         PixelsProto.ColumnEncoding encoding = columnWriter.getColumnChunkEncoding().build();
         DoubleColumnReader columnReader = new DoubleColumnReader(TypeDescription.createDouble());
-        DoubleColumnVector targetVector = new DoubleColumnVector(batchNum*rowNum);
-        columnReader.read(ByteBuffer.wrap(content), encoding, 0, batchNum*rowNum,
+        DoubleColumnVector targetVector = new DoubleColumnVector(numBatches*numRows);
+        columnReader.read(ByteBuffer.wrap(content), encoding, 0, numBatches*numRows,
                 10000, 0, targetVector, chunkIndex);
 
-        for (int i = 0; i < batchNum*rowNum; i++)
+        for (int i = 0; i < numBatches*numRows; i++)
         {
-            assert targetVector.isNull[i] == originVector.isNull[i%rowNum];
+            assert targetVector.isNull[i] == originVector.isNull[i%numRows];
             if (!targetVector.isNull[i])
             {
-                assert targetVector.vector[i] == originVector.vector[i % rowNum];
+                assert targetVector.vector[i] == originVector.vector[i % numRows];
+            }
+        }
+    }
+
+    @Test
+    public void testLargeFragmented() throws IOException
+    {
+        int numBatches = 15;
+        int numRows = 1024;
+        PixelsWriterOption writerOption = new PixelsWriterOption()
+                .pixelStride(10000).byteOrder(ByteOrder.LITTLE_ENDIAN)
+                .encodingLevel(EncodingLevel.EL0).nullsPadding(true);
+        DoubleColumnWriter columnWriter = new DoubleColumnWriter(
+                TypeDescription.createDouble(), writerOption);
+
+        DoubleColumnVector originVector = new DoubleColumnVector(numRows);
+        for (int j = 0; j < numRows; j++)
+        {
+            if (j % 100 == 0)
+            {
+                originVector.addNull();
+            }
+            else
+            {
+                originVector.add(1000.0d);
+            }
+        }
+
+        for (int i = 0; i < numBatches; i++)
+        {
+            columnWriter.write(originVector, numRows);
+        }
+        columnWriter.flush();
+        columnWriter.close();
+
+        byte[] content = columnWriter.getColumnChunkContent();
+        PixelsProto.ColumnChunkIndex chunkIndex = columnWriter.getColumnChunkIndex().build();
+        PixelsProto.ColumnEncoding encoding = columnWriter.getColumnChunkEncoding().build();
+        DoubleColumnReader columnReader = new DoubleColumnReader(TypeDescription.createDouble());
+        DoubleColumnVector targetVector = new DoubleColumnVector(numBatches*numRows);
+        columnReader.read(ByteBuffer.wrap(content), encoding, 0, 123,
+                10000, 0, targetVector, chunkIndex);
+        columnReader.read(ByteBuffer.wrap(content), encoding, 123, 456,
+                10000, 123, targetVector, chunkIndex);
+        columnReader.read(ByteBuffer.wrap(content), encoding, 123+456, numBatches*numRows-123-456,
+                10000, 123+456, targetVector, chunkIndex);
+
+        for (int i = 0; i < numBatches*numRows; i++)
+        {
+            assert targetVector.isNull[i] == originVector.isNull[i%numRows];
+            if (!targetVector.isNull[i])
+            {
+                assert targetVector.vector[i] == originVector.vector[i % numRows];
             }
         }
     }

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestFloatColumnReader.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestFloatColumnReader.java
@@ -267,6 +267,9 @@ public class TestFloatColumnReader
         }
     }
 
+    /**
+     * Test reading into column vectors with a run-length smaller than pixels stride.
+     */
     @Test
     public void testLargeFragmented() throws IOException
     {

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestFloatColumnReader.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestFloatColumnReader.java
@@ -65,7 +65,7 @@ public class TestFloatColumnReader
         floatColumnVector.add(675.34F);
         floatColumnVector.add(235.58F);
         floatColumnVector.add(32434.68F);
-        floatColumnVector.add(3.58F);
+        floatColumnVector.addNull();
         floatColumnVector.add(6.66F);
         floatColumnVector.add(7.77F);
         floatColumnVector.add(65656565.20F);
@@ -84,11 +84,9 @@ public class TestFloatColumnReader
                 pixelsStride, 0, floatColumnVector1, chunkIndex);
         for (int i = 0; i < numRows; ++i)
         {
-            if (!floatColumnVector1.noNulls && floatColumnVector1.isNull[i])
-            {
-                assert !floatColumnVector.noNulls && floatColumnVector.isNull[i];
-            }
-            else
+            assert floatColumnVector1.noNulls == floatColumnVector.noNulls;
+            assert floatColumnVector1.isNull[i] == floatColumnVector.isNull[i];
+            if (floatColumnVector.noNulls || !floatColumnVector.isNull[i])
             {
                 assert floatColumnVector1.vector[i] == floatColumnVector.vector[i];
             }
@@ -141,11 +139,9 @@ public class TestFloatColumnReader
                 pixelsStride, 0, floatColumnVector1, chunkIndex);
         for (int i = 0; i < numRows; ++i)
         {
-            if (!floatColumnVector1.noNulls && floatColumnVector1.isNull[i])
-            {
-                assert !floatColumnVector.noNulls && floatColumnVector.isNull[i];
-            }
-            else
+            assert floatColumnVector1.noNulls == floatColumnVector.noNulls;
+            assert floatColumnVector1.isNull[i] == floatColumnVector.isNull[i];
+            if (floatColumnVector.noNulls || !floatColumnVector.isNull[i])
             {
                 assert floatColumnVector1.vector[i] == floatColumnVector.vector[i];
             }
@@ -204,11 +200,9 @@ public class TestFloatColumnReader
         {
             if (i % 10 != 0)
             {
-                if (!floatColumnVector1.noNulls && floatColumnVector1.isNull[j])
-                {
-                    assert !floatColumnVector.noNulls && floatColumnVector.isNull[i];
-                }
-                else
+                assert floatColumnVector1.noNulls == floatColumnVector.noNulls;
+                assert floatColumnVector1.isNull[j] == floatColumnVector.isNull[i];
+                if (floatColumnVector.noNulls || !floatColumnVector.isNull[i])
                 {
                     assert floatColumnVector1.vector[j] == floatColumnVector.vector[i];
                 }
@@ -259,7 +253,7 @@ public class TestFloatColumnReader
         for (int i = 0; i < numBatches*numRows; i++)
         {
             assert targetVector.isNull[i] == originVector.isNull[i%numRows];
-            if (!targetVector.isNull[i])
+            if (targetVector.noNulls || !targetVector.isNull[i])
             {
                 assert targetVector.vector[i] == originVector.vector[i % numRows];
             }
@@ -312,7 +306,7 @@ public class TestFloatColumnReader
         for (int i = 0; i < numBatches*numRows; i++)
         {
             assert targetVector.isNull[i] == originVector.isNull[i%numRows];
-            if (!targetVector.isNull[i])
+            if (targetVector.noNulls || !targetVector.isNull[i])
             {
                 assert targetVector.vector[i] == originVector.vector[i % numRows];
             }

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestFloatColumnReader.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestFloatColumnReader.java
@@ -22,6 +22,7 @@ package io.pixelsdb.pixels.core.reader;
 import io.pixelsdb.pixels.core.PixelsProto;
 import io.pixelsdb.pixels.core.TypeDescription;
 import io.pixelsdb.pixels.core.encoding.EncodingLevel;
+import io.pixelsdb.pixels.core.utils.Bitmap;
 import io.pixelsdb.pixels.core.vector.FloatColumnVector;
 import io.pixelsdb.pixels.core.writer.FloatColumnWriter;
 import io.pixelsdb.pixels.core.writer.PixelsWriterOption;
@@ -38,14 +39,16 @@ import java.nio.ByteOrder;
 public class TestFloatColumnReader
 {
     @Test
-    public void test() throws IOException
+    public void testNullsPadding() throws IOException
     {
+        int pixelsStride = 10;
+        int numRows = 22;
         PixelsWriterOption writerOption = new PixelsWriterOption()
-                .pixelStride(10).byteOrder(ByteOrder.LITTLE_ENDIAN)
+                .pixelStride(pixelsStride).byteOrder(ByteOrder.LITTLE_ENDIAN)
                 .encodingLevel(EncodingLevel.EL0).nullsPadding(true);
         FloatColumnWriter columnWriter = new FloatColumnWriter(
                 TypeDescription.createFloat(), writerOption);
-        FloatColumnVector floatColumnVector = new FloatColumnVector(22);
+        FloatColumnVector floatColumnVector = new FloatColumnVector(numRows);
         floatColumnVector.add(100.22F);
         floatColumnVector.add(103.32F);
         floatColumnVector.add(106.43F);
@@ -68,16 +71,18 @@ public class TestFloatColumnReader
         floatColumnVector.add(65656565.20F);
         floatColumnVector.add(3434.11F);
         floatColumnVector.add(54578.22F);
-        columnWriter.write(floatColumnVector, 22);
+        columnWriter.write(floatColumnVector, numRows);
         columnWriter.flush();
+        columnWriter.close();
+
         byte[] content = columnWriter.getColumnChunkContent();
         PixelsProto.ColumnChunkIndex chunkIndex = columnWriter.getColumnChunkIndex().build();
         PixelsProto.ColumnEncoding encoding = columnWriter.getColumnChunkEncoding().build();
         FloatColumnReader columnReader = new FloatColumnReader(TypeDescription.createFloat());
-        FloatColumnVector floatColumnVector1 = new FloatColumnVector(22);
-        columnReader.read(ByteBuffer.wrap(content), encoding, 0, 22,
-                10, 0, floatColumnVector1, chunkIndex);
-        for (int i = 0; i < 22; ++i)
+        FloatColumnVector floatColumnVector1 = new FloatColumnVector(numRows);
+        columnReader.read(ByteBuffer.wrap(content), encoding, 0, numRows,
+                pixelsStride, 0, floatColumnVector1, chunkIndex);
+        for (int i = 0; i < numRows; ++i)
         {
             if (!floatColumnVector1.noNulls && floatColumnVector1.isNull[i])
             {
@@ -91,18 +96,140 @@ public class TestFloatColumnReader
     }
 
     @Test
+    public void testWithoutNullsPadding() throws IOException
+    {
+        int pixelsStride = 10;
+        int numRows = 22;
+        PixelsWriterOption writerOption = new PixelsWriterOption()
+                .pixelStride(pixelsStride).byteOrder(ByteOrder.LITTLE_ENDIAN)
+                .encodingLevel(EncodingLevel.EL0).nullsPadding(false);
+        FloatColumnWriter columnWriter = new FloatColumnWriter(
+                TypeDescription.createFloat(), writerOption);
+        FloatColumnVector floatColumnVector = new FloatColumnVector(numRows);
+        floatColumnVector.add(100.22F);
+        floatColumnVector.add(103.32F);
+        floatColumnVector.add(106.43F);
+        floatColumnVector.add(34.10F);
+        floatColumnVector.addNull();
+        floatColumnVector.add(54.09F);
+        floatColumnVector.add(55.00F);
+        floatColumnVector.add(67.23F);
+        floatColumnVector.addNull();
+        floatColumnVector.add(34.58F);
+        floatColumnVector.add(555.98F);
+        floatColumnVector.add(565.76F);
+        floatColumnVector.add(234.11F);
+        floatColumnVector.add(675.34F);
+        floatColumnVector.add(235.58F);
+        floatColumnVector.add(32434.68F);
+        floatColumnVector.addNull();
+        floatColumnVector.add(6.66F);
+        floatColumnVector.add(7.77F);
+        floatColumnVector.add(65656565.20F);
+        floatColumnVector.add(3434.11F);
+        floatColumnVector.add(54578.22F);
+        columnWriter.write(floatColumnVector, numRows);
+        columnWriter.flush();
+        columnWriter.close();
+
+        byte[] content = columnWriter.getColumnChunkContent();
+        PixelsProto.ColumnChunkIndex chunkIndex = columnWriter.getColumnChunkIndex().build();
+        PixelsProto.ColumnEncoding encoding = columnWriter.getColumnChunkEncoding().build();
+        FloatColumnReader columnReader = new FloatColumnReader(TypeDescription.createFloat());
+        FloatColumnVector floatColumnVector1 = new FloatColumnVector(numRows);
+        columnReader.read(ByteBuffer.wrap(content), encoding, 0, numRows,
+                pixelsStride, 0, floatColumnVector1, chunkIndex);
+        for (int i = 0; i < numRows; ++i)
+        {
+            if (!floatColumnVector1.noNulls && floatColumnVector1.isNull[i])
+            {
+                assert !floatColumnVector.noNulls && floatColumnVector.isNull[i];
+            }
+            else
+            {
+                assert floatColumnVector1.vector[i] == floatColumnVector.vector[i];
+            }
+        }
+    }
+
+    @Test
+    public void testSelected() throws IOException
+    {
+        int pixelsStride = 10;
+        int numRows = 22;
+        PixelsWriterOption writerOption = new PixelsWriterOption()
+                .pixelStride(pixelsStride).byteOrder(ByteOrder.LITTLE_ENDIAN)
+                .encodingLevel(EncodingLevel.EL0).nullsPadding(true);
+        FloatColumnWriter columnWriter = new FloatColumnWriter(
+                TypeDescription.createFloat(), writerOption);
+        FloatColumnVector floatColumnVector = new FloatColumnVector(numRows);
+        floatColumnVector.add(100.22F);
+        floatColumnVector.add(103.32F);
+        floatColumnVector.add(106.43F);
+        floatColumnVector.add(34.10F);
+        floatColumnVector.addNull();
+        floatColumnVector.add(54.09F);
+        floatColumnVector.add(55.00F);
+        floatColumnVector.add(67.23F);
+        floatColumnVector.addNull();
+        floatColumnVector.add(34.58F);
+        floatColumnVector.add(555.98F);
+        floatColumnVector.add(565.76F);
+        floatColumnVector.add(234.11F);
+        floatColumnVector.add(675.34F);
+        floatColumnVector.add(235.58F);
+        floatColumnVector.add(32434.68F);
+        floatColumnVector.addNull();
+        floatColumnVector.add(6.66F);
+        floatColumnVector.add(7.77F);
+        floatColumnVector.add(65656565.20F);
+        floatColumnVector.add(3434.11F);
+        floatColumnVector.add(54578.22F);
+        columnWriter.write(floatColumnVector, numRows);
+        columnWriter.flush();
+        columnWriter.close();
+
+        byte[] content = columnWriter.getColumnChunkContent();
+        PixelsProto.ColumnChunkIndex chunkIndex = columnWriter.getColumnChunkIndex().build();
+        PixelsProto.ColumnEncoding encoding = columnWriter.getColumnChunkEncoding().build();
+        FloatColumnReader columnReader = new FloatColumnReader(TypeDescription.createFloat());
+        FloatColumnVector floatColumnVector1 = new FloatColumnVector(numRows);
+        Bitmap selected = new Bitmap(numRows, true);
+        selected.clear(0);
+        selected.clear(10);
+        selected.clear(20);
+        columnReader.readSelected(ByteBuffer.wrap(content), encoding, 0, numRows,
+                pixelsStride, 0, floatColumnVector1, chunkIndex, selected);
+        for (int i = 0, j = 0; i < numRows; ++i)
+        {
+            if (i % 10 != 0)
+            {
+                if (!floatColumnVector1.noNulls && floatColumnVector1.isNull[j])
+                {
+                    assert !floatColumnVector.noNulls && floatColumnVector.isNull[i];
+                }
+                else
+                {
+                    assert floatColumnVector1.vector[j] == floatColumnVector.vector[i];
+                }
+                j++;
+            }
+        }
+    }
+
+    @Test
     public void testLarge() throws IOException
     {
-        int batchNum = 15;
-        int rowNum = 1024;
+        int numBatches = 15;
+        int numRows = 1024;
         PixelsWriterOption writerOption = new PixelsWriterOption()
                 .pixelStride(10000).byteOrder(ByteOrder.LITTLE_ENDIAN)
                 .encodingLevel(EncodingLevel.EL0).nullsPadding(false);
         FloatColumnWriter columnWriter = new FloatColumnWriter(
                 TypeDescription.createFloat(), writerOption);
 
-        FloatColumnVector originVector = new FloatColumnVector(rowNum);
-        for (int j = 0; j < rowNum; j++)
+        FloatColumnVector originVector = new FloatColumnVector(numRows);
+        for (int j = 0; j < numRows; j++)
         {
             if (j % 100 == 0)
             {
@@ -114,9 +241,9 @@ public class TestFloatColumnReader
             }
         }
 
-        for (int i = 0; i < batchNum; i++)
+        for (int i = 0; i < numBatches; i++)
         {
-            columnWriter.write(originVector, rowNum);
+            columnWriter.write(originVector, numRows);
         }
         columnWriter.flush();
         columnWriter.close();
@@ -125,16 +252,69 @@ public class TestFloatColumnReader
         PixelsProto.ColumnChunkIndex chunkIndex = columnWriter.getColumnChunkIndex().build();
         PixelsProto.ColumnEncoding encoding = columnWriter.getColumnChunkEncoding().build();
         FloatColumnReader columnReader = new FloatColumnReader(TypeDescription.createFloat());
-        FloatColumnVector targetVector = new FloatColumnVector(batchNum*rowNum);
-        columnReader.read(ByteBuffer.wrap(content), encoding, 0, batchNum*rowNum,
+        FloatColumnVector targetVector = new FloatColumnVector(numBatches*numRows);
+        columnReader.read(ByteBuffer.wrap(content), encoding, 0, numBatches*numRows,
                 10000, 0, targetVector, chunkIndex);
 
-        for (int i = 0; i < batchNum*rowNum; i++)
+        for (int i = 0; i < numBatches*numRows; i++)
         {
-            assert targetVector.isNull[i] == originVector.isNull[i%rowNum];
+            assert targetVector.isNull[i] == originVector.isNull[i%numRows];
             if (!targetVector.isNull[i])
             {
-                assert targetVector.vector[i] == originVector.vector[i % rowNum];
+                assert targetVector.vector[i] == originVector.vector[i % numRows];
+            }
+        }
+    }
+
+    @Test
+    public void testLargeFragmented() throws IOException
+    {
+        int numBatches = 15;
+        int numRows = 1024;
+        PixelsWriterOption writerOption = new PixelsWriterOption()
+                .pixelStride(10000).byteOrder(ByteOrder.LITTLE_ENDIAN)
+                .encodingLevel(EncodingLevel.EL0).nullsPadding(false);
+        FloatColumnWriter columnWriter = new FloatColumnWriter(
+                TypeDescription.createFloat(), writerOption);
+
+        FloatColumnVector originVector = new FloatColumnVector(numRows);
+        for (int j = 0; j < numRows; j++)
+        {
+            if (j % 100 == 0)
+            {
+                originVector.addNull();
+            }
+            else
+            {
+                originVector.add(1000.0f);
+            }
+        }
+
+        for (int i = 0; i < numBatches; i++)
+        {
+            columnWriter.write(originVector, numRows);
+        }
+        columnWriter.flush();
+        columnWriter.close();
+
+        byte[] content = columnWriter.getColumnChunkContent();
+        PixelsProto.ColumnChunkIndex chunkIndex = columnWriter.getColumnChunkIndex().build();
+        PixelsProto.ColumnEncoding encoding = columnWriter.getColumnChunkEncoding().build();
+        FloatColumnReader columnReader = new FloatColumnReader(TypeDescription.createFloat());
+        FloatColumnVector targetVector = new FloatColumnVector(numBatches*numRows);
+        columnReader.read(ByteBuffer.wrap(content), encoding, 0, 123,
+                10000, 0, targetVector, chunkIndex);
+        columnReader.read(ByteBuffer.wrap(content), encoding, 123, 456,
+                10000, 123, targetVector, chunkIndex);
+        columnReader.read(ByteBuffer.wrap(content), encoding, 123+456, numBatches*numRows-123-456,
+                10000, 123+456, targetVector, chunkIndex);
+
+        for (int i = 0; i < numBatches*numRows; i++)
+        {
+            assert targetVector.isNull[i] == originVector.isNull[i%numRows];
+            if (!targetVector.isNull[i])
+            {
+                assert targetVector.vector[i] == originVector.vector[i % numRows];
             }
         }
     }

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestFloatColumnReader.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestFloatColumnReader.java
@@ -82,6 +82,8 @@ public class TestFloatColumnReader
         FloatColumnVector floatColumnVector1 = new FloatColumnVector(numRows);
         columnReader.read(ByteBuffer.wrap(content), encoding, 0, numRows,
                 pixelsStride, 0, floatColumnVector1, chunkIndex);
+        columnReader.close();
+
         for (int i = 0; i < numRows; ++i)
         {
             assert floatColumnVector1.noNulls == floatColumnVector.noNulls;
@@ -137,6 +139,8 @@ public class TestFloatColumnReader
         FloatColumnVector floatColumnVector1 = new FloatColumnVector(numRows);
         columnReader.read(ByteBuffer.wrap(content), encoding, 0, numRows,
                 pixelsStride, 0, floatColumnVector1, chunkIndex);
+        columnReader.close();
+
         for (int i = 0; i < numRows; ++i)
         {
             assert floatColumnVector1.noNulls == floatColumnVector.noNulls;
@@ -196,6 +200,8 @@ public class TestFloatColumnReader
         selected.clear(20);
         columnReader.readSelected(ByteBuffer.wrap(content), encoding, 0, numRows,
                 pixelsStride, 0, floatColumnVector1, chunkIndex, selected);
+        columnReader.close();
+
         for (int i = 0, j = 0; i < numRows; ++i)
         {
             if (i % 10 != 0)
@@ -249,6 +255,7 @@ public class TestFloatColumnReader
         FloatColumnVector targetVector = new FloatColumnVector(numBatches*numRows);
         columnReader.read(ByteBuffer.wrap(content), encoding, 0, numBatches*numRows,
                 10000, 0, targetVector, chunkIndex);
+        columnReader.close();
 
         for (int i = 0; i < numBatches*numRows; i++)
         {
@@ -296,12 +303,14 @@ public class TestFloatColumnReader
         PixelsProto.ColumnEncoding encoding = columnWriter.getColumnChunkEncoding().build();
         FloatColumnReader columnReader = new FloatColumnReader(TypeDescription.createFloat());
         FloatColumnVector targetVector = new FloatColumnVector(numBatches*numRows);
-        columnReader.read(ByteBuffer.wrap(content), encoding, 0, 123,
+        ByteBuffer buffer = ByteBuffer.wrap(content);
+        columnReader.read(buffer, encoding, 0, 123,
                 10000, 0, targetVector, chunkIndex);
-        columnReader.read(ByteBuffer.wrap(content), encoding, 123, 456,
+        columnReader.read(buffer, encoding, 123, 456,
                 10000, 123, targetVector, chunkIndex);
-        columnReader.read(ByteBuffer.wrap(content), encoding, 123+456, numBatches*numRows-123-456,
+        columnReader.read(buffer, encoding, 123+456, numBatches*numRows-123-456,
                 10000, 123+456, targetVector, chunkIndex);
+        columnReader.close();
 
         for (int i = 0; i < numBatches*numRows; i++)
         {

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestIntColumnReader.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestIntColumnReader.java
@@ -83,6 +83,8 @@ public class TestIntColumnReader
         IntColumnVector intColumnVector = new IntColumnVector(numRows);
         columnReader.read(ByteBuffer.wrap(content), encoding, 0, numRows,
                 pixelsStride, 0, intColumnVector, chunkIndex);
+        columnReader.close();
+
         for (int i = 0; i < numRows; ++i)
         {
             assert intColumnVector.noNulls == longColumnVector.noNulls;
@@ -138,6 +140,8 @@ public class TestIntColumnReader
         IntColumnVector intColumnVector = new IntColumnVector(numRows);
         columnReader.read(ByteBuffer.wrap(content), encoding, 0, numRows,
                 pixelsStride, 0, intColumnVector, chunkIndex);
+        columnReader.close();
+
         for (int i = 0; i < numRows; ++i)
         {
             assert intColumnVector.noNulls == longColumnVector.noNulls;
@@ -197,6 +201,8 @@ public class TestIntColumnReader
         selected.clear(20);
         columnReader.readSelected(ByteBuffer.wrap(content), encoding, 0, numRows,
                 pixelsStride, 0, intColumnVector, chunkIndex, selected);
+        columnReader.close();
+
         for (int i = 0, j = 0; i < numRows; ++i)
         {
             if (i % 10 != 0)
@@ -250,6 +256,7 @@ public class TestIntColumnReader
         IntColumnVector targetVector = new IntColumnVector(numBatches*numRows);
         columnReader.read(ByteBuffer.wrap(content), encoding, 0, numBatches*numRows,
                 10000, 0, targetVector, chunkIndex);
+        columnReader.close();
 
         for (int i = 0; i < numBatches*numRows; i++)
         {
@@ -297,12 +304,14 @@ public class TestIntColumnReader
         PixelsProto.ColumnEncoding encoding = columnWriter.getColumnChunkEncoding().build();
         IntColumnReader columnReader = new IntColumnReader(TypeDescription.createInt());
         IntColumnVector targetVector = new IntColumnVector(numBatches*numRows);
-        columnReader.read(ByteBuffer.wrap(content), encoding, 0, 123,
+        ByteBuffer buffer = ByteBuffer.wrap(content);
+        columnReader.read(buffer, encoding, 0, 123,
                 10000, 0, targetVector, chunkIndex);
-        columnReader.read(ByteBuffer.wrap(content), encoding, 123, 456,
+        columnReader.read(buffer, encoding, 123, 456,
                 10000, 123, targetVector, chunkIndex);
-        columnReader.read(ByteBuffer.wrap(content), encoding, 123+456, numBatches*numRows-123-456,
+        columnReader.read(buffer, encoding, 123+456, numBatches*numRows-123-456,
                 10000, 123+456, targetVector, chunkIndex);
+        columnReader.close();
 
         for (int i = 0; i < numBatches*numRows; i++)
         {

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestIntColumnReader.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestIntColumnReader.java
@@ -268,6 +268,9 @@ public class TestIntColumnReader
         }
     }
 
+    /**
+     * Test reading into column vectors with a run-length smaller than pixels stride.
+     */
     @Test
     public void testLargeFragmented() throws IOException
     {

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestLongColumnReader.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestLongColumnReader.java
@@ -324,6 +324,9 @@ public class TestLongColumnReader
         }
     }
 
+    /**
+     * Test reading into column vectors with a run-length smaller than pixels stride.
+     */
     @Test
     public void testLargeFragmented() throws IOException
     {

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestLongColumnReader.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestLongColumnReader.java
@@ -82,6 +82,8 @@ public class TestLongColumnReader
         LongColumnVector longColumnVector1 = new LongColumnVector(numRows);
         columnReader.read(ByteBuffer.wrap(content), encoding, 0, numRows,
                 pixelsStride, 0, longColumnVector1, chunkIndex);
+        columnReader.close();
+
         for (int i = 0; i < numRows; ++i)
         {
             assert longColumnVector1.noNulls == longColumnVector.noNulls;
@@ -137,6 +139,8 @@ public class TestLongColumnReader
         LongColumnVector longColumnVector1 = new LongColumnVector(numRows);
         columnReader.read(ByteBuffer.wrap(content), encoding, 0, numRows,
                 pixelsStride, 0, longColumnVector1, chunkIndex);
+        columnReader.close();
+
         for (int i = 0; i < numRows; ++i)
         {
             assert longColumnVector1.noNulls == longColumnVector.noNulls;
@@ -192,6 +196,8 @@ public class TestLongColumnReader
         LongColumnVector longColumnVector1 = new LongColumnVector(numRows);
         columnReader.read(ByteBuffer.wrap(content), encoding, 0, numRows,
                 pixelsStride, 0, longColumnVector1, chunkIndex);
+        columnReader.close();
+
         for (int i = 0; i < numRows; ++i)
         {
             assert longColumnVector1.noNulls == longColumnVector.noNulls;
@@ -251,6 +257,8 @@ public class TestLongColumnReader
         selected.clear(20);
         columnReader.readSelected(ByteBuffer.wrap(content), encoding, 0, numRows,
                 pixelsStride, 0, longColumnVector1, chunkIndex, selected);
+        columnReader.close();
+
         for (int i = 0, j = 0; i < numRows; ++i)
         {
             if (i % 10 != 0)
@@ -304,6 +312,7 @@ public class TestLongColumnReader
         LongColumnVector targetVector = new LongColumnVector(numBatches*numRows);
         columnReader.read(ByteBuffer.wrap(content), encoding, 0, numBatches*numRows,
                 10000, 0, targetVector, chunkIndex);
+        columnReader.close();
 
         for (int i = 0; i < numBatches*numRows; i++)
         {
@@ -351,12 +360,14 @@ public class TestLongColumnReader
         PixelsProto.ColumnEncoding encoding = columnWriter.getColumnChunkEncoding().build();
         LongColumnReader columnReader = new LongColumnReader(TypeDescription.createLong());
         LongColumnVector targetVector = new LongColumnVector(numBatches*numRows);
-        columnReader.read(ByteBuffer.wrap(content), encoding, 0, 123,
+        ByteBuffer buffer = ByteBuffer.wrap(content);
+        columnReader.read(buffer, encoding, 0, 123,
                 10000, 0, targetVector, chunkIndex);
-        columnReader.read(ByteBuffer.wrap(content), encoding, 123, 456,
+        columnReader.read(buffer, encoding, 123, 456,
                 10000, 123, targetVector, chunkIndex);
-        columnReader.read(ByteBuffer.wrap(content), encoding, 123+456, numBatches*numRows-123-456,
+        columnReader.read(buffer, encoding, 123+456, numBatches*numRows-123-456,
                 10000, 123+456, targetVector, chunkIndex);
+        columnReader.close();
 
         for (int i = 0; i < numBatches*numRows; i++)
         {

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestLongColumnReader.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestLongColumnReader.java
@@ -22,6 +22,7 @@ package io.pixelsdb.pixels.core.reader;
 import io.pixelsdb.pixels.core.PixelsProto;
 import io.pixelsdb.pixels.core.TypeDescription;
 import io.pixelsdb.pixels.core.encoding.EncodingLevel;
+import io.pixelsdb.pixels.core.utils.Bitmap;
 import io.pixelsdb.pixels.core.vector.LongColumnVector;
 import io.pixelsdb.pixels.core.writer.IntegerColumnWriter;
 import io.pixelsdb.pixels.core.writer.PixelsWriterOption;
@@ -38,14 +39,16 @@ import java.nio.ByteOrder;
 public class TestLongColumnReader
 {
     @Test
-    public void testInt() throws IOException
+    public void testNullsPaddingInt() throws IOException
     {
+        int pixelsStride = 10;
+        int numRows = 22;
         PixelsWriterOption writerOption = new PixelsWriterOption()
-                .pixelStride(10).byteOrder(ByteOrder.LITTLE_ENDIAN)
+                .pixelStride(pixelsStride).byteOrder(ByteOrder.LITTLE_ENDIAN)
                 .encodingLevel(EncodingLevel.EL0).nullsPadding(true);
         IntegerColumnWriter columnWriter = new IntegerColumnWriter(
                 TypeDescription.createInt(), writerOption);
-        LongColumnVector longColumnVector = new LongColumnVector(22);
+        LongColumnVector longColumnVector = new LongColumnVector(numRows);
         longColumnVector.add(100);
         longColumnVector.add(103);
         longColumnVector.add(106);
@@ -62,28 +65,28 @@ public class TestLongColumnReader
         longColumnVector.add(675);
         longColumnVector.add(235);
         longColumnVector.add(32434);
-        longColumnVector.add(3);
+        longColumnVector.addNull();
         longColumnVector.add(6);
         longColumnVector.add(7);
         longColumnVector.add(65656565);
         longColumnVector.add(3434);
         longColumnVector.add(54578);
-        columnWriter.write(longColumnVector, 22);
+        columnWriter.write(longColumnVector, numRows);
         columnWriter.flush();
+        columnWriter.close();
+
         byte[] content = columnWriter.getColumnChunkContent();
         PixelsProto.ColumnChunkIndex chunkIndex = columnWriter.getColumnChunkIndex().build();
         PixelsProto.ColumnEncoding encoding = columnWriter.getColumnChunkEncoding().build();
         LongColumnReader columnReader = new LongColumnReader(TypeDescription.createInt());
-        LongColumnVector longColumnVector1 = new LongColumnVector(22);
-        columnReader.read(ByteBuffer.wrap(content), encoding, 0, 22,
-                10, 0, longColumnVector1, chunkIndex);
-        for (int i = 0; i < 22; ++i)
+        LongColumnVector longColumnVector1 = new LongColumnVector(numRows);
+        columnReader.read(ByteBuffer.wrap(content), encoding, 0, numRows,
+                pixelsStride, 0, longColumnVector1, chunkIndex);
+        for (int i = 0; i < numRows; ++i)
         {
-            if (!longColumnVector1.noNulls && longColumnVector1.isNull[i])
-            {
-                assert !longColumnVector.noNulls && longColumnVector.isNull[i];
-            }
-            else
+            assert longColumnVector1.noNulls == longColumnVector.noNulls;
+            assert longColumnVector1.isNull[i] == longColumnVector.isNull[i];
+            if (longColumnVector.noNulls || !longColumnVector.isNull[i])
             {
                 assert longColumnVector1.vector[i] == longColumnVector.vector[i];
             }
@@ -91,14 +94,16 @@ public class TestLongColumnReader
     }
 
     @Test
-    public void testLong() throws IOException
+    public void testNullsPaddingLong() throws IOException
     {
+        int pixelsStride = 10;
+        int numRows = 22;
         PixelsWriterOption writerOption = new PixelsWriterOption()
-                .pixelStride(10).byteOrder(ByteOrder.LITTLE_ENDIAN)
+                .pixelStride(pixelsStride).byteOrder(ByteOrder.LITTLE_ENDIAN)
                 .encodingLevel(EncodingLevel.EL0).nullsPadding(true);
         IntegerColumnWriter columnWriter = new IntegerColumnWriter(
                 TypeDescription.createLong(), writerOption);
-        LongColumnVector longColumnVector = new LongColumnVector(22);
+        LongColumnVector longColumnVector = new LongColumnVector(numRows);
         longColumnVector.add(100);
         longColumnVector.add(103);
         longColumnVector.add(106);
@@ -115,30 +120,148 @@ public class TestLongColumnReader
         longColumnVector.add(675);
         longColumnVector.add(235);
         longColumnVector.add(32434);
-        longColumnVector.add(3);
+        longColumnVector.addNull();
         longColumnVector.add(6);
         longColumnVector.add(7);
         longColumnVector.add(65656565);
         longColumnVector.add(3434);
         longColumnVector.add(54578);
-        columnWriter.write(longColumnVector, 22);
+        columnWriter.write(longColumnVector, numRows);
         columnWriter.flush();
+        columnWriter.close();
+
         byte[] content = columnWriter.getColumnChunkContent();
         PixelsProto.ColumnChunkIndex chunkIndex = columnWriter.getColumnChunkIndex().build();
         PixelsProto.ColumnEncoding encoding = columnWriter.getColumnChunkEncoding().build();
         LongColumnReader columnReader = new LongColumnReader(TypeDescription.createLong());
-        LongColumnVector longColumnVector1 = new LongColumnVector(22);
-        columnReader.read(ByteBuffer.wrap(content), encoding, 0, 22,
-                10, 0, longColumnVector1, chunkIndex);
-        for (int i = 0; i < 22; ++i)
+        LongColumnVector longColumnVector1 = new LongColumnVector(numRows);
+        columnReader.read(ByteBuffer.wrap(content), encoding, 0, numRows,
+                pixelsStride, 0, longColumnVector1, chunkIndex);
+        for (int i = 0; i < numRows; ++i)
         {
-            if (!longColumnVector1.noNulls && longColumnVector1.isNull[i])
-            {
-                assert !longColumnVector.noNulls && longColumnVector.isNull[i];
-            }
-            else
+            assert longColumnVector1.noNulls == longColumnVector.noNulls;
+            assert longColumnVector1.isNull[i] == longColumnVector.isNull[i];
+            if (longColumnVector.noNulls || !longColumnVector.isNull[i])
             {
                 assert longColumnVector1.vector[i] == longColumnVector.vector[i];
+            }
+        }
+    }
+
+    @Test
+    public void testWithoutNullsPadding() throws IOException
+    {
+        int pixelsStride = 10;
+        int numRows = 22;
+        PixelsWriterOption writerOption = new PixelsWriterOption()
+                .pixelStride(pixelsStride).byteOrder(ByteOrder.LITTLE_ENDIAN)
+                .encodingLevel(EncodingLevel.EL0).nullsPadding(false);
+        IntegerColumnWriter columnWriter = new IntegerColumnWriter(
+                TypeDescription.createLong(), writerOption);
+        LongColumnVector longColumnVector = new LongColumnVector(numRows);
+        longColumnVector.add(100);
+        longColumnVector.add(103);
+        longColumnVector.add(106);
+        longColumnVector.add(34);
+        longColumnVector.addNull();
+        longColumnVector.add(54);
+        longColumnVector.add(55);
+        longColumnVector.add(67);
+        longColumnVector.addNull();
+        longColumnVector.add(34);
+        longColumnVector.add(555);
+        longColumnVector.add(565);
+        longColumnVector.add(234);
+        longColumnVector.add(675);
+        longColumnVector.add(235);
+        longColumnVector.add(32434);
+        longColumnVector.addNull();
+        longColumnVector.add(6);
+        longColumnVector.add(7);
+        longColumnVector.add(65656565);
+        longColumnVector.add(3434);
+        longColumnVector.add(54578);
+        columnWriter.write(longColumnVector, numRows);
+        columnWriter.flush();
+        columnWriter.close();
+
+        byte[] content = columnWriter.getColumnChunkContent();
+        PixelsProto.ColumnChunkIndex chunkIndex = columnWriter.getColumnChunkIndex().build();
+        PixelsProto.ColumnEncoding encoding = columnWriter.getColumnChunkEncoding().build();
+        LongColumnReader columnReader = new LongColumnReader(TypeDescription.createLong());
+        LongColumnVector longColumnVector1 = new LongColumnVector(numRows);
+        columnReader.read(ByteBuffer.wrap(content), encoding, 0, numRows,
+                pixelsStride, 0, longColumnVector1, chunkIndex);
+        for (int i = 0; i < numRows; ++i)
+        {
+            assert longColumnVector1.noNulls == longColumnVector.noNulls;
+            assert longColumnVector1.isNull[i] == longColumnVector.isNull[i];
+            if (longColumnVector.noNulls || !longColumnVector.isNull[i])
+            {
+                assert longColumnVector1.vector[i] == longColumnVector.vector[i];
+            }
+        }
+    }
+
+    @Test
+    public void testSelected() throws IOException
+    {
+        int pixelsStride = 10;
+        int numRows = 22;
+        PixelsWriterOption writerOption = new PixelsWriterOption()
+                .pixelStride(pixelsStride).byteOrder(ByteOrder.LITTLE_ENDIAN)
+                .encodingLevel(EncodingLevel.EL0).nullsPadding(false);
+        IntegerColumnWriter columnWriter = new IntegerColumnWriter(
+                TypeDescription.createLong(), writerOption);
+        LongColumnVector longColumnVector = new LongColumnVector(numRows);
+        longColumnVector.add(100);
+        longColumnVector.add(103);
+        longColumnVector.add(106);
+        longColumnVector.add(34);
+        longColumnVector.addNull();
+        longColumnVector.add(54);
+        longColumnVector.add(55);
+        longColumnVector.add(67);
+        longColumnVector.addNull();
+        longColumnVector.add(34);
+        longColumnVector.add(555);
+        longColumnVector.add(565);
+        longColumnVector.add(234);
+        longColumnVector.add(675);
+        longColumnVector.add(235);
+        longColumnVector.add(32434);
+        longColumnVector.addNull();
+        longColumnVector.add(6);
+        longColumnVector.add(7);
+        longColumnVector.add(65656565);
+        longColumnVector.add(3434);
+        longColumnVector.add(54578);
+        columnWriter.write(longColumnVector, numRows);
+        columnWriter.flush();
+        columnWriter.close();
+
+        byte[] content = columnWriter.getColumnChunkContent();
+        PixelsProto.ColumnChunkIndex chunkIndex = columnWriter.getColumnChunkIndex().build();
+        PixelsProto.ColumnEncoding encoding = columnWriter.getColumnChunkEncoding().build();
+        LongColumnReader columnReader = new LongColumnReader(TypeDescription.createLong());
+        LongColumnVector longColumnVector1 = new LongColumnVector(numRows);
+        Bitmap selected = new Bitmap(numRows, true);
+        selected.clear(0);
+        selected.clear(10);
+        selected.clear(20);
+        columnReader.readSelected(ByteBuffer.wrap(content), encoding, 0, numRows,
+                pixelsStride, 0, longColumnVector1, chunkIndex, selected);
+        for (int i = 0, j = 0; i < numRows; ++i)
+        {
+            if (i % 10 != 0)
+            {
+                assert longColumnVector1.noNulls == longColumnVector.noNulls;
+                assert longColumnVector1.isNull[j] == longColumnVector.isNull[i];
+                if (longColumnVector.noNulls || !longColumnVector.isNull[i])
+                {
+                    assert longColumnVector1.vector[j] == longColumnVector.vector[i];
+                }
+                j++;
             }
         }
     }
@@ -146,16 +269,16 @@ public class TestLongColumnReader
     @Test
     public void testLarge() throws IOException
     {
-        int batchNum = 15;
-        int rowNum = 1024;
+        int numBatches = 15;
+        int numRows = 1024;
         PixelsWriterOption writerOption = new PixelsWriterOption()
                 .pixelStride(10000).byteOrder(ByteOrder.LITTLE_ENDIAN)
                 .encodingLevel(EncodingLevel.EL0).nullsPadding(true);
         IntegerColumnWriter columnWriter = new IntegerColumnWriter(
                 TypeDescription.createLong(), writerOption);
 
-        LongColumnVector originVector = new LongColumnVector(rowNum);
-        for (int j = 0; j < rowNum; j++)
+        LongColumnVector originVector = new LongColumnVector(numRows);
+        for (int j = 0; j < numRows; j++)
         {
             if (j % 100 == 0)
             {
@@ -167,9 +290,9 @@ public class TestLongColumnReader
             }
         }
 
-        for (int i = 0; i < batchNum; i++)
+        for (int i = 0; i < numBatches; i++)
         {
-            columnWriter.write(originVector, rowNum);
+            columnWriter.write(originVector, numRows);
         }
         columnWriter.flush();
         columnWriter.close();
@@ -178,16 +301,69 @@ public class TestLongColumnReader
         PixelsProto.ColumnChunkIndex chunkIndex = columnWriter.getColumnChunkIndex().build();
         PixelsProto.ColumnEncoding encoding = columnWriter.getColumnChunkEncoding().build();
         LongColumnReader columnReader = new LongColumnReader(TypeDescription.createLong());
-        LongColumnVector targetVector = new LongColumnVector(batchNum*rowNum);
-        columnReader.read(ByteBuffer.wrap(content), encoding, 0, batchNum*rowNum,
+        LongColumnVector targetVector = new LongColumnVector(numBatches*numRows);
+        columnReader.read(ByteBuffer.wrap(content), encoding, 0, numBatches*numRows,
                 10000, 0, targetVector, chunkIndex);
 
-        for (int i = 0; i < batchNum*rowNum; i++)
+        for (int i = 0; i < numBatches*numRows; i++)
         {
-            assert targetVector.isNull[i] == originVector.isNull[i%rowNum];
-            if (!targetVector.isNull[i])
+            assert targetVector.isNull[i] == originVector.isNull[i%numRows];
+            if (targetVector.noNulls || !targetVector.isNull[i])
             {
-                assert targetVector.vector[i] == originVector.vector[i % rowNum];
+                assert targetVector.vector[i] == originVector.vector[i % numRows];
+            }
+        }
+    }
+
+    @Test
+    public void testLargeFragmented() throws IOException
+    {
+        int numBatches = 15;
+        int numRows = 1024;
+        PixelsWriterOption writerOption = new PixelsWriterOption()
+                .pixelStride(10000).byteOrder(ByteOrder.LITTLE_ENDIAN)
+                .encodingLevel(EncodingLevel.EL0).nullsPadding(true);
+        IntegerColumnWriter columnWriter = new IntegerColumnWriter(
+                TypeDescription.createLong(), writerOption);
+
+        LongColumnVector originVector = new LongColumnVector(numRows);
+        for (int j = 0; j < numRows; j++)
+        {
+            if (j % 100 == 0)
+            {
+                originVector.addNull();
+            }
+            else
+            {
+                originVector.add(1000L);
+            }
+        }
+
+        for (int i = 0; i < numBatches; i++)
+        {
+            columnWriter.write(originVector, numRows);
+        }
+        columnWriter.flush();
+        columnWriter.close();
+
+        byte[] content = columnWriter.getColumnChunkContent();
+        PixelsProto.ColumnChunkIndex chunkIndex = columnWriter.getColumnChunkIndex().build();
+        PixelsProto.ColumnEncoding encoding = columnWriter.getColumnChunkEncoding().build();
+        LongColumnReader columnReader = new LongColumnReader(TypeDescription.createLong());
+        LongColumnVector targetVector = new LongColumnVector(numBatches*numRows);
+        columnReader.read(ByteBuffer.wrap(content), encoding, 0, 123,
+                10000, 0, targetVector, chunkIndex);
+        columnReader.read(ByteBuffer.wrap(content), encoding, 123, 456,
+                10000, 123, targetVector, chunkIndex);
+        columnReader.read(ByteBuffer.wrap(content), encoding, 123+456, numBatches*numRows-123-456,
+                10000, 123+456, targetVector, chunkIndex);
+
+        for (int i = 0; i < numBatches*numRows; i++)
+        {
+            assert targetVector.isNull[i] == originVector.isNull[i%numRows];
+            if (targetVector.noNulls || !targetVector.isNull[i])
+            {
+                assert targetVector.vector[i] == originVector.vector[i % numRows];
             }
         }
     }

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestLongDecimalColumnReader.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestLongDecimalColumnReader.java
@@ -22,6 +22,7 @@ package io.pixelsdb.pixels.core.reader;
 import io.pixelsdb.pixels.core.PixelsProto;
 import io.pixelsdb.pixels.core.TypeDescription;
 import io.pixelsdb.pixels.core.encoding.EncodingLevel;
+import io.pixelsdb.pixels.core.utils.Bitmap;
 import io.pixelsdb.pixels.core.vector.LongDecimalColumnVector;
 import io.pixelsdb.pixels.core.writer.LongDecimalColumnWriter;
 import io.pixelsdb.pixels.core.writer.PixelsWriterOption;
@@ -38,14 +39,16 @@ import java.nio.ByteOrder;
 public class TestLongDecimalColumnReader
 {
     @Test
-    public void test() throws IOException
+    public void testNullsPadding() throws IOException
     {
+        int pixelsStride = 10;
+        int numRows = 22;
         PixelsWriterOption writerOption = new PixelsWriterOption()
-                .pixelStride(10).byteOrder(ByteOrder.LITTLE_ENDIAN)
+                .pixelStride(pixelsStride).byteOrder(ByteOrder.LITTLE_ENDIAN)
                 .encodingLevel(EncodingLevel.EL0).nullsPadding(true);
         LongDecimalColumnWriter columnWriter = new LongDecimalColumnWriter(
                 TypeDescription.createDecimal(38, 2), writerOption);
-        LongDecimalColumnVector decimalColumnVector = new LongDecimalColumnVector(22, 38, 2);
+        LongDecimalColumnVector decimalColumnVector = new LongDecimalColumnVector(numRows, 38, 2);
         decimalColumnVector.add(100.22);
         decimalColumnVector.add(103.32);
         decimalColumnVector.add(106.43);
@@ -62,29 +65,31 @@ public class TestLongDecimalColumnReader
         decimalColumnVector.add(675.34);
         decimalColumnVector.add(235.58);
         decimalColumnVector.add(32434.68);
-        decimalColumnVector.add(3.58);
+        decimalColumnVector.addNull();
         decimalColumnVector.add(6.66);
         decimalColumnVector.add(7.77);
         decimalColumnVector.add(65656565.20);
         decimalColumnVector.add(3434.11);
         decimalColumnVector.add(54578.22);
-        columnWriter.write(decimalColumnVector, 22);
+        columnWriter.write(decimalColumnVector, numRows);
         columnWriter.flush();
+        columnWriter.close();
+
         byte[] content = columnWriter.getColumnChunkContent();
         PixelsProto.ColumnChunkIndex chunkIndex = columnWriter.getColumnChunkIndex().build();
         PixelsProto.ColumnEncoding encoding = columnWriter.getColumnChunkEncoding().build();
         LongDecimalColumnReader columnReader = new LongDecimalColumnReader(
                 TypeDescription.createDecimal(38, 2));
-        LongDecimalColumnVector decimalColumnVector1 = new LongDecimalColumnVector(22, 38, 2);
-        columnReader.read(ByteBuffer.wrap(content), encoding, 0, 22,
-                10, 0, decimalColumnVector1, chunkIndex);
-        for (int i = 0; i < 22; ++i)
+        LongDecimalColumnVector decimalColumnVector1 = new LongDecimalColumnVector(numRows, 38, 2);
+        columnReader.read(ByteBuffer.wrap(content), encoding, 0, numRows,
+                pixelsStride, 0, decimalColumnVector1, chunkIndex);
+        columnReader.close();
+
+        for (int i = 0; i < numRows; ++i)
         {
-            if (!decimalColumnVector1.noNulls && decimalColumnVector1.isNull[i])
-            {
-                assert !decimalColumnVector.noNulls && decimalColumnVector.isNull[i];
-            }
-            else
+            assert decimalColumnVector1.noNulls == decimalColumnVector.noNulls;
+            assert decimalColumnVector1.isNull[i] == decimalColumnVector.isNull[i];
+            if (decimalColumnVector.noNulls || !decimalColumnVector.isNull[i])
             {
                 assert decimalColumnVector1.vector[i * 2] == decimalColumnVector.vector[i * 2];
                 assert decimalColumnVector1.vector[i * 2 + 1] == decimalColumnVector.vector[i * 2 + 1];
@@ -93,18 +98,144 @@ public class TestLongDecimalColumnReader
     }
 
     @Test
+    public void testWithoutNullsPadding() throws IOException
+    {
+        int pixelsStride = 10;
+        int numRows = 22;
+        PixelsWriterOption writerOption = new PixelsWriterOption()
+                .pixelStride(pixelsStride).byteOrder(ByteOrder.LITTLE_ENDIAN)
+                .encodingLevel(EncodingLevel.EL0).nullsPadding(false);
+        LongDecimalColumnWriter columnWriter = new LongDecimalColumnWriter(
+                TypeDescription.createDecimal(38, 2), writerOption);
+        LongDecimalColumnVector decimalColumnVector = new LongDecimalColumnVector(numRows, 38, 2);
+        decimalColumnVector.add(100.22);
+        decimalColumnVector.add(103.32);
+        decimalColumnVector.add(106.43);
+        decimalColumnVector.add(34.10);
+        decimalColumnVector.addNull();
+        decimalColumnVector.add(54.09);
+        decimalColumnVector.add(55.00);
+        decimalColumnVector.add(67.23);
+        decimalColumnVector.addNull();
+        decimalColumnVector.add(34.58);
+        decimalColumnVector.add(555.98);
+        decimalColumnVector.add(565.76);
+        decimalColumnVector.add(234.11);
+        decimalColumnVector.add(675.34);
+        decimalColumnVector.add(235.58);
+        decimalColumnVector.add(32434.68);
+        decimalColumnVector.addNull();
+        decimalColumnVector.add(6.66);
+        decimalColumnVector.add(7.77);
+        decimalColumnVector.add(65656565.20);
+        decimalColumnVector.add(3434.11);
+        decimalColumnVector.add(54578.22);
+        columnWriter.write(decimalColumnVector, numRows);
+        columnWriter.flush();
+        columnWriter.close();
+
+        byte[] content = columnWriter.getColumnChunkContent();
+        PixelsProto.ColumnChunkIndex chunkIndex = columnWriter.getColumnChunkIndex().build();
+        PixelsProto.ColumnEncoding encoding = columnWriter.getColumnChunkEncoding().build();
+        LongDecimalColumnReader columnReader = new LongDecimalColumnReader(
+                TypeDescription.createDecimal(38, 2));
+        LongDecimalColumnVector decimalColumnVector1 = new LongDecimalColumnVector(numRows, 38, 2);
+        columnReader.read(ByteBuffer.wrap(content), encoding, 0, numRows,
+                pixelsStride, 0, decimalColumnVector1, chunkIndex);
+        columnReader.close();
+
+        for (int i = 0; i < numRows; ++i)
+        {
+            assert decimalColumnVector1.noNulls == decimalColumnVector.noNulls;
+            assert decimalColumnVector1.isNull[i] == decimalColumnVector.isNull[i];
+            if (decimalColumnVector.noNulls || !decimalColumnVector.isNull[i])
+            {
+                assert decimalColumnVector1.vector[i * 2] == decimalColumnVector.vector[i * 2];
+                assert decimalColumnVector1.vector[i * 2 + 1] == decimalColumnVector.vector[i * 2 + 1];
+            }
+        }
+    }
+
+    @Test
+    public void testSelected() throws IOException
+    {
+        int pixelsStride = 10;
+        int numRows = 22;
+        PixelsWriterOption writerOption = new PixelsWriterOption()
+                .pixelStride(pixelsStride).byteOrder(ByteOrder.LITTLE_ENDIAN)
+                .encodingLevel(EncodingLevel.EL0).nullsPadding(true);
+        LongDecimalColumnWriter columnWriter = new LongDecimalColumnWriter(
+                TypeDescription.createDecimal(38, 2), writerOption);
+        LongDecimalColumnVector decimalColumnVector = new LongDecimalColumnVector(numRows, 38, 2);
+        decimalColumnVector.add(100.22);
+        decimalColumnVector.add(103.32);
+        decimalColumnVector.add(106.43);
+        decimalColumnVector.add(34.10);
+        decimalColumnVector.addNull();
+        decimalColumnVector.add(54.09);
+        decimalColumnVector.add(55.00);
+        decimalColumnVector.add(67.23);
+        decimalColumnVector.addNull();
+        decimalColumnVector.add(34.58);
+        decimalColumnVector.add(555.98);
+        decimalColumnVector.add(565.76);
+        decimalColumnVector.add(234.11);
+        decimalColumnVector.add(675.34);
+        decimalColumnVector.add(235.58);
+        decimalColumnVector.add(32434.68);
+        decimalColumnVector.addNull();
+        decimalColumnVector.add(6.66);
+        decimalColumnVector.add(7.77);
+        decimalColumnVector.add(65656565.20);
+        decimalColumnVector.add(3434.11);
+        decimalColumnVector.add(54578.22);
+        columnWriter.write(decimalColumnVector, numRows);
+        columnWriter.flush();
+        columnWriter.close();
+
+        byte[] content = columnWriter.getColumnChunkContent();
+        PixelsProto.ColumnChunkIndex chunkIndex = columnWriter.getColumnChunkIndex().build();
+        PixelsProto.ColumnEncoding encoding = columnWriter.getColumnChunkEncoding().build();
+        LongDecimalColumnReader columnReader = new LongDecimalColumnReader(
+                TypeDescription.createDecimal(38, 2));
+        Bitmap selected = new Bitmap(numRows, true);
+        selected.clear(0);
+        selected.clear(10);
+        selected.clear(20);
+        LongDecimalColumnVector decimalColumnVector1 = new LongDecimalColumnVector(numRows, 38, 2);
+        columnReader.readSelected(ByteBuffer.wrap(content), encoding, 0, numRows,
+                pixelsStride, 0, decimalColumnVector1, chunkIndex, selected);
+        columnReader.close();
+
+        for (int i = 0, j = 0; i < numRows; ++i)
+        {
+            if (i % 10 != 0)
+            {
+                assert decimalColumnVector1.noNulls == decimalColumnVector.noNulls;
+                assert decimalColumnVector1.isNull[j] == decimalColumnVector.isNull[i];
+                if (decimalColumnVector.noNulls || !decimalColumnVector.isNull[i])
+                {
+                    assert decimalColumnVector1.vector[j * 2] == decimalColumnVector.vector[i * 2];
+                    assert decimalColumnVector1.vector[j * 2 + 1] == decimalColumnVector.vector[i * 2 + 1];
+                }
+                j++;
+            }
+        }
+    }
+
+    @Test
     public void testLarge() throws IOException
     {
-        int batchNum = 15;
-        int rowNum = 1024;
+        int numBatches = 15;
+        int numRows = 1024;
         PixelsWriterOption writerOption = new PixelsWriterOption()
                 .pixelStride(10000).byteOrder(ByteOrder.LITTLE_ENDIAN)
                 .encodingLevel(EncodingLevel.EL0).nullsPadding(true);
         LongDecimalColumnWriter columnWriter = new LongDecimalColumnWriter(
                 TypeDescription.createDecimal(38, 2), writerOption);
 
-        LongDecimalColumnVector originVector = new LongDecimalColumnVector(rowNum, 38, 2);
-        for (int j = 0; j < rowNum; j++)
+        LongDecimalColumnVector originVector = new LongDecimalColumnVector(numRows, 38, 2);
+        for (int j = 0; j < numRows; j++)
         {
             if (j % 100 == 0)
             {
@@ -116,9 +247,9 @@ public class TestLongDecimalColumnReader
             }
         }
 
-        for (int i = 0; i < batchNum; i++)
+        for (int i = 0; i < numBatches; i++)
         {
-            columnWriter.write(originVector, rowNum);
+            columnWriter.write(originVector, numRows);
         }
         columnWriter.flush();
         columnWriter.close();
@@ -128,15 +259,74 @@ public class TestLongDecimalColumnReader
         PixelsProto.ColumnEncoding encoding = columnWriter.getColumnChunkEncoding().build();
         LongDecimalColumnReader columnReader = new LongDecimalColumnReader(
                 TypeDescription.createDecimal(38, 2));
-        LongDecimalColumnVector targetVector = new LongDecimalColumnVector(batchNum*rowNum, 38, 2);
-        columnReader.read(ByteBuffer.wrap(content), encoding, 0, batchNum*rowNum,
+        LongDecimalColumnVector targetVector = new LongDecimalColumnVector(numBatches*numRows, 38, 2);
+        columnReader.read(ByteBuffer.wrap(content), encoding, 0, numBatches*numRows,
                 10000, 0, targetVector, chunkIndex);
+        columnReader.close();
 
-        for (int i = 0; i < batchNum*rowNum; i++)
+        for (int i = 0; i < numBatches*numRows; i++)
         {
-            int j = i % rowNum;
+            int j = i % numRows;
             assert targetVector.isNull[i] == originVector.isNull[j];
-            if (!targetVector.isNull[i])
+            if (targetVector.noNulls || !targetVector.isNull[i])
+            {
+                assert originVector.vector[j * 2] == targetVector.vector[i * 2];
+                assert originVector.vector[j * 2 + 1] == targetVector.vector[i * 2 + 1];
+            }
+        }
+    }
+
+    @Test
+    public void testLargeFragmented() throws IOException
+    {
+        int numBatches = 15;
+        int numRows = 1024;
+        PixelsWriterOption writerOption = new PixelsWriterOption()
+                .pixelStride(10000).byteOrder(ByteOrder.LITTLE_ENDIAN)
+                .encodingLevel(EncodingLevel.EL0).nullsPadding(true);
+        LongDecimalColumnWriter columnWriter = new LongDecimalColumnWriter(
+                TypeDescription.createDecimal(38, 2), writerOption);
+
+        LongDecimalColumnVector originVector = new LongDecimalColumnVector(numRows, 38, 2);
+        for (int j = 0; j < numRows; j++)
+        {
+            if (j % 100 == 0)
+            {
+                originVector.addNull();
+            }
+            else
+            {
+                originVector.add(1000.00d);
+            }
+        }
+
+        for (int i = 0; i < numBatches; i++)
+        {
+            columnWriter.write(originVector, numRows);
+        }
+        columnWriter.flush();
+        columnWriter.close();
+
+        byte[] content = columnWriter.getColumnChunkContent();
+        PixelsProto.ColumnChunkIndex chunkIndex = columnWriter.getColumnChunkIndex().build();
+        PixelsProto.ColumnEncoding encoding = columnWriter.getColumnChunkEncoding().build();
+        LongDecimalColumnReader columnReader = new LongDecimalColumnReader(
+                TypeDescription.createDecimal(38, 2));
+        LongDecimalColumnVector targetVector = new LongDecimalColumnVector(numBatches*numRows, 38, 2);
+        ByteBuffer buffer = ByteBuffer.wrap(content);
+        columnReader.read(buffer, encoding, 0, 123,
+                10000, 0, targetVector, chunkIndex);
+        columnReader.read(buffer, encoding, 123, 456,
+                10000, 123, targetVector, chunkIndex);
+        columnReader.read(buffer, encoding, 123+456, numBatches*numRows-123-456,
+                10000, 123+456, targetVector, chunkIndex);
+        columnReader.close();
+
+        for (int i = 0; i < numBatches*numRows; i++)
+        {
+            int j = i % numRows;
+            assert targetVector.isNull[i] == originVector.isNull[j];
+            if (targetVector.noNulls || !targetVector.isNull[i])
             {
                 assert originVector.vector[j * 2] == targetVector.vector[i * 2];
                 assert originVector.vector[j * 2 + 1] == targetVector.vector[i * 2 + 1];

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestLongDecimalColumnReader.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestLongDecimalColumnReader.java
@@ -156,6 +156,9 @@ public class TestLongDecimalColumnReader
         }
     }
 
+    /**
+     * Test reading into column vectors with a run-length smaller than pixels stride.
+     */
     @Test
     public void testSelected() throws IOException
     {

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestStringColumnReader.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestStringColumnReader.java
@@ -22,6 +22,7 @@ package io.pixelsdb.pixels.core.reader;
 import io.pixelsdb.pixels.core.PixelsProto;
 import io.pixelsdb.pixels.core.TypeDescription;
 import io.pixelsdb.pixels.core.encoding.EncodingLevel;
+import io.pixelsdb.pixels.core.utils.Bitmap;
 import io.pixelsdb.pixels.core.vector.BinaryColumnVector;
 import io.pixelsdb.pixels.core.writer.PixelsWriterOption;
 import io.pixelsdb.pixels.core.writer.StringColumnWriter;
@@ -38,14 +39,16 @@ import java.nio.ByteOrder;
 public class TestStringColumnReader
 {
     @Test
-    public void test() throws IOException
+    public void testNullsPadding() throws IOException
     {
+        int pixelsStride = 10;
+        int numRows = 22;
         PixelsWriterOption writerOption = new PixelsWriterOption()
-                .pixelStride(10).byteOrder(ByteOrder.LITTLE_ENDIAN)
+                .pixelStride(pixelsStride).byteOrder(ByteOrder.LITTLE_ENDIAN)
                 .encodingLevel(EncodingLevel.EL0).nullsPadding(true);
         StringColumnWriter columnWriter = new StringColumnWriter(
                 TypeDescription.createString(), writerOption);
-        BinaryColumnVector binaryColumnVector = new BinaryColumnVector(22);
+        BinaryColumnVector binaryColumnVector = new BinaryColumnVector(numRows);
         binaryColumnVector.add("100");
         binaryColumnVector.add("103");
         binaryColumnVector.add("106");
@@ -62,28 +65,30 @@ public class TestStringColumnReader
         binaryColumnVector.add("675");
         binaryColumnVector.add("235");
         binaryColumnVector.add("32434");
-        binaryColumnVector.add("3");
+        binaryColumnVector.addNull();
         binaryColumnVector.add("6");
         binaryColumnVector.add("7");
         binaryColumnVector.add("65656565");
         binaryColumnVector.add("3434");
         binaryColumnVector.add("54578");
-        columnWriter.write(binaryColumnVector, 22);
+        columnWriter.write(binaryColumnVector, numRows);
         columnWriter.flush();
+        columnWriter.close();
+
         byte[] content = columnWriter.getColumnChunkContent();
         PixelsProto.ColumnChunkIndex chunkIndex = columnWriter.getColumnChunkIndex().build();
         PixelsProto.ColumnEncoding encoding = columnWriter.getColumnChunkEncoding().build();
         StringColumnReader columnReader = new StringColumnReader(TypeDescription.createString());
-        BinaryColumnVector binaryColumnVector1 = new BinaryColumnVector(22);
-        columnReader.read(ByteBuffer.wrap(content), encoding, 0, 22,
-                10, 0, binaryColumnVector1, chunkIndex);
-        for (int i = 0; i < 22; ++i)
+        BinaryColumnVector binaryColumnVector1 = new BinaryColumnVector(numRows);
+        columnReader.read(ByteBuffer.wrap(content), encoding, 0, numRows,
+                pixelsStride, 0, binaryColumnVector1, chunkIndex);
+        columnReader.close();
+
+        for (int i = 0; i < numRows; ++i)
         {
-            if (!binaryColumnVector1.noNulls && binaryColumnVector1.isNull[i])
-            {
-                assert !binaryColumnVector.noNulls && binaryColumnVector.isNull[i];
-            }
-            else
+            assert binaryColumnVector1.noNulls == binaryColumnVector.noNulls;
+            assert binaryColumnVector1.isNull[i] == binaryColumnVector.isNull[i];
+            if (binaryColumnVector.noNulls || !binaryColumnVector.isNull[i])
             {
                 String s1 = new String(binaryColumnVector1.vector[i], binaryColumnVector1.start[i], binaryColumnVector1.lens[i]);
                 String s = new String(binaryColumnVector.vector[i], binaryColumnVector.start[i], binaryColumnVector.lens[i]);
@@ -93,18 +98,144 @@ public class TestStringColumnReader
     }
 
     @Test
+    public void testWithoutNullsPadding() throws IOException
+    {
+        int pixelsStride = 10;
+        int numRows = 22;
+        PixelsWriterOption writerOption = new PixelsWriterOption()
+                .pixelStride(pixelsStride).byteOrder(ByteOrder.LITTLE_ENDIAN)
+                .encodingLevel(EncodingLevel.EL0).nullsPadding(false);
+        StringColumnWriter columnWriter = new StringColumnWriter(
+                TypeDescription.createString(), writerOption);
+        BinaryColumnVector binaryColumnVector = new BinaryColumnVector(numRows);
+        binaryColumnVector.add("100");
+        binaryColumnVector.add("103");
+        binaryColumnVector.add("106");
+        binaryColumnVector.add("34");
+        binaryColumnVector.addNull();
+        binaryColumnVector.add("54");
+        binaryColumnVector.add("55");
+        binaryColumnVector.add("67");
+        binaryColumnVector.addNull();
+        binaryColumnVector.add("34");
+        binaryColumnVector.add("555");
+        binaryColumnVector.add("565");
+        binaryColumnVector.add("234");
+        binaryColumnVector.add("675");
+        binaryColumnVector.add("235");
+        binaryColumnVector.add("32434");
+        binaryColumnVector.addNull();
+        binaryColumnVector.add("6");
+        binaryColumnVector.add("7");
+        binaryColumnVector.add("65656565");
+        binaryColumnVector.add("3434");
+        binaryColumnVector.add("54578");
+        columnWriter.write(binaryColumnVector, numRows);
+        columnWriter.flush();
+        columnWriter.close();
+
+        byte[] content = columnWriter.getColumnChunkContent();
+        PixelsProto.ColumnChunkIndex chunkIndex = columnWriter.getColumnChunkIndex().build();
+        PixelsProto.ColumnEncoding encoding = columnWriter.getColumnChunkEncoding().build();
+        StringColumnReader columnReader = new StringColumnReader(TypeDescription.createString());
+        BinaryColumnVector binaryColumnVector1 = new BinaryColumnVector(numRows);
+        columnReader.read(ByteBuffer.wrap(content), encoding, 0, numRows,
+                pixelsStride, 0, binaryColumnVector1, chunkIndex);
+        columnReader.close();
+
+        for (int i = 0; i < numRows; ++i)
+        {
+            assert binaryColumnVector1.noNulls == binaryColumnVector.noNulls;
+            assert binaryColumnVector1.isNull[i] == binaryColumnVector.isNull[i];
+            if (binaryColumnVector.noNulls || !binaryColumnVector.isNull[i])
+            {
+                String s1 = new String(binaryColumnVector1.vector[i], binaryColumnVector1.start[i], binaryColumnVector1.lens[i]);
+                String s = new String(binaryColumnVector.vector[i], binaryColumnVector.start[i], binaryColumnVector.lens[i]);
+                assert s1.equals(s);
+            }
+        }
+    }
+
+    @Test
+    public void testSelect() throws IOException
+    {
+        int pixelsStride = 10;
+        int numRows = 22;
+        PixelsWriterOption writerOption = new PixelsWriterOption()
+                .pixelStride(pixelsStride).byteOrder(ByteOrder.LITTLE_ENDIAN)
+                .encodingLevel(EncodingLevel.EL0).nullsPadding(true);
+        StringColumnWriter columnWriter = new StringColumnWriter(
+                TypeDescription.createString(), writerOption);
+        BinaryColumnVector binaryColumnVector = new BinaryColumnVector(numRows);
+        binaryColumnVector.add("100");
+        binaryColumnVector.add("103");
+        binaryColumnVector.add("106");
+        binaryColumnVector.add("34");
+        binaryColumnVector.addNull();
+        binaryColumnVector.add("54");
+        binaryColumnVector.add("55");
+        binaryColumnVector.add("67");
+        binaryColumnVector.addNull();
+        binaryColumnVector.add("34");
+        binaryColumnVector.add("555");
+        binaryColumnVector.add("565");
+        binaryColumnVector.add("234");
+        binaryColumnVector.add("675");
+        binaryColumnVector.add("235");
+        binaryColumnVector.add("32434");
+        binaryColumnVector.addNull();
+        binaryColumnVector.add("6");
+        binaryColumnVector.add("7");
+        binaryColumnVector.add("65656565");
+        binaryColumnVector.add("3434");
+        binaryColumnVector.add("54578");
+        columnWriter.write(binaryColumnVector, numRows);
+        columnWriter.flush();
+        columnWriter.close();
+
+        byte[] content = columnWriter.getColumnChunkContent();
+        PixelsProto.ColumnChunkIndex chunkIndex = columnWriter.getColumnChunkIndex().build();
+        PixelsProto.ColumnEncoding encoding = columnWriter.getColumnChunkEncoding().build();
+        StringColumnReader columnReader = new StringColumnReader(TypeDescription.createString());
+        BinaryColumnVector binaryColumnVector1 = new BinaryColumnVector(numRows);
+        Bitmap selected = new Bitmap(numRows, true);
+        selected.clear(0);
+        selected.clear(10);
+        selected.clear(20);
+        columnReader.readSelected(ByteBuffer.wrap(content), encoding, 0, numRows,
+                pixelsStride, 0, binaryColumnVector1, chunkIndex, selected);
+        columnReader.close();
+
+        for (int i = 0, j = 0; i < numRows; ++i)
+        {
+            if (i % 10 != 0)
+            {
+                assert binaryColumnVector1.noNulls == binaryColumnVector.noNulls;
+                assert binaryColumnVector1.isNull[j] == binaryColumnVector.isNull[i];
+                if (binaryColumnVector.noNulls || !binaryColumnVector.isNull[i])
+                {
+                    String s1 = new String(binaryColumnVector1.vector[j], binaryColumnVector1.start[j], binaryColumnVector1.lens[j]);
+                    String s = new String(binaryColumnVector.vector[i], binaryColumnVector.start[i], binaryColumnVector.lens[i]);
+                    assert s1.equals(s);
+                }
+                j++;
+            }
+        }
+    }
+
+    @Test
     public void testLarge() throws IOException
     {
-        int batchNum = 15;
-        int rowNum = 1024;
+        int numBatches = 15;
+        int numRows = 1024;
         PixelsWriterOption writerOption = new PixelsWriterOption()
                 .pixelStride(10000).byteOrder(ByteOrder.LITTLE_ENDIAN)
                 .encodingLevel(EncodingLevel.EL0).nullsPadding(true);
         StringColumnWriter columnWriter = new StringColumnWriter(
                 TypeDescription.createString(), writerOption);
 
-        BinaryColumnVector originVector = new BinaryColumnVector(rowNum);
-        for (int j = 0; j < rowNum; j++)
+        BinaryColumnVector originVector = new BinaryColumnVector(numRows);
+        for (int j = 0; j < numRows; j++)
         {
             if (j % 100 == 0)
             {
@@ -115,9 +246,9 @@ public class TestStringColumnReader
             }
         }
 
-        for (int i = 0; i < batchNum; i++)
+        for (int i = 0; i < numBatches; i++)
         {
-            columnWriter.write(originVector, rowNum);
+            columnWriter.write(originVector, numRows);
         }
         columnWriter.flush();
         columnWriter.close();
@@ -126,15 +257,74 @@ public class TestStringColumnReader
         PixelsProto.ColumnChunkIndex chunkIndex = columnWriter.getColumnChunkIndex().build();
         PixelsProto.ColumnEncoding encoding = columnWriter.getColumnChunkEncoding().build();
         StringColumnReader columnReader = new StringColumnReader(TypeDescription.createString());
-        BinaryColumnVector targetVector = new BinaryColumnVector(batchNum*rowNum);
-        columnReader.read(ByteBuffer.wrap(content), encoding, 0, batchNum*rowNum,
+        BinaryColumnVector targetVector = new BinaryColumnVector(numBatches*numRows);
+        columnReader.read(ByteBuffer.wrap(content), encoding, 0, numBatches*numRows,
                 10000, 0, targetVector, chunkIndex);
+        columnReader.close();
 
-        for (int i = 0; i < batchNum*rowNum; i++)
+        for (int i = 0; i < numBatches*numRows; i++)
         {
-            int j = i % rowNum;
+            int j = i % numRows;
             assert targetVector.isNull[i] == originVector.isNull[j];
-            if (!targetVector.isNull[i])
+            if (targetVector.noNulls || !targetVector.isNull[i])
+            {
+                String s1 = new String(targetVector.vector[i], targetVector.start[i], targetVector.lens[i]);
+
+                String s = new String(originVector.vector[j], originVector.start[j], originVector.lens[j]);
+                assert s1.equals(s);
+            }
+        }
+    }
+
+    @Test
+    public void testLargeFragment() throws IOException
+    {
+        int numBatches = 15;
+        int numRows = 1024;
+        PixelsWriterOption writerOption = new PixelsWriterOption()
+                .pixelStride(10000).byteOrder(ByteOrder.LITTLE_ENDIAN)
+                .encodingLevel(EncodingLevel.EL0).nullsPadding(true);
+        StringColumnWriter columnWriter = new StringColumnWriter(
+                TypeDescription.createString(), writerOption);
+
+        BinaryColumnVector originVector = new BinaryColumnVector(numRows);
+        for (int j = 0; j < numRows; j++)
+        {
+            if (j % 100 == 0)
+            {
+                originVector.addNull();
+            } else
+            {
+                originVector.add("1000");
+            }
+        }
+
+        for (int i = 0; i < numBatches; i++)
+        {
+            columnWriter.write(originVector, numRows);
+        }
+        columnWriter.flush();
+        columnWriter.close();
+
+        byte[] content = columnWriter.getColumnChunkContent();
+        PixelsProto.ColumnChunkIndex chunkIndex = columnWriter.getColumnChunkIndex().build();
+        PixelsProto.ColumnEncoding encoding = columnWriter.getColumnChunkEncoding().build();
+        StringColumnReader columnReader = new StringColumnReader(TypeDescription.createString());
+        BinaryColumnVector targetVector = new BinaryColumnVector(numBatches*numRows);
+        ByteBuffer buffer = ByteBuffer.wrap(content);
+        columnReader.read(buffer, encoding, 0, 123,
+                10000, 0, targetVector, chunkIndex);
+        columnReader.read(buffer, encoding, 123, 456,
+                10000, 123, targetVector, chunkIndex);
+        columnReader.read(buffer, encoding, 123+456, numBatches*numRows-123-456,
+                10000, 123+456, targetVector, chunkIndex);
+        columnReader.close();
+
+        for (int i = 0; i < numBatches*numRows; i++)
+        {
+            int j = i % numRows;
+            assert targetVector.isNull[i] == originVector.isNull[j];
+            if (targetVector.noNulls || !targetVector.isNull[i])
             {
                 String s1 = new String(targetVector.vector[i], targetVector.start[i], targetVector.lens[i]);
 

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestTimestampColumnReader.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestTimestampColumnReader.java
@@ -22,6 +22,7 @@ package io.pixelsdb.pixels.core.reader;
 import io.pixelsdb.pixels.core.PixelsProto;
 import io.pixelsdb.pixels.core.TypeDescription;
 import io.pixelsdb.pixels.core.encoding.EncodingLevel;
+import io.pixelsdb.pixels.core.utils.Bitmap;
 import io.pixelsdb.pixels.core.vector.TimestampColumnVector;
 import io.pixelsdb.pixels.core.writer.PixelsWriterOption;
 import io.pixelsdb.pixels.core.writer.TimestampColumnWriter;
@@ -38,14 +39,16 @@ import java.nio.ByteOrder;
 public class TestTimestampColumnReader
 {
     @Test
-    public void test() throws IOException
+    public void testNullsPadding() throws IOException
     {
+        int pixelsStride = 10;
+        int numRows = 22;
         PixelsWriterOption writerOption = new PixelsWriterOption()
-                .pixelStride(10).byteOrder(ByteOrder.LITTLE_ENDIAN)
+                .pixelStride(pixelsStride).byteOrder(ByteOrder.LITTLE_ENDIAN)
                 .encodingLevel(EncodingLevel.EL0).nullsPadding(true);
         TimestampColumnWriter columnWriter = new TimestampColumnWriter(
                 TypeDescription.createTimestamp(6), writerOption);
-        TimestampColumnVector timestampColumnVector = new TimestampColumnVector(22, 6);
+        TimestampColumnVector timestampColumnVector = new TimestampColumnVector(numRows, 6);
         timestampColumnVector.add(100L);
         timestampColumnVector.add(103L);
         timestampColumnVector.add(106L);
@@ -62,28 +65,30 @@ public class TestTimestampColumnReader
         timestampColumnVector.add(675L);
         timestampColumnVector.add(235L);
         timestampColumnVector.add(32434L);
-        timestampColumnVector.add(3L);
+        timestampColumnVector.addNull();
         timestampColumnVector.add(6L);
         timestampColumnVector.add(7L);
         timestampColumnVector.add(65656565L);
         timestampColumnVector.add(3434L);
         timestampColumnVector.add(54578L);
-        columnWriter.write(timestampColumnVector, 22);
+        columnWriter.write(timestampColumnVector, numRows);
         columnWriter.flush();
+        columnWriter.close();
+
         byte[] content = columnWriter.getColumnChunkContent();
         PixelsProto.ColumnChunkIndex chunkIndex = columnWriter.getColumnChunkIndex().build();
         PixelsProto.ColumnEncoding encoding = columnWriter.getColumnChunkEncoding().build();
         TimestampColumnReader columnReader = new TimestampColumnReader(TypeDescription.createTimestamp(6));
-        TimestampColumnVector timestampColumnVector1 = new TimestampColumnVector(22, 6);
-        columnReader.read(ByteBuffer.wrap(content), encoding, 0, 22,
-                10, 0, timestampColumnVector1, chunkIndex);
-        for (int i = 0; i < 22; ++i)
+        TimestampColumnVector timestampColumnVector1 = new TimestampColumnVector(numRows, 6);
+        columnReader.read(ByteBuffer.wrap(content), encoding, 0, numRows,
+                pixelsStride, 0, timestampColumnVector1, chunkIndex);
+        columnReader.close();
+
+        for (int i = 0; i < numRows; ++i)
         {
-            if (!timestampColumnVector1.noNulls && timestampColumnVector1.isNull[i])
-            {
-                assert !timestampColumnVector.noNulls && timestampColumnVector.isNull[i];
-            }
-            else
+            assert timestampColumnVector1.noNulls == timestampColumnVector.noNulls;
+            assert timestampColumnVector1.isNull[i] == timestampColumnVector.isNull[i];
+            if (timestampColumnVector.noNulls || !timestampColumnVector.isNull[i])
             {
                 assert timestampColumnVector1.times[i] == timestampColumnVector.times[i];
             }
@@ -91,18 +96,140 @@ public class TestTimestampColumnReader
     }
 
     @Test
+    public void testWithoutNullsPadding() throws IOException
+    {
+        int pixelsStride = 10;
+        int numRows = 22;
+        PixelsWriterOption writerOption = new PixelsWriterOption()
+                .pixelStride(pixelsStride).byteOrder(ByteOrder.LITTLE_ENDIAN)
+                .encodingLevel(EncodingLevel.EL0).nullsPadding(false);
+        TimestampColumnWriter columnWriter = new TimestampColumnWriter(
+                TypeDescription.createTimestamp(6), writerOption);
+        TimestampColumnVector timestampColumnVector = new TimestampColumnVector(numRows, 6);
+        timestampColumnVector.add(100L);
+        timestampColumnVector.add(103L);
+        timestampColumnVector.add(106L);
+        timestampColumnVector.add(34L);
+        timestampColumnVector.addNull();
+        timestampColumnVector.add(54L);
+        timestampColumnVector.add(55L);
+        timestampColumnVector.add(67L);
+        timestampColumnVector.addNull();
+        timestampColumnVector.add(34L);
+        timestampColumnVector.add(555L);
+        timestampColumnVector.add(565L);
+        timestampColumnVector.add(234L);
+        timestampColumnVector.add(675L);
+        timestampColumnVector.add(235L);
+        timestampColumnVector.add(32434L);
+        timestampColumnVector.addNull();
+        timestampColumnVector.add(6L);
+        timestampColumnVector.add(7L);
+        timestampColumnVector.add(65656565L);
+        timestampColumnVector.add(3434L);
+        timestampColumnVector.add(54578L);
+        columnWriter.write(timestampColumnVector, numRows);
+        columnWriter.flush();
+        columnWriter.close();
+
+        byte[] content = columnWriter.getColumnChunkContent();
+        PixelsProto.ColumnChunkIndex chunkIndex = columnWriter.getColumnChunkIndex().build();
+        PixelsProto.ColumnEncoding encoding = columnWriter.getColumnChunkEncoding().build();
+        TimestampColumnReader columnReader = new TimestampColumnReader(TypeDescription.createTimestamp(6));
+        TimestampColumnVector timestampColumnVector1 = new TimestampColumnVector(numRows, 6);
+        columnReader.read(ByteBuffer.wrap(content), encoding, 0, numRows,
+                pixelsStride, 0, timestampColumnVector1, chunkIndex);
+        columnReader.close();
+
+        for (int i = 0; i < numRows; ++i)
+        {
+            assert timestampColumnVector1.noNulls == timestampColumnVector.noNulls;
+            assert timestampColumnVector1.isNull[i] == timestampColumnVector.isNull[i];
+            if (timestampColumnVector.noNulls || !timestampColumnVector.isNull[i])
+            {
+                assert timestampColumnVector1.times[i] == timestampColumnVector.times[i];
+            }
+        }
+    }
+
+    @Test
+    public void testSelected() throws IOException
+    {
+        int pixelsStride = 10;
+        int numRows = 22;
+        PixelsWriterOption writerOption = new PixelsWriterOption()
+                .pixelStride(pixelsStride).byteOrder(ByteOrder.LITTLE_ENDIAN)
+                .encodingLevel(EncodingLevel.EL0).nullsPadding(true);
+        TimestampColumnWriter columnWriter = new TimestampColumnWriter(
+                TypeDescription.createTimestamp(6), writerOption);
+        TimestampColumnVector timestampColumnVector = new TimestampColumnVector(numRows, 6);
+        timestampColumnVector.add(100L);
+        timestampColumnVector.add(103L);
+        timestampColumnVector.add(106L);
+        timestampColumnVector.add(34L);
+        timestampColumnVector.addNull();
+        timestampColumnVector.add(54L);
+        timestampColumnVector.add(55L);
+        timestampColumnVector.add(67L);
+        timestampColumnVector.addNull();
+        timestampColumnVector.add(34L);
+        timestampColumnVector.add(555L);
+        timestampColumnVector.add(565L);
+        timestampColumnVector.add(234L);
+        timestampColumnVector.add(675L);
+        timestampColumnVector.add(235L);
+        timestampColumnVector.add(32434L);
+        timestampColumnVector.addNull();
+        timestampColumnVector.add(6L);
+        timestampColumnVector.add(7L);
+        timestampColumnVector.add(65656565L);
+        timestampColumnVector.add(3434L);
+        timestampColumnVector.add(54578L);
+        columnWriter.write(timestampColumnVector, numRows);
+        columnWriter.flush();
+        columnWriter.close();
+
+        byte[] content = columnWriter.getColumnChunkContent();
+        PixelsProto.ColumnChunkIndex chunkIndex = columnWriter.getColumnChunkIndex().build();
+        PixelsProto.ColumnEncoding encoding = columnWriter.getColumnChunkEncoding().build();
+        TimestampColumnReader columnReader = new TimestampColumnReader(TypeDescription.createTimestamp(6));
+        TimestampColumnVector timestampColumnVector1 = new TimestampColumnVector(numRows, 6);
+        Bitmap selected = new Bitmap(numRows, true);
+        selected.clear(0);
+        selected.clear(10);
+        selected.clear(20);
+        columnReader.readSelected(ByteBuffer.wrap(content), encoding, 0, numRows,
+                pixelsStride, 0, timestampColumnVector1, chunkIndex, selected);
+        columnReader.close();
+
+        for (int i = 0, j = 0; i < numRows; ++i)
+        {
+            if (i % 10 != 0)
+            {
+                assert timestampColumnVector1.noNulls == timestampColumnVector.noNulls;
+                assert timestampColumnVector1.isNull[j] == timestampColumnVector.isNull[i];
+                if (timestampColumnVector.noNulls || !timestampColumnVector.isNull[i])
+                {
+                    assert timestampColumnVector1.times[j] == timestampColumnVector.times[i];
+                }
+                j++;
+            }
+        }
+    }
+
+    @Test
     public void testLarge() throws IOException
     {
-        int batchNum = 15;
-        int rowNum = 1024;
+        int numBatches = 15;
+        int numRows = 1024;
         PixelsWriterOption writerOption = new PixelsWriterOption()
                 .pixelStride(10000).byteOrder(ByteOrder.LITTLE_ENDIAN)
                 .encodingLevel(EncodingLevel.EL0).nullsPadding(true);
         TimestampColumnWriter columnWriter = new TimestampColumnWriter(
                 TypeDescription.createTimestamp(6), writerOption);
 
-        TimestampColumnVector originVector = new TimestampColumnVector(rowNum, 6);
-        for (int j = 0; j < rowNum; j++)
+        TimestampColumnVector originVector = new TimestampColumnVector(numRows, 6);
+        for (int j = 0; j < numRows; j++)
         {
             if (j % 100 == 0)
             {
@@ -113,9 +240,9 @@ public class TestTimestampColumnReader
             }
         }
 
-        for (int i = 0; i < batchNum; i++)
+        for (int i = 0; i < numBatches; i++)
         {
-            columnWriter.write(originVector, rowNum);
+            columnWriter.write(originVector, numRows);
         }
         columnWriter.flush();
         columnWriter.close();
@@ -124,16 +251,71 @@ public class TestTimestampColumnReader
         PixelsProto.ColumnChunkIndex chunkIndex = columnWriter.getColumnChunkIndex().build();
         PixelsProto.ColumnEncoding encoding = columnWriter.getColumnChunkEncoding().build();
         TimestampColumnReader columnReader = new TimestampColumnReader(TypeDescription.createTimestamp(6));
-        TimestampColumnVector targetVector = new TimestampColumnVector(batchNum*rowNum, 6);
-        columnReader.read(ByteBuffer.wrap(content), encoding, 0, batchNum*rowNum,
+        TimestampColumnVector targetVector = new TimestampColumnVector(numBatches*numRows, 6);
+        columnReader.read(ByteBuffer.wrap(content), encoding, 0, numBatches*numRows,
                 10000, 0, targetVector, chunkIndex);
+        columnReader.close();
 
-        for (int i = 0; i < batchNum*rowNum; i++)
+        for (int i = 0; i < numBatches*numRows; i++)
         {
-            assert targetVector.isNull[i] == originVector.isNull[i%rowNum];
-            if (!targetVector.isNull[i])
+            assert targetVector.isNull[i] == originVector.isNull[i%numRows];
+            if (targetVector.noNulls || !targetVector.isNull[i])
             {
-                assert targetVector.times[i] == originVector.times[i % rowNum];
+                assert targetVector.times[i] == originVector.times[i % numRows];
+            }
+        }
+    }
+
+    @Test
+    public void testLargeFragmented() throws IOException
+    {
+        int numBatches = 15;
+        int numRows = 1024;
+        PixelsWriterOption writerOption = new PixelsWriterOption()
+                .pixelStride(10000).byteOrder(ByteOrder.LITTLE_ENDIAN)
+                .encodingLevel(EncodingLevel.EL0).nullsPadding(true);
+        TimestampColumnWriter columnWriter = new TimestampColumnWriter(
+                TypeDescription.createTimestamp(6), writerOption);
+
+        TimestampColumnVector originVector = new TimestampColumnVector(numRows, 6);
+        for (int j = 0; j < numRows; j++)
+        {
+            if (j % 100 == 0)
+            {
+                originVector.addNull();
+            } else
+            {
+                originVector.add(1000L);
+            }
+        }
+
+        for (int i = 0; i < numBatches; i++)
+        {
+            columnWriter.write(originVector, numRows);
+        }
+        columnWriter.flush();
+        columnWriter.close();
+
+        byte[] content = columnWriter.getColumnChunkContent();
+        PixelsProto.ColumnChunkIndex chunkIndex = columnWriter.getColumnChunkIndex().build();
+        PixelsProto.ColumnEncoding encoding = columnWriter.getColumnChunkEncoding().build();
+        TimestampColumnReader columnReader = new TimestampColumnReader(TypeDescription.createTimestamp(6));
+        TimestampColumnVector targetVector = new TimestampColumnVector(numBatches*numRows, 6);
+        ByteBuffer buffer = ByteBuffer.wrap(content);
+        columnReader.read(buffer, encoding, 0, 123,
+                10000, 0, targetVector, chunkIndex);
+        columnReader.read(buffer, encoding, 123, 456,
+                10000, 123, targetVector, chunkIndex);
+        columnReader.read(buffer, encoding, 123+456, numBatches*numRows-123-456,
+                10000, 123+456, targetVector, chunkIndex);
+        columnReader.close();
+
+        for (int i = 0; i < numBatches*numRows; i++)
+        {
+            assert targetVector.isNull[i] == originVector.isNull[i%numRows];
+            if (targetVector.noNulls || !targetVector.isNull[i])
+            {
+                assert targetVector.times[i] == originVector.times[i % numRows];
             }
         }
     }

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestVectorColumnReader.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestVectorColumnReader.java
@@ -3,9 +3,7 @@ package io.pixelsdb.pixels.core.reader;
 import io.pixelsdb.pixels.core.PixelsProto;
 import io.pixelsdb.pixels.core.TypeDescription;
 import io.pixelsdb.pixels.core.encoding.EncodingLevel;
-import io.pixelsdb.pixels.core.vector.DoubleColumnVector;
 import io.pixelsdb.pixels.core.vector.VectorColumnVector;
-import io.pixelsdb.pixels.core.writer.DoubleColumnWriter;
 import io.pixelsdb.pixels.core.writer.PixelsWriterOption;
 import io.pixelsdb.pixels.core.writer.VectorColumnWriter;
 import org.junit.Test;
@@ -66,7 +64,8 @@ public class TestVectorColumnReader
         int length = 1000;
         int dimension = 1024;
         VectorColumnVector vectorColumnVector = new VectorColumnVector(length, dimension);
-        for (int i=0; i<length; i++) {
+        for (int i=0; i<length; i++)
+        {
             vectorColumnVector.add(getRandomVector(dimension));
         }
 
@@ -104,7 +103,8 @@ public class TestVectorColumnReader
     {
         Random random = new Random();
         double[] randomVec = new double[dimension];
-        for (int i=0; i<dimension; i++) {
+        for (int i=0; i<dimension; i++)
+        {
             randomVec[i] = random.nextDouble();
         }
         return randomVec;


### PR DESCRIPTION
1. add more tests;
2. fix bitmap alignment to the pixel boundary when pixelsStride is not aligned to 8. This affects isNull bitmap reading of all types and the value reading of Boolean;
3. fix the buffer out-of-bound problem in readSelected of Int and Long when nulls padding is disabled, value should be read only when the value at the position is not null;
4. fix readSelected of String, isNull bitmap should be firstly read into the temporary isNull boolean array.

Closes #789.