### PR TITLE
[Issue #955] replace exec-maven-plugin with maven-antrun-plugin for flatbuffer source generation

### DIFF
--- a/pixels-common/pom.xml
+++ b/pixels-common/pom.xml
@@ -189,28 +189,31 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>exec-maven-plugin</artifactId>
-                <version>${maven.plugin.codehaus-exec.version}</version>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>${maven.plugin.antrun.version}</version>
                 <executions>
                     <execution>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
+                        <id>generate-flatbuffers</id>
                         <phase>generate-sources</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <mkdir dir="${project.build.directory}/generated-sources/flatbuffers/java"/>
+                                <apply executable="${project.build.directory}/bin/flatc" parallel="false"  failonerror="true">
+                                    <arg value="--java"/>
+                                    <arg value="--gen-mutable"/>
+                                    <arg value="--no-warnings"/>
+                                    <arg value="-o"/>
+                                    <arg value="${project.build.directory}/generated-sources/flatbuffers/java"/>
+                                    <fileset dir="${basedir}/../flatbuffers" includes="**/*.fbs"/>
+                                </apply>
+                            </target>
+                        </configuration>
                     </execution>
                 </executions>
-                <configuration>
-                    <executable>${project.build.directory}/bin/flatc</executable>
-                    <workingDirectory>${project.parent.basedir}/flatbuffers</workingDirectory>
-                    <arguments>
-                        <argument>--java</argument>
-                        <argument>--gen-mutable</argument>
-                        <argument>-o</argument>
-                        <argument>${project.build.directory}/generated-sources/flatbuffers/java</argument>
-                        <argument>rowBatch.fbs</argument>
-                    </arguments>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -82,8 +82,7 @@
         <maven.plugin.os-maven.version>1.6.2</maven.plugin.os-maven.version>
         <maven.plugin.protobuf.version>0.6.1</maven.plugin.protobuf.version>
         <maven.plugin.protoc-jar.version>3.3.0.1</maven.plugin.protoc-jar.version>
-        <maven.plugin.build-helper.version>3.1.0</maven.plugin.build-helper.version>
-        <maven.plugin.codehaus-exec.version>1.6.0</maven.plugin.codehaus-exec.version>
+        <maven.plugin.build-helper.version>3.6.1</maven.plugin.build-helper.version>
 
 
         <!-- query engines -->


### PR DESCRIPTION
exec-maven-plugin is incompatible with the Maven panel in IntelliJ. We use the maven-antrun-plugin to generate flatbuffer sources.