### PR TITLE
[Issue #834] writing fileTailOffset in big endian in cpp PixelsWriterImpl

### DIFF
--- a/cpp/pixels-core/lib/PixelsReaderBuilder.cpp
+++ b/cpp/pixels-core/lib/PixelsReaderBuilder.cpp
@@ -76,17 +76,7 @@ std::shared_ptr <PixelsReader> PixelsReaderBuilder::build()
         long fileLen = fsReader->getFileLength();
         std::cout << "filelen: " << fsReader->getFileLength() << std::endl;
         fsReader->seek(fileLen - (long) sizeof(long));
-        long SmallEndianFileTailOffset = fsReader->readLong();
-        long BigEndianFileTailOffset = (long) __builtin_bswap64(SmallEndianFileTailOffset);
-        long fileTailOffset = 0;
-        if (SmallEndianFileTailOffset < 0)
-        {
-            fileTailOffset = BigEndianFileTailOffset;
-        }
-        else
-        {
-            fileTailOffset = SmallEndianFileTailOffset;
-        }
+        long fileTailOffset = (long) __builtin_bswap64(fsReader->readLong());
         std::cout << "fileTailOffset: " << fileTailOffset << std::endl;
         int fileTailLength = (int) (fileLen - fileTailOffset - sizeof(long));
         fsReader->seek(fileTailOffset);


### PR DESCRIPTION
fix comments
![image](https://github.com/user-attachments/assets/15106b4e-a47e-439e-b191-b93cdd9fe2dc)
![image](https://github.com/user-attachments/assets/57e13a8d-7ad4-4dc8-bb29-e4e308188767)
A conversion from little-endian to big-endian has been implemented, and modifications have been made to the Reader so that there is no need to determine the endianness.
