### PR TITLE
[Issue #949] add missing spike worker names into pixels.properties

### DIFF
--- a/pixels-common/src/main/resources/pixels.properties
+++ b/pixels-common/src/main/resources/pixels.properties
@@ -205,6 +205,15 @@ sort.worker.name=SortWorker
 sorted.join.worker.name=SortedJoinWorker
 aggregation.worker.name=AggregationWorker
 
+# the names of the spike cloud function workers
+#scan.worker.name=pixels-worker-spike
+#partition.worker.name=pixels-worker-spike
+#broadcast.join.worker.name=pixels-worker-spike
+#broadcast.chain.join.worker.name=pixels-worker-spike
+#partitioned.join.worker.name=pixels-worker-spike
+#partitioned.chain.join.worker.name=pixels-worker-spike
+#aggregation.worker.name=pixels-worker-spike
+
 # parameter for spike client
 spike.cpu=8192
 spike.memory=32768


### PR DESCRIPTION
These worker names were lost during the rebasing process.

Resolves #949.