### PR TITLE
[Issue #959] initialize initializedChunkNum property in DynamicArray when removeAll

### DIFF
--- a/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/DynamicArray.java
+++ b/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/DynamicArray.java
@@ -173,6 +173,7 @@ public class DynamicArray<T>
         this.size = 0;
         this.chunkNum = DEFAULT_CHUNK_NUM;
         this.content = new Object[chunkNum][];
+        this.initializedChunkNum = 0;
     }
 
     /**


### PR DESCRIPTION
The 'initializedChunkNum' property in DynamicArray is not initialized when removeAll() is called.

<img width="1003" height="285" alt="Image" src="https://github.com/user-attachments/assets/f8718e04-2465-406f-a792-b95f09e5eb4c" />