### PR TITLE
[Issue #806] download and build boost automatically in cmake

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -29,14 +29,11 @@ include_directories(pixels-core/include)
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 include_directories(${CMAKE_CURRENT_BINARY_DIR}/pixels-common/liburing/src/include)
 
-
-
 target_link_libraries(
         ${EXTENSION_NAME}
         pixels-common
         pixels-core
 )
-
 
 # Add the subdirectory that contains the build_loadable_extension definition
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.19)
 set(CMAKE_CXX_STANDARD 14)
 # Set extension name here
 set(TARGET_NAME pixels)
@@ -20,7 +20,7 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 add_subdirectory(pixels-common)
 add_subdirectory(pixels-core)
- add_subdirectory(pixels-cli)
+add_subdirectory(pixels-cli)
 add_subdirectory(third-party/googletest)
 add_subdirectory(tests)
 

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -2,11 +2,11 @@
 
 ## Usage
 
-### Compilation
+### Build Source Code
 
-Pixels C++ relies on protobuf and liburing. And it builds the pixels extension of duckdb by default,
+Pixels C++ relies on protobuf, liburing, and googletest. And it builds the pixels extension of duckdb by default,
 which relies on [duckdb](https://github.com/pixelsdb/duckdb).
-We don't need to manually install these prerequisites, since the Makefile would automatically download them.
+We don't need to manually install these prerequisites, since the build scripts would automatically download them.
 
 Pixels C++ reader uses `iouring` system calls. You can use the following command to check if iouring is supported in your system:
 
@@ -51,7 +51,7 @@ Finally, compile the code:
 make -j
 ```
 
-### Example
+### Run Basic Example
 
 Here is a pixels reader example in the directory `duckdb/examples/pixels-example`.
 This example validates the correctness of compilation and gives you an idea how to load the Pixels data. 
@@ -71,7 +71,7 @@ set `CMake options` as:
 -DDUCKDB_EXTENSION_NAMES="pixels" -DDUCKDB_EXTENSION_PIXELS_PATH=${PIXELS_SRC}/cpp -DDUCKDB_EXTENSION_PIXELS_SHOULD_LINK="TRUE" -DDUCKDB_EXTENSION_PIXELS_INCLUDE_PATH=${PIXELS_SRC}/cpp/include -DCMAKE_PREFIX_PATH=${PIXELS_SRC}/cpp/third-party/protobuf/cmake/build
 ```
 
-### Benchmark
+### Run Benchmarks
 
 Note: the benchmark runs on diascld31 server. If you run the benchmark on your machine, please refer to [Common issue](#4-i-fail-to-run-the-pixels-and-parquet-benchmark)
 

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -4,7 +4,7 @@
 
 ### Build Source Code
 
-Pixels C++ relies on protobuf, liburing, and googletest. And it builds the pixels extension of duckdb by default,
+Pixels C++ relies on protobuf, liburing, boost, and googletest. Furthermore, it builds the pixels extension of duckdb by default,
 which relies on [duckdb](https://github.com/pixelsdb/duckdb).
 We don't need to manually install these prerequisites, since the build scripts would automatically download them.
 
@@ -248,36 +248,6 @@ def clean_page_cache():
 ### 4. The protobuf version issue
 We use protobuf [v3.21.6](https://github.com/protocolbuffers/protobuf/releases/tag/v3.21.6). It is pulled as a submodule. The latest protobuf version doesn't work for pixels c++ reader. 
 
-### 5. Install Boost C++ Libraries
-We need the Boost C++ Libraries in pixels-cli, which can be installed with the following command.
-
-```
-sudo apt-get install libboost-all-dev
-```
-
-For every Boost release this information is added by the CMake maintainers and it gets part of the next CMake release. So you have to make sure, that your CMake version was released after the Boost version you try to find.
-
-```
-Boost 1.63 requires CMake 3.7 or newer.
-Boost 1.64 requires CMake 3.8 or newer.
-Boost 1.65 and 1.65.1 require CMake 3.9.3 or newer.
-Boost 1.66 requires CMake 3.11 or newer.
-Boost 1.67 requires CMake 3.12 or newer.
-Boost 1.68, 1.69 require CMake 3.13 or newer.
-Boost 1.70 requires CMake 3.14 or newer.
-Boost 1.71 requires CMake 3.15.3 or newer.
-Boost 1.72 requires CMake 3.16.2 or newer.
-Boost 1.73 requires CMake 3.17.2 or newer.
-Boost 1.74 requires CMake 3.19 or newer.
-Boost 1.75 requires CMake 3.19.5 or newer.
-Boost 1.76 requires CMake 3.20.3 or newer.
-Boost 1.77 requires CMake 3.21.3 or newer.
-Boost 1.78 requires CMake 3.22.2 or newer.
-Boost 1.79 requires CMake 3.23.2 or newer.
-Boost 1.80 requires CMake 3.24.2 or newer.
-Boost 1.81 requires CMake 3.25.2 or newer.
-Boost 1.82 requires CMake 3.27.0 or newer.
-Boost 1.83 requires CMake 3.27.4 or newer.
-Boost 1.84 requires CMake 3.28.2 or newer.
-Boost 1.85 requires CMake 3.29.3 or newer.
-```
+### 5. Boost C++ Libraries
+We use boost [1.74.0](https://github.com/boostorg/boost/tree/boost-1.74.0) that requires CMake 3.19 or later.
+Boost is downloaded automatically in the CMakeLists of pixels-cli.

--- a/cpp/pixels-cli/CMakeLists.txt
+++ b/cpp/pixels-cli/CMakeLists.txt
@@ -16,7 +16,7 @@ set(BOOST_LIBRARIES "regex,program_options")
 set(BOOST_BOOTSTRAP_COMMAND ./bootstrap.sh --with-libraries=${BOOST_LIBRARIES})
 set(BOOST_BUILD_TOOL ./b2)
 set(BOOST_CXXFLAGS "cxxflags=-std=c++11")
-set(BOOST_GIT_REPOSITORY https://github.com/boostorg/boost.git)
+set(BOOST_GIT_REPOSITORY git@github.com:boostorg/boost.git)
 set(BOOST_GIT_TAG boost-1.74.0)
 set(BOOST_GIT_SUBMODULES
 libs/config libs/core libs/headers libs/regex libs/program_options

--- a/cpp/pixels-cli/CMakeLists.txt
+++ b/cpp/pixels-cli/CMakeLists.txt
@@ -2,40 +2,68 @@ project(pixels-cli)
 
 set(CMAKE_CXX_STANDARD 17)
 
-# boost-dev
 include(ExternalProject)
-ExternalProject_Add(boost_regex
-		GIT_REPOSITORY git@github.com:boostorg/regex.git
-		GIT_TAG boost-1.70.0
-		PREFIX ${CMAKE_CURRENT_BINARY_DIR}
-		SOURCE_DIR "boost_regex"
-		CONFIGURE_COMMAND ""
-		INSTALL_COMMAND ""
-		BUILD_COMMAND ""
-		BUILD_IN_SOURCE false
-		)
+include(ProcessorCount)
 
-ExternalProject_Add(boost_program_options
-		GIT_REPOSITORY git@github.com:boostorg/program_options.git
-		GIT_TAG boost-1.70.0
-		PREFIX ${CMAKE_CURRENT_BINARY_DIR}
-		SOURCE_DIR "boost_program_options"
-		CONFIGURE_COMMAND ""
-		INSTALL_COMMAND ""
-		BUILD_COMMAND ""
-		BUILD_IN_SOURCE false
-		)
-
-set(Boost_USE_STATIC_LIBS ON)
-set(Boost_USE_MULTITHREADED ON)
-
-if(POLICY CMP0057)
-    cmake_policy(SET CMP0057 NEW)
+# get core count
+ProcessorCount(CORES)
+if(CORES EQUAL 0)
+  set(CORES 1)
 endif()
 
-if(POLICY CMP0167)
-  cmake_policy(SET CMP0167 NEW)
-endif()
+# boost-dev
+set(BOOST_LIBRARIES "regex,program_options")
+set(BOOST_BOOTSTRAP_COMMAND ./bootstrap.sh --with-libraries=${BOOST_LIBRARIES})
+set(BOOST_BUILD_TOOL ./b2)
+set(BOOST_CXXFLAGS "cxxflags=-std=c++11")
+set(BOOST_GIT_REPOSITORY https://github.com/boostorg/boost.git)
+set(BOOST_GIT_TAG boost-1.74.0)
+set(BOOST_GIT_SUBMODULES
+libs/config libs/core libs/headers libs/regex libs/program_options
+tools/auto_index tools/bcp tools/boost_install tools/boostbook tools/boostdep
+tools/build tools/check_build tools/cmake tools/docca tools/inspect tools/litre tools/quickbook)
+
+# download and compile boost libraries
+ExternalProject_Add(boost
+    PREFIX ${CMAKE_CURRENT_BINARY_DIR}/deps
+    GIT_REPOSITORY ${BOOST_GIT_REPOSITORY}
+    GIT_TAG ${BOOST_GIT_TAG}
+    GIT_SUBMODULES ${BOOST_GIT_SUBMODULES}
+    GIT_SUBMODULES_RECURSE true
+    SOURCE_DIR "boost"
+    BUILD_IN_SOURCE true
+    UPDATE_COMMAND ${BOOST_BOOTSTRAP_COMMAND}
+    CONFIGURE_COMMAND ./b2 headers
+    BUILD_COMMAND ${BOOST_BUILD_TOOL} stage
+                  ${BOOST_CXXFLAGS}
+                  threading=multi
+                  variant=release
+                  link=static
+                  -j${CORES}
+    INSTALL_COMMAND ""
+    # logging
+    LOG_CONFIGURE true
+    LOG_BUILD true
+    LOG_INSTALL true
+)
+
+ExternalProject_Get_Property(boost SOURCE_DIR)
+set(BOOST_INCLUDE_DIR ${SOURCE_DIR})
+set(BOOST_LIBRARY_PREFIX ${SOURCE_DIR}/stage/lib/${CMAKE_STATIC_LIBRARY_PREFIX})
+
+# boost regex library
+add_library(Boost::regex STATIC IMPORTED GLOBAL)
+set_property(TARGET Boost::regex PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${BOOST_INCLUDE_DIR})
+set_property(TARGET Boost::regex PROPERTY IMPORTED_LOCATION ${BOOST_LIBRARY_PREFIX}boost_regex${CMAKE_STATIC_LIBRARY_SUFFIX})
+add_dependencies(Boost::regex boost)
+
+# boost program_options library
+add_library(Boost::program_options STATIC IMPORTED GLOBAL)
+set_property(TARGET Boost::program_options PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${BOOST_INCLUDE_DIR})
+set_property(TARGET Boost::program_options PROPERTY IMPORTED_LOCATION ${BOOST_LIBRARY_PREFIX}boost_program_options${CMAKE_STATIC_LIBRARY_SUFFIX})
+add_dependencies(Boost::program_options boost)
+
+unset(SOURCE_DIR)
 
 set(pixels_cli_cxx
         main.cpp
@@ -46,6 +74,4 @@ add_executable(pixels-cli ${pixels_cli_cxx})
 include_directories(include)
 include_directories(../pixels-core/include)
 include_directories(../pixels-common/include)
-include_directories(${CMAKE_CURRENT_BINARY_DIR}/boost_regex/include)
-include_directories(${CMAKE_CURRENT_BINARY_DIR}/boost_program_options/include)
-target_link_libraries(pixels-cli pixels-core pixels-common duckdb)
+target_link_libraries(pixels-cli Boost::program_options Boost::regex pixels-core pixels-common duckdb)

--- a/cpp/pixels-cli/CMakeLists.txt
+++ b/cpp/pixels-cli/CMakeLists.txt
@@ -1,7 +1,31 @@
-cmake_minimum_required(VERSION 3.0)
 project(pixels-cli)
 
 set(CMAKE_CXX_STANDARD 17)
+
+# boost-dev
+include(ExternalProject)
+ExternalProject_Add(boost_regex
+		GIT_REPOSITORY git@github.com:boostorg/regex.git
+		GIT_TAG boost-1.70.0
+		PREFIX ${CMAKE_CURRENT_BINARY_DIR}
+		SOURCE_DIR "boost_regex"
+		CONFIGURE_COMMAND ""
+		INSTALL_COMMAND ""
+		BUILD_COMMAND ""
+		BUILD_IN_SOURCE false
+		)
+
+ExternalProject_Add(boost_program_options
+		GIT_REPOSITORY git@github.com:boostorg/program_options.git
+		GIT_TAG boost-1.70.0
+		PREFIX ${CMAKE_CURRENT_BINARY_DIR}
+		SOURCE_DIR "boost_program_options"
+		CONFIGURE_COMMAND ""
+		INSTALL_COMMAND ""
+		BUILD_COMMAND ""
+		BUILD_IN_SOURCE false
+		)
+
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 
@@ -13,13 +37,6 @@ if(POLICY CMP0167)
   cmake_policy(SET CMP0167 NEW)
 endif()
 
-find_package(Boost REQUIRED COMPONENTS program_options regex)
-if(Boost_FOUND)
-    include_directories(${Boost_INCLUDE_DIRS})
-else()
-    message(FATAL_ERROR "Could not find Boost")
-endif()
-
 set(pixels_cli_cxx
         main.cpp
         lib/executor/LoadExecutor.cpp
@@ -29,4 +46,6 @@ add_executable(pixels-cli ${pixels_cli_cxx})
 include_directories(include)
 include_directories(../pixels-core/include)
 include_directories(../pixels-common/include)
-target_link_libraries(pixels-cli Boost::program_options Boost::regex pixels-core pixels-common duckdb)
+include_directories(${CMAKE_CURRENT_BINARY_DIR}/boost_regex/include)
+include_directories(${CMAKE_CURRENT_BINARY_DIR}/boost_program_options/include)
+target_link_libraries(pixels-cli pixels-core pixels-common duckdb)

--- a/cpp/pixels-common/CMakeLists.txt
+++ b/cpp/pixels-common/CMakeLists.txt
@@ -1,6 +1,9 @@
 project(pixels-common)
 
 set(CMAKE_CXX_STANDARD 17)
+
+include(ExternalProject)
+
 set(pixels_common_cxx
         lib/physical/storage/LocalFS.cpp
 		lib/physical/storage/LocalFSProvider.cpp
@@ -58,15 +61,18 @@ protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS $ENV{PIXELS_SRC}/proto/pixels.proto)
 add_library(pixels-common ${pixels_common_cxx} ${PROTO_SRCS} ${PROTO_HDRS})
 
 # liburing
-include(ExternalProject)
+set(LIBURING_GIT_REPOSITORY git@github.com:axboe/liburing.git)
+set(LIBURING_GIT_TAG liburing-2.2)
+set(LIBURING_BUILD_COMMAND make -j)
+
 ExternalProject_Add(liburing
-		GIT_REPOSITORY git@github.com:axboe/liburing.git
-		GIT_TAG liburing-2.2
-		PREFIX ${CMAKE_CURRENT_BINARY_DIR}
+		PREFIX ${CMAKE_CURRENT_BINARY_DIR}/deps
+		GIT_REPOSITORY ${LIBURING_GIT_REPOSITORY}
+		GIT_TAG ${LIBURING_GIT_TAG}
 		SOURCE_DIR "liburing"
 		CONFIGURE_COMMAND ""
 		INSTALL_COMMAND ""
-		BUILD_COMMAND make -j
+		BUILD_COMMAND ${LIBURING_BUILD_COMMAND}
 		BUILD_IN_SOURCE true
 		)
 
@@ -76,5 +82,4 @@ link_directories(${CMAKE_CURRENT_BINARY_DIR}/liburing/src)
 message(${CMAKE_CURRENT_BINARY_DIR}/liburing/src)
 target_link_libraries(pixels-common
         ${Protobuf_LIBRARIES}
-		${CMAKE_CURRENT_BINARY_DIR}/liburing/src/liburing.a
-        )
+		${CMAKE_CURRENT_BINARY_DIR}/liburing/src/liburing.a)

--- a/cpp/pixels-common/CMakeLists.txt
+++ b/cpp/pixels-common/CMakeLists.txt
@@ -60,7 +60,7 @@ add_library(pixels-common ${pixels_common_cxx} ${PROTO_SRCS} ${PROTO_HDRS})
 # liburing
 include(ExternalProject)
 ExternalProject_Add(liburing
-		GIT_REPOSITORY https://gitee.com/wszdc/liburing.git
+		GIT_REPOSITORY git@github.com:axboe/liburing.git
 		GIT_TAG liburing-2.2
 		PREFIX ${CMAKE_CURRENT_BINARY_DIR}
 		SOURCE_DIR "liburing"


### PR DESCRIPTION
Also update the README and use the official liburing repository.