### PR TITLE
[Issue #795] upgrade aws sdk to version 2.29.31

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,8 +79,8 @@
         <!-- storage systems -->
         <dep.hadoop.version>3.3.1</dep.hadoop.version>
         <dep.ozone.version>0.5.0-beta</dep.ozone.version>
-        <dep.awssdk.version>2.17.231</dep.awssdk.version>
-        <dep.awssdk.preview.version>2.17.231-PREVIEW</dep.awssdk.preview.version>
+        <dep.awssdk.version>2.29.31</dep.awssdk.version>
+        <dep.awssdk.preview.version>2.29.31</dep.awssdk.preview.version>
         <dep.jedis.version>4.2.0</dep.jedis.version>
         <dep.gcp.version>26.1.2</dep.gcp.version>
 


### PR DESCRIPTION
The upgrade does not provide obvious performance gain on TPC-H q6 and q8.
Closes #795.