### PR TITLE
[Issue #957] Implement a multi-zone non-blocking caching framework with online cache scaling capabilities

### DIFF
--- a/pixels-cache/README.md
+++ b/pixels-cache/README.md
@@ -42,6 +42,10 @@ cache.size=68719476736
 index.location=/mnt/ramfs/pixels.index
 # the size of the index file of pixels-cache in bytes
 index.size=1073741824
+# the number of zones in the cache
+cache.zone.num=3
+# the number of swap zones in the cache
+cache.zone.swap.num=1
 # the scheme of the storage system to be cached
 cache.storage.scheme=hdfs
 # set to true if cache.storage.scheme is a locality sensitive storage such as hdfs
@@ -135,3 +139,23 @@ Then, run:
 on any node in the cluster to reset the states related to pixels-cache in etcd.
 If you have modified the `etcd` hostname and port in `PIXELS_HOME/etc/pixels.properties`, change the `ENDPOINTS` property
 in `reset-cache.sh` as well.
+
+## Cache Scaling
+
+To enable cache scaling, set `cache_expand_or_shrink` to `1` or `2` in etcd to trigger cache expansion or shrink.
+The field values are interpreted as follows:
+- `0`: No scaling operation (default state)
+- `1`: Trigger cache expansion (scale out)
+- `2`: Trigger cache shrink (scale in)
+
+```bash
+# Set cache_expand_or_shrink to 1 to trigger cache expansion
+etcdctl --endpoints=$host:$port put cache_expand_or_shrink 1
+```
+
+**Notes for Cache Scaling:**
+
+- The scaling operation does not aim to modify the configuration file. Once the PixelsWorker restarts, the scaling effect is no longer active.
+- Now, Shrink cannot be used together with expansion within the same PixelsWorker lifecycle.
+- The cache can automatically create a new physical zone file, but the deleted physical zone file needs to be removed manually after the shrink operation. The deleted physical zone file is the one located before the swap zones (the swap zones are positioned before the last location). 
+- The added or deleted physical zone file requires pinning or unpinning manually.

--- a/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/CacheScalingOperation.java
+++ b/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/CacheScalingOperation.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2025 PixelsDB.
+ *
+ * This file is part of Pixels.
+ *
+ * Pixels is free software: you can redistribute it and/or modify
+ * it under the terms of the Affero GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * Pixels is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Affero GNU General Public License for more details.
+ *
+ * You should have received a copy of the Affero GNU General Public
+ * License along with Pixels.  If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package io.pixelsdb.pixels.cache;
+
+/**
+ * @author alph00
+ */
+public enum CacheScalingOperation
+{
+    NORMAL(0), EXPAND(1), SHRINK(2);
+
+    public final int Operation;
+    CacheScalingOperation(int operation)
+    {
+        this.Operation = operation;
+    }
+}

--- a/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsBucketToZoneMap.java
+++ b/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsBucketToZoneMap.java
@@ -26,11 +26,11 @@ import org.apache.logging.log4j.Logger;
 import java.util.List;
 
 /**
- * Created at: 2024/2/17
- *
+ * @create 2024-02-17
  * @author alph00
  */
-public class PixelsBucketToZoneMap {
+public class PixelsBucketToZoneMap 
+{
     private static final Logger logger = LogManager.getLogger(PixelsBucketToZoneMap.class);
     MemoryMappedFile indexFile;
     long zoneNum;
@@ -42,51 +42,67 @@ public class PixelsBucketToZoneMap {
     final long sizeOfSlot = sizeOfRwAndCount + sizeOfBucketToZone;
     final long stepOfSlot = 3;
 
-    PixelsBucketToZoneMap(MemoryMappedFile indexFile, long zoneNum) {
+    PixelsBucketToZoneMap(MemoryMappedFile indexFile, long zoneNum) 
+    {
         this.indexFile = indexFile;
         this.zoneNum = zoneNum;
         this.startOfRwAndCounts = this.startOfMap + this.sizeOfBucketToZone;
     }
 
-    public void updateBucketZoneMap(long bucketId, int zoneId) {
+    public void updateBucketZoneMap(long bucketId, int zoneId) 
+    {
         indexFile.setIntVolatile(this.startOfMap + (bucketId << this.stepOfSlot), zoneId);
     }
 
-    public boolean initialize() {
-        if (indexFile.getSize() < this.startOfMap + (this.zoneNum << this.stepOfSlot)) {
+    public boolean initialize() 
+    {
+        if (indexFile.getSize() < this.startOfMap + (this.zoneNum << this.stepOfSlot)) 
+        {
             return false;
         }
-        for (int i = 0; i < this.zoneNum; i++) {
+        for (int i = 0; i < this.zoneNum; i++) 
+        {
             indexFile.setIntVolatile(this.startOfMap + (i << this.stepOfSlot), i);
             indexFile.setIntVolatile(this.startOfRwAndCounts + (i << this.stepOfSlot), 0);
         }
         return true;
     }
-     public boolean isMapFull(long num){
-        if (indexFile.getSize() < this.startOfMap + (num << this.stepOfSlot)) {
+
+    public boolean isMapFull(long num)
+    {
+        if (indexFile.getSize() < this.startOfMap + (num << this.stepOfSlot)) 
+        {
             return true;
         }
         return false;
-     }
+    }
 
-    public int getBucketToZone(long bucketId) {
+    public int getBucketToZone(long bucketId) 
+    {
         return indexFile.getIntVolatile(this.startOfMap + (bucketId << this.stepOfSlot));
     }
 
-    public int getHashNodeNum(){
+    public int getHashNodeNum()
+    {
         return indexFile.getIntVolatile(this.startOfHashNodeNum);
     }
 
-    public void setHashNodeNum(int hashNodeNum){
+    public void setHashNodeNum(int hashNodeNum)
+    {
         indexFile.setIntVolatile(this.startOfHashNodeNum, hashNodeNum);
     }
 
-    public void close() {
-        try {
-            if (indexFile != null) {
+    public void close() 
+    {
+        try 
+        {
+            if (indexFile != null) 
+            {
                 indexFile.unmap();
             }
-        } catch (Exception e) {
+        } 
+        catch (Exception e) 
+        {
             logger.error("Failed to unmap index file", e);
         }
     }

--- a/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsBucketToZoneMap.java
+++ b/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsBucketToZoneMap.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2024 PixelsDB.
+ *
+ * This file is part of Pixels.
+ *
+ * Pixels is free software: you can redistribute it and/or modify
+ * it under the terms of the Affero GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * Pixels is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Affero GNU General Public License for more details.
+ *
+ * You should have received a copy of the Affero GNU General Public
+ * License along with Pixels.  If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package io.pixelsdb.pixels.cache;
+
+import io.pixelsdb.pixels.common.physical.natives.MemoryMappedFile;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.List;
+
+/**
+ * Created at: 2024/2/17
+ *
+ * @author alph00
+ */
+public class PixelsBucketToZoneMap {
+    private static final Logger logger = LogManager.getLogger(PixelsBucketToZoneMap.class);
+    MemoryMappedFile indexFile;
+    long zoneNum;
+    long startOfRwAndCounts;
+    final long startOfHashNodeNum = 14;// store the number of nodes on hashcycle, it is used when scaling cache size.
+    final long startOfMap = 18;
+    final long sizeOfRwAndCount = 4;
+    final long sizeOfBucketToZone = 4;
+    final long sizeOfSlot = sizeOfRwAndCount + sizeOfBucketToZone;
+    final long stepOfSlot = 3;
+
+    PixelsBucketToZoneMap(MemoryMappedFile indexFile, long zoneNum) {
+        this.indexFile = indexFile;
+        this.zoneNum = zoneNum;
+        this.startOfRwAndCounts = this.startOfMap + this.sizeOfBucketToZone;
+    }
+
+    public void updateBucketZoneMap(long bucketId, int zoneId) {
+        indexFile.setIntVolatile(this.startOfMap + (bucketId << this.stepOfSlot), zoneId);
+    }
+
+    public boolean initialize() {
+        if (indexFile.getSize() < this.startOfMap + (this.zoneNum << this.stepOfSlot)) {
+            return false;
+        }
+        for (int i = 0; i < this.zoneNum; i++) {
+            indexFile.setIntVolatile(this.startOfMap + (i << this.stepOfSlot), i);
+            indexFile.setIntVolatile(this.startOfRwAndCounts + (i << this.stepOfSlot), 0);
+        }
+        return true;
+    }
+     public boolean isMapFull(long num){
+        if (indexFile.getSize() < this.startOfMap + (num << this.stepOfSlot)) {
+            return true;
+        }
+        return false;
+     }
+
+    public int getBucketToZone(long bucketId) {
+        return indexFile.getIntVolatile(this.startOfMap + (bucketId << this.stepOfSlot));
+    }
+
+    public int getHashNodeNum(){
+        return indexFile.getIntVolatile(this.startOfHashNodeNum);
+    }
+
+    public void setHashNodeNum(int hashNodeNum){
+        indexFile.setIntVolatile(this.startOfHashNodeNum, hashNodeNum);
+    }
+
+    public void close() {
+        try {
+            if (indexFile != null) {
+                indexFile.unmap();
+            }
+        } catch (Exception e) {
+            logger.error("Failed to unmap index file", e);
+        }
+    }
+}

--- a/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsBucketTypeInfo.java
+++ b/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsBucketTypeInfo.java
@@ -26,11 +26,11 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Created at: 2024/1/23
- *
+ * @create 2024-01-23
  * @author alph00
  */
-public class PixelsBucketTypeInfo {
+public class PixelsBucketTypeInfo 
+{
     private final static Logger logger = LogManager.getLogger(PixelsBucketTypeInfo.class);
     private int allBucketNum;
     private int swapBucketNum;
@@ -41,7 +41,8 @@ public class PixelsBucketTypeInfo {
     private final List<Integer> swapBucketIds;
     private final List<Integer> eagerBucketIds;
 
-    private PixelsBucketTypeInfo(Builder builder) {
+    private PixelsBucketTypeInfo(Builder builder) 
+    {
         this.allBucketNum = builder.allBucketNum;
         this.swapBucketNum = builder.swapBucketNum;
         this.lazyBucketNum = builder.lazyBucketNum;
@@ -51,7 +52,8 @@ public class PixelsBucketTypeInfo {
         this.eagerBucketIds = builder.eagerBucketIds;
     }
 
-    public static class Builder {
+    public static class Builder 
+    {
         private int allBucketNum = 2;
         private int swapBucketNum = 1;
         private int eagerBucketNum = 0;
@@ -61,8 +63,10 @@ public class PixelsBucketTypeInfo {
         private List<Integer> swapBucketIds = new ArrayList<>();
         private List<Integer> eagerBucketIds = new ArrayList<>();
 
-        public Builder(int allBucketNum) {
-            if (allBucketNum <= 0) {
+        public Builder(int allBucketNum) 
+        {
+            if (allBucketNum <= 0) 
+            {
                 throw new IllegalArgumentException("allBucketNum must be positive");
             }
             this.allBucketNum = allBucketNum;
@@ -70,120 +74,148 @@ public class PixelsBucketTypeInfo {
             validate();
         }
 
-        private void validate() {
-            if (swapBucketNum < 0 || eagerBucketNum < 0 || lazyBucketNum < 0) {
+        private void validate() 
+        {
+            if (swapBucketNum < 0 || eagerBucketNum < 0 || lazyBucketNum < 0) 
+            {
                 throw new IllegalStateException("Bucket counts can't be negative");
             }
-            if (swapBucketNum + eagerBucketNum + lazyBucketNum != allBucketNum) {
-                    throw new IllegalStateException("Sum of buckets must equal allBucketNum");
+            if (swapBucketNum + eagerBucketNum + lazyBucketNum != allBucketNum) 
+            {
+                throw new IllegalStateException("Sum of buckets must equal allBucketNum");
             }
         }
 
-        public Builder setAllBucketNum(int allBucketNum) {
+        public Builder setAllBucketNum(int allBucketNum) 
+        {
             this.allBucketNum = allBucketNum;
             return this;
         }
 
-        public Builder setLazyBucketNum(int lazyBucketNum) {
+        public Builder setLazyBucketNum(int lazyBucketNum) 
+        {
             this.lazyBucketNum = lazyBucketNum;
             return this;
         }
 
-        public Builder setSwapBucketNum(int swapBucketNum) {
+        public Builder setSwapBucketNum(int swapBucketNum) 
+        {
             this.swapBucketNum = swapBucketNum;
             return this;
         }
 
-        public Builder setEagerBucketNum(int eagerBucketNum) {
+        public Builder setEagerBucketNum(int eagerBucketNum) 
+        {
             this.eagerBucketNum = eagerBucketNum;
             return this;
         }
 
-        public Builder setLazyBucketIds(List<Integer> lazyBucketIds) {
+        public Builder setLazyBucketIds(List<Integer> lazyBucketIds) 
+        {
             this.lazyBucketIds = lazyBucketIds;
             return this;
         }
 
-        public Builder setSwapBucketIds(List<Integer> swapBucketIds) {
+        public Builder setSwapBucketIds(List<Integer> swapBucketIds) 
+        {
             this.swapBucketIds = swapBucketIds;
             return this;
         }
 
-        public Builder setEagerBucketIds(List<Integer> eagerBucketIds) {
+        public Builder setEagerBucketIds(List<Integer> eagerBucketIds) 
+        {
             this.eagerBucketIds = eagerBucketIds;
             return this;
         }
 
-        public PixelsBucketTypeInfo build() {
+        public PixelsBucketTypeInfo build() 
+        {
             return new PixelsBucketTypeInfo(this);
         }
     }
 
-    public static Builder newBuilder(int allBucketNum) {
+    public static Builder newBuilder(int allBucketNum) 
+    {
         return new Builder(allBucketNum);
     }
 
-    public int getAllBucketNum() {
+    public int getAllBucketNum() 
+    {
         return allBucketNum;
     }
 
-    public void setAllBucketNum(int allBucketNum) {
+    public void setAllBucketNum(int allBucketNum) 
+    {
         this.allBucketNum = allBucketNum;
     }
 
-    public int getSwapBucketNum() {
+    public int getSwapBucketNum() 
+    {
         return swapBucketNum;
     }
 
-    public void setSwapBucketNum(int swapBucketNum) {
+    public void setSwapBucketNum(int swapBucketNum) 
+    {
         this.swapBucketNum = swapBucketNum;
     }
 
-    public int getLazyBucketNum() {
+    public int getLazyBucketNum() 
+    {
         return lazyBucketNum;
     }
 
-    public void setLazyBucketNum(int lazyBucketNum) {
+    public void setLazyBucketNum(int lazyBucketNum) 
+    {
         this.lazyBucketNum = lazyBucketNum;
     }
 
-    public int getEagerBucketNum() {
+    public int getEagerBucketNum() 
+    {
         return eagerBucketNum;
     }
 
-    public void setEagerBucketNum(int eagerBucketNum) {
+    public void setEagerBucketNum(int eagerBucketNum) 
+    {
         this.eagerBucketNum = eagerBucketNum;
     }
 
-    public void incrementLazyBucketNum() {
+    public void incrementLazyBucketNum() 
+    {
         this.lazyBucketNum++;
     }
 
-    public void incrementSwapBucketNum() {
+    public void incrementSwapBucketNum() 
+    {
         this.swapBucketNum++;
     }
 
-    public void incrementEagerBucketNum() {
+    public void incrementEagerBucketNum() 
+    {
         this.eagerBucketNum++;
     }
 
-    public void decrementLazyBucketNum() {
+    public void decrementLazyBucketNum() 
+    {
         this.lazyBucketNum--;
     }
 
-    public List<Integer> getLazyBucketIds() {
+    public List<Integer> getLazyBucketIds() 
+    {
         return lazyBucketIds;
     }
 
-    public List<Integer> getSwapBucketIds() {
+    public List<Integer> getSwapBucketIds() 
+    {
         return swapBucketIds;
     }
 
-    public List<Integer> getEagerBucketIds() {
+    public List<Integer> getEagerBucketIds() 
+    {
         return eagerBucketIds;
     }
 
-    public void close() {
+    public void close() 
+    {
         lazyBucketIds.clear();
         swapBucketIds.clear();
         eagerBucketIds.clear();

--- a/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsBucketTypeInfo.java
+++ b/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsBucketTypeInfo.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2024 PixelsDB.
+ *
+ * This file is part of Pixels.
+ *
+ * Pixels is free software: you can redistribute it and/or modify
+ * it under the terms of the Affero GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * Pixels is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Affero GNU General Public License for more details.
+ *
+ * You should have received a copy of the Affero GNU General Public
+ * License along with Pixels.  If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package io.pixelsdb.pixels.cache;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Created at: 2024/1/23
+ *
+ * @author alph00
+ */
+public class PixelsBucketTypeInfo {
+    private final static Logger logger = LogManager.getLogger(PixelsBucketTypeInfo.class);
+    private int allBucketNum;
+    private int swapBucketNum;
+    private int lazyBucketNum;
+    private int eagerBucketNum;
+
+    private final List<Integer> lazyBucketIds;
+    private final List<Integer> swapBucketIds;
+    private final List<Integer> eagerBucketIds;
+
+    private PixelsBucketTypeInfo(Builder builder) {
+        this.allBucketNum = builder.allBucketNum;
+        this.swapBucketNum = builder.swapBucketNum;
+        this.lazyBucketNum = builder.lazyBucketNum;
+        this.eagerBucketNum = builder.eagerBucketNum;
+        this.lazyBucketIds = builder.lazyBucketIds;
+        this.swapBucketIds = builder.swapBucketIds;
+        this.eagerBucketIds = builder.eagerBucketIds;
+    }
+
+    public static class Builder {
+        private int allBucketNum = 2;
+        private int swapBucketNum = 1;
+        private int eagerBucketNum = 0;
+        private int lazyBucketNum = 1;
+
+        private List<Integer> lazyBucketIds = new ArrayList<>();
+        private List<Integer> swapBucketIds = new ArrayList<>();
+        private List<Integer> eagerBucketIds = new ArrayList<>();
+
+        public Builder(int allBucketNum) {
+            if (allBucketNum <= 0) {
+                throw new IllegalArgumentException("allBucketNum must be positive");
+            }
+            this.allBucketNum = allBucketNum;
+            this.lazyBucketNum = allBucketNum - swapBucketNum - eagerBucketNum;
+            validate();
+        }
+
+        private void validate() {
+            if (swapBucketNum < 0 || eagerBucketNum < 0 || lazyBucketNum < 0) {
+                throw new IllegalStateException("Bucket counts can't be negative");
+            }
+            if (swapBucketNum + eagerBucketNum + lazyBucketNum != allBucketNum) {
+                    throw new IllegalStateException("Sum of buckets must equal allBucketNum");
+            }
+        }
+
+        public Builder setAllBucketNum(int allBucketNum) {
+            this.allBucketNum = allBucketNum;
+            return this;
+        }
+
+        public Builder setLazyBucketNum(int lazyBucketNum) {
+            this.lazyBucketNum = lazyBucketNum;
+            return this;
+        }
+
+        public Builder setSwapBucketNum(int swapBucketNum) {
+            this.swapBucketNum = swapBucketNum;
+            return this;
+        }
+
+        public Builder setEagerBucketNum(int eagerBucketNum) {
+            this.eagerBucketNum = eagerBucketNum;
+            return this;
+        }
+
+        public Builder setLazyBucketIds(List<Integer> lazyBucketIds) {
+            this.lazyBucketIds = lazyBucketIds;
+            return this;
+        }
+
+        public Builder setSwapBucketIds(List<Integer> swapBucketIds) {
+            this.swapBucketIds = swapBucketIds;
+            return this;
+        }
+
+        public Builder setEagerBucketIds(List<Integer> eagerBucketIds) {
+            this.eagerBucketIds = eagerBucketIds;
+            return this;
+        }
+
+        public PixelsBucketTypeInfo build() {
+            return new PixelsBucketTypeInfo(this);
+        }
+    }
+
+    public static Builder newBuilder(int allBucketNum) {
+        return new Builder(allBucketNum);
+    }
+
+    public int getAllBucketNum() {
+        return allBucketNum;
+    }
+
+    public void setAllBucketNum(int allBucketNum) {
+        this.allBucketNum = allBucketNum;
+    }
+
+    public int getSwapBucketNum() {
+        return swapBucketNum;
+    }
+
+    public void setSwapBucketNum(int swapBucketNum) {
+        this.swapBucketNum = swapBucketNum;
+    }
+
+    public int getLazyBucketNum() {
+        return lazyBucketNum;
+    }
+
+    public void setLazyBucketNum(int lazyBucketNum) {
+        this.lazyBucketNum = lazyBucketNum;
+    }
+
+    public int getEagerBucketNum() {
+        return eagerBucketNum;
+    }
+
+    public void setEagerBucketNum(int eagerBucketNum) {
+        this.eagerBucketNum = eagerBucketNum;
+    }
+
+    public void incrementLazyBucketNum() {
+        this.lazyBucketNum++;
+    }
+
+    public void incrementSwapBucketNum() {
+        this.swapBucketNum++;
+    }
+
+    public void incrementEagerBucketNum() {
+        this.eagerBucketNum++;
+    }
+
+    public void decrementLazyBucketNum() {
+        this.lazyBucketNum--;
+    }
+
+    public List<Integer> getLazyBucketIds() {
+        return lazyBucketIds;
+    }
+
+    public List<Integer> getSwapBucketIds() {
+        return swapBucketIds;
+    }
+
+    public List<Integer> getEagerBucketIds() {
+        return eagerBucketIds;
+    }
+
+    public void close() {
+        lazyBucketIds.clear();
+        swapBucketIds.clear();
+        eagerBucketIds.clear();
+    }
+}

--- a/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsCacheConfig.java
+++ b/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsCacheConfig.java
@@ -63,6 +63,15 @@ public class PixelsCacheConfig
         return Long.parseLong(configFactory.getProperty("cache.size"));
     }
 
+    public int getZoneNum()
+    {
+        return Integer.parseInt(configFactory.getProperty("cache.zone.num"));
+    }
+    public int getSwapZoneNum()
+    {
+        return Integer.parseInt(configFactory.getProperty("cache.zone.swap.num"));
+    }
+
     public String getStorageScheme()
     {
          return configFactory.getProperty("cache.storage.scheme");

--- a/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsCacheReader.java
+++ b/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsCacheReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 PixelsDB.
+ * Copyright 2024 PixelsDB.
  *
  * This file is part of Pixels.
  *
@@ -19,312 +19,109 @@
  */
 package io.pixelsdb.pixels.cache;
 
-import io.pixelsdb.pixels.common.physical.natives.MemoryMappedFile;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import io.pixelsdb.pixels.common.physical.natives.MemoryMappedFile;
 
 import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
-import java.util.List;
+import java.util.*;
 
 /**
  * pixels cache reader.
- * It is not thread safe.
  *
- * @author guodong
- * @author hank
+ * @author alph00
  */
-public class PixelsCacheReader implements AutoCloseable
-{
+public class PixelsCacheReader implements AutoCloseable {
     private static final Logger logger = LogManager.getLogger(PixelsCacheReader.class);
-    // private static CacheLogger cacheLogger = new CacheLogger();
+    private final PixelsLocator locator;
+    private final List<PixelsZoneReader> zones;
+    private final PixelsBucketToZoneMap bucketToZoneMap;
 
-    private final MemoryMappedFile cacheFile;
-    private final MemoryMappedFile indexFile;
-
-    /**
-     * <p>
-     *     A node can have at most 256 children, plus an edge (a segment of
-     *     lookup key). Each child is 8 bytes.
-     * </p>
-     * <p>
-     *     In pixels, where will be one PixelsCacheReader on each split. And each
-     *     split is supposed to be processed by one single thread. There are
-     *     typically 10 - 200 concurrent threads (splits) on a machine. So that it
-     *     is not a problem to allocate nodeData in each PixelsCacheReader instance.
-     *     By this, we can avoid frequent memory allocation in the search() method.
-     * </p>
-     * <p>
-     *     For the edge, although PixelsRadix can support 1MB edge length, we only
-     *     use 12 byte path (PixelsCacheKey). That means no edges can exceeds 12 bytes.
-     *     So that 16 bytes is more than enough.
-     * </p>
-     */
-    private final byte[] nodeData = new byte[256 * 8 + 16];
-    private final ByteBuffer childrenBuffer = ByteBuffer.wrap(nodeData);
-
-    private final ByteBuffer keyBuffer = ByteBuffer.allocate(PixelsCacheKey.SIZE).order(ByteOrder.BIG_ENDIAN);
-
-//    static
-//    {
-//        new Thread(cacheLogger).start();
-//    }
-
-    private PixelsCacheReader(MemoryMappedFile cacheFile, MemoryMappedFile indexFile)
-    {
-        this.cacheFile = cacheFile;
-        this.indexFile = indexFile;
+    private PixelsCacheReader(PixelsLocator builderLocator, List<PixelsZoneReader> builderZones, PixelsBucketToZoneMap bucketToZoneMap) {
+        this.zones = builderZones;
+        this.locator = builderLocator;
+        this.bucketToZoneMap = bucketToZoneMap;
     }
 
-    public static class Builder
-    {
-        private MemoryMappedFile builderCacheFile;
-        private MemoryMappedFile builderIndexFile;
+    public static class Builder {
+        private List<MemoryMappedFile> zoneFiles;
+        private List<MemoryMappedFile> indexFiles;
+        private MemoryMappedFile globalIndexFile;
+        private int zoneNum = 0;
+        private int swapZoneNum = 1;
 
-        private Builder()
-        {
+        private Builder() {
         }
 
-        public PixelsCacheReader.Builder setCacheFile(MemoryMappedFile cacheFile)
-        {
-//            requireNonNull(cacheFile, "cache file is null");
-            this.builderCacheFile = cacheFile;
-
+        // we calculate zoneNum from zoneFiles including swap zone
+        public PixelsCacheReader.Builder setCacheFile(List<MemoryMappedFile> zoneFiles) {
+            this.zoneFiles = zoneFiles;
+            if(zoneFiles != null) {
+                zoneNum = zoneFiles.size();
+            } else {
+                zoneNum = 0;
+            }
             return this;
         }
 
-        public PixelsCacheReader.Builder setIndexFile(MemoryMappedFile indexFile)
-        {
-//            requireNonNull(indexFile, "index file is null");
-            this.builderIndexFile = indexFile;
-
+        public PixelsCacheReader.Builder setIndexFile(List<MemoryMappedFile> indexFiles) {
+            this.indexFiles = indexFiles;
             return this;
         }
 
-        public PixelsCacheReader build()
-        {
-            return new PixelsCacheReader(builderCacheFile, builderIndexFile);
+        public PixelsCacheReader.Builder setGlobalIndexFile(MemoryMappedFile globalIndexFile) {
+            this.globalIndexFile = globalIndexFile;
+            return this;
+        }
+
+        // now this function is not used, swapZoneNum is set to 1 by default
+        public PixelsCacheReader.Builder setSwapZoneNum(int swapZoneNum) {
+            this.swapZoneNum = swapZoneNum;
+            return this;
+        }
+
+        public PixelsCacheReader build() {
+            List<PixelsZoneReader> builderZones = new ArrayList<>();
+            for (int i = 0; i < zoneNum; i++) {
+                builderZones.add(PixelsZoneReader.newBuilder().setZoneFile(zoneFiles.get(i)).setIndexFile(indexFiles.get(i)).build());
+            }
+            PixelsLocator builderLocator = new PixelsLocator(zoneNum - swapZoneNum);
+            PixelsBucketToZoneMap bucketToZoneMap = new PixelsBucketToZoneMap(globalIndexFile, zoneNum);
+            return new PixelsCacheReader(builderLocator, builderZones, bucketToZoneMap);
         }
     }
 
-    public static PixelsCacheReader.Builder newBuilder()
-    {
+    public static PixelsCacheReader.Builder newBuilder() {
         return new PixelsCacheReader.Builder();
     }
 
-    public ByteBuffer get(long blockId, short rowGroupId, short columnId)
-    {
-        return this.get(blockId, rowGroupId, columnId, true);
-    }
-
-    /**
-     * Read specified column chunk from cache.
-     * If cache is not hit, empty byte array is returned, and an access message is sent to the mq.
-     * If cache is hit, the column chunk content is returned as byte array.
-     * This method may return NULL value. Be careful dealing with null!!!
-     *
-     * @param blockId    block id
-     * @param rowGroupId row group id
-     * @param columnId   column id
-     * @param direct get direct byte buffer if true
-     * @return the column chunk content, or null if failed to read the cache
-     */
-    public ByteBuffer get(long blockId, short rowGroupId, short columnId, boolean direct)
-    {
-        // search index file for column chunk id
-        PixelsCacheKey.getBytes(keyBuffer, blockId, rowGroupId, columnId);
-
-        // check the rwFlag and increase readCount.
-        long lease = 0;
-        try
-        {
-            lease = PixelsCacheUtil.beginIndexRead(indexFile);
-        }
-        catch (InterruptedException e)
-        {
-            logger.error("Failed to get read permission on index.", e);
-            /**
-             * Issue #88:
-             * In case of failure (e.g. reaches max cache reader count),
-             * return null here to stop reading cache, then the content
-             * will be read from disk.
-             */
+    public ByteBuffer get(long blockId, short rowGroupId, short columnId, boolean direct) {
+        long bucketId = locator.getLocation(new PixelsCacheKey(blockId, rowGroupId, columnId));
+        int zoneId = bucketToZoneMap.getBucketToZone(bucketId);
+        if (zoneId < 0 || zoneId >= zones.size()) {
+            logger.warn("Invalid zone id: {}", zoneId);
             return null;
         }
-
-        ByteBuffer content = null;
-        // search cache key
-//        long searchBegin = System.nanoTime();
-        PixelsCacheIdx cacheIdx = search(keyBuffer);
-//        long searchEnd = System.nanoTime();
-//        cacheLogger.addSearchLatency(searchEnd - searchBegin);
-//        logger.debug("[cache search]: " + (searchEnd - searchBegin));
-        // if found, read content from cache
-//        long readBegin = System.nanoTime();
-        if (cacheIdx != null)
-        {
-            if (direct)
-            {
-                // read content
-                content = cacheFile.getDirectByteBuffer(cacheIdx.offset, cacheIdx.length);
-            }
-            else
-            {
-                content = ByteBuffer.allocate(cacheIdx.length);
-                // read content
-                cacheFile.getBytes(cacheIdx.offset, content.array(), 0, cacheIdx.length);
-            }
-        }
-
-        boolean cacheReadSuccess = PixelsCacheUtil.endIndexRead(indexFile, lease);
-
-//        long readEnd = System.nanoTime();
-//        cacheLogger.addReadLatency(readEnd - readBegin);
-//        logger.debug("[cache read]: " + (readEnd - readBegin));
-        if (cacheReadSuccess)
-        {
-            return content;
-        }
-        return null;
-    }
-
-    public void batchGet(List<ColumnChunkId> columnChunkIds, byte[][] container)
-    {
-        // TODO batch get cache items. merge cache accesses to reduce the number of jni invocation.
-    }
-
-    /**
-     * This interface is only used by TESTS, DO NOT USE.
-     * It will be removed soon!
-     */
-    public PixelsCacheIdx search(long blockId, short rowGroupId, short columnId)
-    {
-        PixelsCacheKey.getBytes(keyBuffer, blockId, rowGroupId, columnId);
-
-        return search(keyBuffer);
-    }
-
-    /**
-     * Search key from radix tree.
-     * If found, update counter in cache idx.
-     * Else, return null
-     */
-    private PixelsCacheIdx search(ByteBuffer keyBuffer)
-    {
-        int dramAccessCounter = 0;
-        int radixLevel = 0;
-        final int keyLen = keyBuffer.position();
-        long currentNodeOffset = PixelsCacheUtil.INDEX_RADIX_OFFSET;
-        int bytesMatched = 0;
-        int bytesMatchedInNodeFound = 0;
-
-        // get root
-        // TODO: root currently does not have edge, which is not efficient in some cases.
-        int currentNodeHeader = indexFile.getInt(currentNodeOffset);
-        dramAccessCounter++;
-        int currentNodeChildrenNum = currentNodeHeader & 0x000001FF;
-        int currentNodeEdgeSize = (currentNodeHeader & 0x7FFFFE00) >>> 9;
-        if (currentNodeChildrenNum == 0 && currentNodeEdgeSize == 0)
-        {
+        PixelsZoneReader zone = zones.get(zoneId);
+        if (zone == null) {
+            logger.warn("Zone reader {} not initialized", zoneId);
             return null;
         }
-        indexFile.getBytes(currentNodeOffset + 4, this.nodeData, 0, currentNodeChildrenNum * 8);
-        dramAccessCounter++;
-        radixLevel++;
-
-        // search
-        // it can be more clear with a do while function
-        outer_loop:
-        while (bytesMatched < keyLen)
-        {
-            // search each child for the matching node
-            long matchingChildOffset = 0L;
-            childrenBuffer.position(0);
-            childrenBuffer.limit(currentNodeChildrenNum * 8);
-            // linearly scan all the children
-            for (int i = 0; i < currentNodeChildrenNum; i++)
-            {
-                // long is 8 byte, which is 64 bit
-                long child = childrenBuffer.getLong();
-                // first byte is matching byte
-                byte leader = (byte) ((child >>> 56) & 0xFF);
-                if (leader == keyBuffer.get(bytesMatched))
-                {
-                    // child last 7 bytes is grandson's offset, that is, the address is 7-bytes long
-                    matchingChildOffset = child & 0x00FFFFFFFFFFFFFFL;
-                    break;
-                }
-            }
-            if (matchingChildOffset == 0)
-            {
-                break;
-            }
-
-            currentNodeOffset = matchingChildOffset;
-            bytesMatchedInNodeFound = 0;
-            currentNodeHeader = indexFile.getInt(currentNodeOffset);
-            dramAccessCounter++;
-            currentNodeChildrenNum = currentNodeHeader & 0x000001FF;
-            currentNodeEdgeSize = (currentNodeHeader & 0x7FFFFE00) >>> 9;
-            // read the children and edge in one memory access.
-            indexFile.getBytes(currentNodeOffset + 4,
-                    this.nodeData, 0, currentNodeChildrenNum * 8 + currentNodeEdgeSize);
-            dramAccessCounter++;
-            int edgeEndOffset = currentNodeChildrenNum * 8 + currentNodeEdgeSize;
-            /**
-             * The first byte is matched in the child leader of the parent node,
-             * therefore we start the matching from the second byte in edge.
-             * this is useful for below `bytesMatchedInNodeFound == currentNodeEdgeSize`
-             */
-            bytesMatched++;
-            bytesMatchedInNodeFound++;
-            // now we are visiting the edge! rather than children data
-            // it seems between children and edge, there is a one byte gap?
-            // or the first byte of the edge does not matter here anyway
-            for (int i = currentNodeChildrenNum * 8 + 1; i < edgeEndOffset && bytesMatched < keyLen; i++)
-            {
-                // the edge is shared across this node, so the edge should be fully matched
-                if (this.nodeData[i] != keyBuffer.get(bytesMatched))
-                {
-                    break outer_loop;
-                }
-                bytesMatched++;
-                bytesMatchedInNodeFound++;
-            }
-
-            // only increase level when a child is really matched.
-            radixLevel++;
-        }
-
-        // if matches, node found.
-        if (bytesMatched == keyLen && bytesMatchedInNodeFound == currentNodeEdgeSize)
-        {
-            // if the current node is leaf node.
-            if (((currentNodeHeader >>> 31) & 1) > 0)
-            {
-                byte[] idx = new byte[12];
-                indexFile.getBytes(currentNodeOffset + 4 + (currentNodeChildrenNum * 8) + currentNodeEdgeSize,
-                        idx, 0, 12);
-                dramAccessCounter++;
-                PixelsCacheIdx cacheIdx = new PixelsCacheIdx(idx);
-                cacheIdx.dramAccessCount = dramAccessCounter;
-                cacheIdx.radixLevel = radixLevel;
-                return cacheIdx;
-            }
-        }
-        return null;
+        return zone.get(blockId, rowGroupId, columnId, direct);
     }
 
-    public void close()
-    {
-        try
-        {
-//            logger.info("cache reader unmaps cache/index file");
-            cacheFile.unmap();
-            indexFile.unmap();
-        }
-        catch (Exception e)
-        {
+    public void close() {
+        try {
+            for (PixelsZoneReader zone : zones) {
+                zone.close();
+            }
+            if (bucketToZoneMap != null) {
+                bucketToZoneMap.close();
+            }
+            if (locator != null) {                
+                locator.close();
+            }
+        } catch (Exception e) {
             e.printStackTrace();
         }
     }

--- a/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsCacheUtil.java
+++ b/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsCacheUtil.java
@@ -364,9 +364,9 @@ public class PixelsCacheUtil
      * @param cacheFile the cache file of the local cache
      * @return the local cache version in the index file, or -1 when the local cache is empty
      */
-    public static int getIndexVersion(MemoryMappedFile indexFile, MemoryMappedFile cacheFile)
+    public static int getIndexVersion(MemoryMappedFile indexFile, PixelsCacheWriter cacheWriter)
     {
-        if (isCacheFileEmpty(cacheFile))
+        if (cacheWriter.isExistZoneEmpty())
         {
             return -1;
         }

--- a/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsCacheWriter.java
+++ b/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsCacheWriter.java
@@ -240,7 +240,7 @@ public class PixelsCacheWriter
                             schemaTableName.getSchemaName(), schemaTableName.getSchemaName(), cachedVersion);
                     Compact compact = cachedLayout.getCompact();
                     int cacheBorder = compact.getCacheBorder();
-                    cachedColumnChunks.addAll(compact.getColumnChunkOrder().subList(0, cacheBorder));
+                    cachedColumnChunks.addAll(compact.getColumnChunkOrder());//.subList(0, cacheBorder));
                 }
             }
             else
@@ -421,7 +421,7 @@ public class PixelsCacheWriter
         // get the new caching layout
         Compact compact = layout.getCompact();
         int cacheBorder = compact.getCacheBorder();
-        List<String> cacheColumnChunkOrders = compact.getColumnChunkOrder().subList(0, cacheBorder);
+        List<String> cacheColumnChunkOrders = compact.getColumnChunkOrder();//.subList(0, cacheBorder);
 
 
         // update cache content
@@ -544,7 +544,7 @@ public class PixelsCacheWriter
          */
         Compact compact = layout.getCompact();
         int cacheBorder = compact.getCacheBorder();
-        List<String> nextVersionCached = compact.getColumnChunkOrder().subList(0, cacheBorder);
+        List<String> nextVersionCached = compact.getColumnChunkOrder();//.subList(0, cacheBorder);
         /**
          * Prepare structures for the survived and new coming cache elements.
          */

--- a/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsCacheWriter.java
+++ b/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsCacheWriter.java
@@ -44,7 +44,7 @@ import static com.google.common.base.Preconditions.checkArgument;
  *
  * @author guodong
  * @author hank
- * @author qfs
+ * @author alph00
  */
 public class PixelsCacheWriter
 {
@@ -207,7 +207,8 @@ public class PixelsCacheWriter
                 {
                     int zoneId = bucketToZoneMap.getBucketToZone(i);
                     zones.get(zoneId).loadIndex();
-                    switch (zones.get(zoneId).getZoneType()){
+                    switch (zones.get(zoneId).getZoneType())
+                    {
                         case LAZY:
                             bucketTypeInfo.incrementLazyBucketNum();
                             bucketTypeInfo.getLazyBucketIds().add(i);
@@ -397,7 +398,8 @@ public class PixelsCacheWriter
      * Currently, this is an interface for unit tests.
      * This method only updates index content and cache content (without touching headers)
      */
-    public void write(PixelsCacheKey key, byte[] value) throws IOException {
+    public void write(PixelsCacheKey key, byte[] value) throws IOException 
+    {
        int zoneId = bucketToZoneMap.getBucketToZone(locator.getLocation(key));
        PixelsZoneWriter zone = zones.get(zoneId);
        zone.write(key, value);
@@ -466,7 +468,7 @@ public class PixelsCacheWriter
                 }
                 int physicalLen;
                 long physicalOffset;
-                try(PixelsPhysicalReader pixelsPhysicalReader = new PixelsPhysicalReader(storage, file))
+                try (PixelsPhysicalReader pixelsPhysicalReader = new PixelsPhysicalReader(storage, file))
                 {
                     if (pixelsPhysicalReader.getRowGroupNum() < rowGroupNumInLayout)
                     {
@@ -484,7 +486,8 @@ public class PixelsCacheWriter
                         short rowGroupId = Short.parseShort(columnChunkIdStr[0]);
                         short columnId = Short.parseShort(columnChunkIdStr[1]);
                         PixelsCacheKey key = new PixelsCacheKey(pixelsPhysicalReader.getCurrentBlockId(), rowGroupId, columnId);
-                        if(locator.getLocation(key) != bucketId){
+                        if(locator.getLocation(key) != bucketId)
+                        {
                             continue;
                         }
 
@@ -497,7 +500,8 @@ public class PixelsCacheWriter
                         {
                             logger.debug("Cache writes have exceeded bucket size. Break. Current size: " + currCacheOffset + "current bucketId: " + bucketId);
                             break outer_loop;
-                        } else
+                        } 
+                        else
                         {
                             zone.getRadix().put(new PixelsCacheKey(pixelsPhysicalReader.getCurrentBlockId(), rowGroupId, columnId),
                                     new PixelsCacheIdx(currCacheOffset, physicalLen));
@@ -537,7 +541,8 @@ public class PixelsCacheWriter
      * @throws IOException
      */
     private int internalUpdateIncremental(int version, Layout layout, String[] files)
-            throws IOException, InterruptedException, NullPointerException {
+            throws IOException, InterruptedException, NullPointerException 
+    {
         int status = 0;
         /**
          * Get the new caching layout.
@@ -566,7 +571,7 @@ public class PixelsCacheWriter
         int rowGroupNumInLayout = compact.getNumRowGroupInFile();
         for (String file : files)
         {
-            try(PixelsPhysicalReader physicalReader = new PixelsPhysicalReader(storage, file))
+            try (PixelsPhysicalReader physicalReader = new PixelsPhysicalReader(storage, file))
             {
                 if(physicalReader.getRowGroupNum() < rowGroupNumInLayout)
                 {
@@ -589,14 +594,20 @@ public class PixelsCacheWriter
                     int zoneId = bucketToZoneMap.getBucketToZone(bucketId);
                     PixelsZoneWriter zone = zones.get(zoneId);
                     PixelsCacheIdx curCacheIdx = zone.getRadix().get(blockId, rowGroupId, columnId);
-                    if(curCacheIdx == null){
-                        if(missSurvivedIdxes.containsKey(blockId)){
+                    if(curCacheIdx == null)
+                    {
+                        if(missSurvivedIdxes.containsKey(blockId))
+                        {
                             missSurvivedIdxes.get(blockId).add(new PixelsCacheKey(blockId, rowGroupId, columnId));
-                        }else{
+                        }
+                        else
+                        {
                             missSurvivedIdxes.put(blockId, new ArrayList<>());
                             missSurvivedIdxes.get(blockId).add(new PixelsCacheKey(blockId, rowGroupId, columnId));
                         }
-                    }else{
+                    }
+                    else
+                    {
                         survivedIdxes.add(new PixelsCacheEntry(new PixelsCacheKey(blockId, rowGroupId, columnId), curCacheIdx));
                     }
                 }
@@ -621,8 +632,10 @@ public class PixelsCacheWriter
             int swapZoneId = bucketToZoneMap.getBucketToZone(swapBucketId);
             PixelsZoneWriter swapZone = zones.get(swapZoneId);
             // copy the survived cache elements from this lazy zone to the swap zone.
-            for (PixelsCacheEntry survivedIdx : survivedIdxes) {
-                if (locator.getLocation(survivedIdx.key) != bucketId) {
+            for (PixelsCacheEntry survivedIdx : survivedIdxes) 
+            {
+                if (locator.getLocation(survivedIdx.key) != bucketId) 
+                {
                     continue;
                 }
                 swapZone.getZoneFile().copyMemory(zone.getZoneFile().getAddress() + survivedIdx.idx.offset, swapZone.getZoneFile().getAddress() + newCacheOffset, survivedIdx.idx.length);
@@ -651,7 +664,7 @@ public class PixelsCacheWriter
                     // may be removed later.
                     file = ensureLocality(file);
                 }
-                try(PixelsPhysicalReader pixelsPhysicalReader = new PixelsPhysicalReader(storage, file))
+                try (PixelsPhysicalReader pixelsPhysicalReader = new PixelsPhysicalReader(storage, file))
                 {
                     if(pixelsPhysicalReader.getRowGroupNum() < rowGroupNumInLayout)
                     {
@@ -670,7 +683,8 @@ public class PixelsCacheWriter
                         String[] columnChunkIdStr = newCachedColumnChunks.get(i).split(":");
                         short rowGroupId = Short.parseShort(columnChunkIdStr[0]);
                         short columnId = Short.parseShort(columnChunkIdStr[1]);
-                        if(locator.getLocation(new PixelsCacheKey(pixelsPhysicalReader.getCurrentBlockId(), rowGroupId, columnId)) != bucketId) {
+                        if(locator.getLocation(new PixelsCacheKey(pixelsPhysicalReader.getCurrentBlockId(), rowGroupId, columnId)) != bucketId) 
+                        {
                             continue;
                         }
                         PixelsProto.RowGroupFooter rowGroupFooter = pixelsPhysicalReader.readRowGroupFooter(rowGroupId);
@@ -696,19 +710,25 @@ public class PixelsCacheWriter
                         }
                     }
                     // load missSurvivedIdxes from bottom storage
-                    if(missSurvivedIdxes.containsKey(pixelsPhysicalReader.getCurrentBlockId())){
-                        for(PixelsCacheKey key : missSurvivedIdxes.get(pixelsPhysicalReader.getCurrentBlockId())){
-                            if(locator.getLocation(key) != bucketId){
+                    if(missSurvivedIdxes.containsKey(pixelsPhysicalReader.getCurrentBlockId()))
+                    {
+                        for(PixelsCacheKey key : missSurvivedIdxes.get(pixelsPhysicalReader.getCurrentBlockId()))
+                        {
+                            if(locator.getLocation(key) != bucketId)
+                            {
                                 continue;
                             }
                             PixelsProto.RowGroupFooter rowGroupFooter = pixelsPhysicalReader.readRowGroupFooter(key.rowGroupId);
                             PixelsProto.ColumnChunkIndex chunkIndex = rowGroupFooter.getRowGroupIndexEntry().getColumnChunkIndexEntries(key.columnId);
                             physicalLen = chunkIndex.getChunkLength();
                             physicalOffset = chunkIndex.getChunkOffset();
-                            if(newCacheOffset + physicalLen >= swapZone.getZoneFile().getSize()){
+                            if(newCacheOffset + physicalLen >= swapZone.getZoneFile().getSize())
+                            {
                                 logger.debug("Cache writes have exceeded bucket size. Break. Current size: " + newCacheOffset + "current bucketId: " + bucketId);
                                 break outer_loop;
-                            }else{
+                            }
+                            else
+                            {
                                 byte[] columnChunk = pixelsPhysicalReader.read(physicalOffset, physicalLen);
                                 swapZone.getZoneFile().setBytes(newCacheOffset, columnChunk);
                                 swapZone.getRadix().put(key, new PixelsCacheIdx(newCacheOffset, physicalLen));
@@ -739,9 +759,11 @@ public class PixelsCacheWriter
             bucketToZoneMap.updateBucketZoneMap(bucketId,swapZoneId);
             // change zone type from lazy to swap
             long start = System.currentTimeMillis();
-            while(PixelsZoneUtil.getReaderCount(zone.getIndexFile()) > 0){
+            while(PixelsZoneUtil.getReaderCount(zone.getIndexFile()) > 0)
+            {
                 Thread.sleep(10);
-                if(System.currentTimeMillis() - start > 2*PixelsZoneUtil.ZONE_READ_LEASE_MS){
+                if(System.currentTimeMillis() - start > 2*PixelsZoneUtil.ZONE_READ_LEASE_MS)
+                {
                     PixelsZoneUtil.eliminateReaderCount(zone.getIndexFile());
                     break;
                 }
@@ -768,11 +790,13 @@ public class PixelsCacheWriter
      */
     public void expand() throws Exception
     {
-        if(bucketTypeInfo.getSwapBucketNum() == 0){
+        if(bucketTypeInfo.getSwapBucketNum() == 0)
+        {
             logger.warn("No swap zone, can not expand!");
             return;
         }
-        if(bucketToZoneMap.isMapFull(zoneNum + 1)){
+        if(bucketToZoneMap.isMapFull(zoneNum + 1))
+        {
             logger.warn("routing table is full, can not expand!");
             return;
         }
@@ -796,16 +820,19 @@ public class PixelsCacheWriter
         int newBucketId = bucketTypeInfo.getSwapBucketIds().get(0);
         bucketTypeInfo.getLazyBucketIds().add(newBucketId);
         bucketTypeInfo.incrementLazyBucketNum();
-        for(int i = 0; i < bucketTypeInfo.getSwapBucketNum() - 1; i++){
+        for(int i = 0; i < bucketTypeInfo.getSwapBucketNum() - 1; i++)
+        {
             bucketTypeInfo.getSwapBucketIds().set(i, bucketTypeInfo.getSwapBucketIds().get(i+1));
         }
         bucketTypeInfo.getSwapBucketIds().set(bucketTypeInfo.getSwapBucketNum() - 1, newZoneId);
-        for(int i = bucketTypeInfo.getSwapBucketNum() - 1; i > 0; i--){
+        for(int i = bucketTypeInfo.getSwapBucketNum() - 1; i > 0; i--)
+        {
             bucketToZoneMap.updateBucketZoneMap(bucketTypeInfo.getSwapBucketIds().get(i), bucketToZoneMap.getBucketToZone(bucketTypeInfo.getSwapBucketIds().get(i-1)));
         }
         bucketToZoneMap.updateBucketZoneMap(bucketTypeInfo.getSwapBucketIds().get(0), firstSwapZoneId);
         // there is no data in the cache, just build a empty zone
-        if(this.files == null || this.files.size() == 0){
+        if(this.files == null || this.files.size() == 0)
+        {
             PixelsZoneUtil.setIndexVersion(newZone.getIndexFile(), PixelsZoneUtil.getIndexVersion(zones.get(bucketTypeInfo.getLazyBucketIds().get(0)).getIndexFile()));
             PixelsZoneUtil.setStatus(newZone.getZoneFile(), PixelsZoneUtil.ZoneStatus.OK.getId());
             bucketToZoneMap.updateBucketZoneMap(newBucketId, newZoneId);
@@ -817,7 +844,8 @@ public class PixelsCacheWriter
         long newZoneOffset = PixelsZoneUtil.ZONE_DATA_OFFSET;
         PixelsLocator pseudoLocator = new PixelsLocator(locator.getNodeNum());
         pseudoLocator.addNode();
-        for(int i = 0; i < pseudoLocator.getReplicaNum(); i++){
+        for(int i = 0; i < pseudoLocator.getReplicaNum(); i++)
+        {
             // Phase 1: find the next bucket by hashcycle
             long nextBucketId = pseudoLocator.findNextBucket(newBucketId, i);
             int nextZoneId = bucketToZoneMap.getBucketToZone(nextBucketId);
@@ -825,7 +853,7 @@ public class PixelsCacheWriter
             // Phase 2: copy data
             for (String file : this.files)
             {
-                try(PixelsPhysicalReader pixelsPhysicalReader = new PixelsPhysicalReader(storage, file))
+                try (PixelsPhysicalReader pixelsPhysicalReader = new PixelsPhysicalReader(storage, file))
                 {
                     for (String cacheColumnChunkOrder : this.cachedColumnChunks)
                     {
@@ -834,33 +862,43 @@ public class PixelsCacheWriter
                         short columnId = Short.parseShort(columnChunkIdStr[1]);
                         long blockId = pixelsPhysicalReader.getCurrentBlockId();
                         PixelsCacheKey key = new PixelsCacheKey(blockId, rowGroupId, columnId);
-                        if(!pseudoLocator.isDataInReplica(key, newBucketId, i)){
+                        if(!pseudoLocator.isDataInReplica(key, newBucketId, i))
+                        {
                             continue;
                         }
                         PixelsCacheIdx curIdx = nextZone.getRadix().get(blockId, rowGroupId, columnId);
-                        if(curIdx != null){
-                            if(newZoneOffset + curIdx.length < newZone.getZoneFile().getSize()){
+                        if(curIdx != null)
+                        {
+                            if(newZoneOffset + curIdx.length < newZone.getZoneFile().getSize())
+                            {
                                 long srcAddr = nextZone.getZoneFile().getAddress() + curIdx.offset;
                                 long destAddr = newZone.getZoneFile().getAddress() + newZoneOffset;
                                 // direct memory copy, avoid intermediate byte array
                                 newZone.getZoneFile().copyMemory(srcAddr, destAddr, curIdx.length);
                                 newZone.getRadix().put(key, new PixelsCacheIdx(newZoneOffset, curIdx.length));
                                 newZoneOffset += curIdx.length;
-                            }else{
+                            }
+                            else
+                            {
                                 logger.debug("Cache writes have exceeded bucket size. Break. Current size: " + newZoneOffset + "current bucketId: " + newBucketId);
                             }
-                        }else{
+                        }
+                        else
+                        {
                             // Phase 3: load new hot data from the bottom storage, now just read the uncached hot data according to the last cache version.
                             PixelsProto.RowGroupFooter rowGroupFooter = pixelsPhysicalReader.readRowGroupFooter(rowGroupId);
                             PixelsProto.ColumnChunkIndex chunkIndex = rowGroupFooter.getRowGroupIndexEntry().getColumnChunkIndexEntries(columnId);
                             int physicalLen = (int) chunkIndex.getChunkLength();
                             long physicalOffset = chunkIndex.getChunkOffset();
-                            if(newZoneOffset + physicalLen < newZone.getZoneFile().getSize()){
+                            if(newZoneOffset + physicalLen < newZone.getZoneFile().getSize())
+                            {
                                 byte[] columnChunk = pixelsPhysicalReader.read(physicalOffset, physicalLen);
                                 newZone.getZoneFile().setBytes(newZoneOffset, columnChunk);
                                 newZone.getRadix().put(key, new PixelsCacheIdx(newZoneOffset, physicalLen));
                                 newZoneOffset += physicalLen;
-                            }else{
+                            }
+                            else
+                            {
                                 logger.debug("Cache writes have exceeded bucket size. Break. Current size: " + newZoneOffset + "current bucketId: " + newBucketId);
                             }
                         }
@@ -891,7 +929,8 @@ public class PixelsCacheWriter
      */
     public void shrink() throws Exception
     {
-        if (bucketTypeInfo.getLazyBucketNum() <= 0) {
+        if (bucketTypeInfo.getLazyBucketNum() <= 0) 
+        {
             logger.warn("No zone to shrink");
             return;
         }
@@ -916,11 +955,13 @@ public class PixelsCacheWriter
         bucketTypeInfo.getLazyBucketIds().remove(bucketTypeInfo.getLazyBucketNum() - 1);
         bucketTypeInfo.decrementLazyBucketNum();
         int lastSwapZoneId = bucketToZoneMap.getBucketToZone(bucketTypeInfo.getSwapBucketIds().get(bucketTypeInfo.getSwapBucketNum() - 1));
-        for(int i = bucketTypeInfo.getSwapBucketNum() - 1; i > 0; i--){
+        for(int i = bucketTypeInfo.getSwapBucketNum() - 1; i > 0; i--)
+        {
             bucketTypeInfo.getSwapBucketIds().set(i, bucketTypeInfo.getSwapBucketIds().get(i-1));
         }
         bucketTypeInfo.getSwapBucketIds().set(0, lastLazyBucketId);
-        for(int i = 0; i < bucketTypeInfo.getSwapBucketNum()-1; i++){
+        for(int i = 0; i < bucketTypeInfo.getSwapBucketNum()-1; i++)
+        {
             bucketToZoneMap.updateBucketZoneMap(bucketTypeInfo.getSwapBucketIds().get(i), bucketToZoneMap.getBucketToZone(bucketTypeInfo.getSwapBucketIds().get(i+1)-1));
         }
         bucketToZoneMap.updateBucketZoneMap(bucketTypeInfo.getSwapBucketIds().get(bucketTypeInfo.getSwapBucketNum() - 1), lastSwapZoneId-1);
@@ -1011,13 +1052,15 @@ public class PixelsCacheWriter
     /**
      * Currently, this is an interface for unit tests.
      */
-    public List<PixelsZoneWriter> getZones() {
+    public List<PixelsZoneWriter> getZones() 
+    {
        return zones;
-   }
+    }
 
     public void close() throws Exception
     {
-        for(PixelsZoneWriter zone:zones){
+        for(PixelsZoneWriter zone:zones)
+        {
             zone.close();
         }
         globalIndexFile.unmap();

--- a/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsHasher.java
+++ b/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsHasher.java
@@ -21,11 +21,11 @@
 package io.pixelsdb.pixels.cache;
 
 /**
- * Created at: 2024/2/24
- *
+ * @create 2024-02-24
  * @author alph00
  */
 
-public interface PixelsHasher {
+public interface PixelsHasher 
+{
     public long getHashCode(String key);
 }

--- a/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsHasher.java
+++ b/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsHasher.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2024 PixelsDB.
+ *
+ * This file is part of Pixels.
+ *
+ * Pixels is free software: you can redistribute it and/or modify
+ * it under the terms of the Affero GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * Pixels is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Affero GNU General Public License for more details.
+ *
+ * You should have received a copy of the Affero GNU General Public
+ * License along with Pixels.  If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+
+package io.pixelsdb.pixels.cache;
+
+/**
+ * Created at: 2024/2/24
+ *
+ * @author alph00
+ */
+
+public interface PixelsHasher {
+    public long getHashCode(String key);
+}

--- a/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsLocator.java
+++ b/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsLocator.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2024 PixelsDB.
+ *
+ * This file is part of Pixels.
+ *
+ * Pixels is free software: you can redistribute it and/or modify
+ * it under the terms of the Affero GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * Pixels is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Affero GNU General Public License for more details.
+ *
+ * You should have received a copy of the Affero GNU General Public
+ * License along with Pixels.  If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package io.pixelsdb.pixels.cache;
+
+import java.util.TreeMap;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * Created at: 2024/1/20
+ *
+ * @author alph00
+ */
+class PixelsLocator {
+    private static final Logger logger = LogManager.getLogger(PixelsLocator.class);
+    // the number of nodes in the hash cycle, now it is equal to the number of lazy zone
+    private int nodeNum = 1;
+    // the number of replicas of each bucket
+    private int replicaNum = 160;
+    // specific hash function
+    private PixelsHasher hasher;
+    // the number of hash slots, copy from Redis
+    private static final int NUM_HASH_SLOTS = 16384;
+    // the suffix of virtual node
+    private static final String VNODE_SUFFIX = "VNODE&&";
+    // the prefix of node
+    private static final String NODE_PREFIX = "BUCKET#";
+
+    private TreeMap<Long,Long> hashCycle;
+
+    private Map<String,Long> slotMap;
+
+    public PixelsLocator(int nodeNum) {
+        this.nodeNum = nodeNum;
+        init();
+    }
+
+
+    public PixelsLocator(int nodeNum, int replicaNum) {
+        this.nodeNum = nodeNum;
+        this.replicaNum = replicaNum;
+        init();
+    }
+
+    public PixelsLocator(int nodeNum, PixelsHasher hasher) {
+        this.nodeNum = nodeNum;
+        this.hasher = hasher;
+        init();
+    }
+
+    public PixelsLocator(int nodeNum, int replicaNum, PixelsHasher hasher) {
+        this.nodeNum = nodeNum;
+        this.replicaNum = replicaNum;
+        this.hasher = hasher;
+        init();
+    }
+
+    private void init(){
+        if(hasher == null){
+            hasher = new PixelsMurmurHasher();
+        }
+        hashCycle = new TreeMap<>();
+        slotMap = new HashMap<>();
+        for (int j = 0; j < replicaNum; j++) {
+            for (int i = 0; i < nodeNum; i++) {
+                String vnode = VNODE_SUFFIX + j;
+                String nodeName = NODE_PREFIX + i + "-" + vnode;
+                long hash = hasher.getHashCode(nodeName) % NUM_HASH_SLOTS;
+                int cnt = 0;
+                while(hashCycle.containsKey(hash)){
+                    hash = (hash + 1) % NUM_HASH_SLOTS;
+                    cnt++;
+                    if(cnt > NUM_HASH_SLOTS){
+                        logger.error("init failed, bucketId: " + i + " replicaId: " + j);
+                        break;
+                    }
+                }
+                hashCycle.put(hash, (long) i);
+                slotMap.put(nodeName, hash);
+            }
+        }
+    }
+
+    public long getLocation(PixelsCacheKey key) {
+        if (key == null) {
+            throw new IllegalArgumentException("Cache key cannot be null");
+        }
+        // build cache key by rowGroupId, columnId and offset
+        String keyStr = String.format("%d:%d:%d", 
+            key.blockId,
+            key.rowGroupId,
+            key.columnId);
+        long keyHash = hasher.getHashCode(keyStr) % NUM_HASH_SLOTS;
+        Long replicaHash = hashCycle.ceilingKey(keyHash);
+        return replicaHash == null ? hashCycle.get(hashCycle.firstKey()) : hashCycle.get(replicaHash);
+    }
+
+    public int getNodeNum(){
+        return nodeNum;
+    }
+
+    public int getReplicaNum(){
+        return replicaNum;
+    }
+
+    
+
+    public void close() {
+        hashCycle.clear();
+    }
+}

--- a/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsMurmurHasher.java
+++ b/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsMurmurHasher.java
@@ -23,14 +23,15 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
 /**
- * Created at: 2024/2/26
- *
+ * @create 2024-02-26
  * @author alph00
  */
 
-public class PixelsMurmurHasher implements PixelsHasher {
+public class PixelsMurmurHasher implements PixelsHasher 
+{
     @Override
-    public long getHashCode(String key) {
+    public long getHashCode(String key) 
+    {
         ByteBuffer buf = ByteBuffer.wrap(key.getBytes());
         int seed = 0x1234ABCD;
 
@@ -43,7 +44,8 @@ public class PixelsMurmurHasher implements PixelsHasher {
         long h = seed ^ (buf.remaining() * m);
 
         long k;
-        while (buf.remaining() >= 8) {
+        while (buf.remaining() >= 8) 
+        {
             k = buf.getLong();
 
             k *= m;
@@ -54,7 +56,8 @@ public class PixelsMurmurHasher implements PixelsHasher {
             h *= m;
         }
 
-        if (buf.remaining() > 0) {
+        if (buf.remaining() > 0) 
+        {
             ByteBuffer finish = ByteBuffer.allocate(8).order(
                     ByteOrder.LITTLE_ENDIAN);
             // for big-endian version, do this first:

--- a/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsMurmurHasher.java
+++ b/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsMurmurHasher.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2024 PixelsDB.
+ *
+ * This file is part of Pixels.
+ *
+ * Pixels is free software: you can redistribute it and/or modify
+ * it under the terms of the Affero GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * Pixels is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Affero GNU General Public License for more details.
+ *
+ * You should have received a copy of the Affero GNU General Public
+ * License along with Pixels.  If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package io.pixelsdb.pixels.cache;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+/**
+ * Created at: 2024/2/26
+ *
+ * @author alph00
+ */
+
+public class PixelsMurmurHasher implements PixelsHasher {
+    @Override
+    public long getHashCode(String key) {
+        ByteBuffer buf = ByteBuffer.wrap(key.getBytes());
+        int seed = 0x1234ABCD;
+
+        ByteOrder byteOrder = buf.order();
+        buf.order(ByteOrder.LITTLE_ENDIAN);
+
+        long m = 0xc6a4a7935bd1e995L;
+        int r = 47;
+
+        long h = seed ^ (buf.remaining() * m);
+
+        long k;
+        while (buf.remaining() >= 8) {
+            k = buf.getLong();
+
+            k *= m;
+            k ^= k >>> r;
+            k *= m;
+
+            h ^= k;
+            h *= m;
+        }
+
+        if (buf.remaining() > 0) {
+            ByteBuffer finish = ByteBuffer.allocate(8).order(
+                    ByteOrder.LITTLE_ENDIAN);
+            // for big-endian version, do this first:
+            // finish.position(8-buf.remaining());
+            finish.put(buf).rewind();
+            h ^= finish.getLong();
+            h *= m;
+        }
+        h ^= h >>> r;
+        h *= m;
+        h ^= h >>> r;
+
+        buf.order(byteOrder);
+        return (long) (h & 0xffffffffL);
+    }
+}

--- a/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsZoneReader.java
+++ b/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsZoneReader.java
@@ -333,7 +333,8 @@ public class PixelsZoneReader implements AutoCloseable
     {
         try
         {
-            if (zoneFile != null) {
+            if (zoneFile != null) 
+            {
                 zoneFile.unmap();
             }
         }
@@ -343,7 +344,8 @@ public class PixelsZoneReader implements AutoCloseable
         }
         try
         {
-            if (indexFile != null) {
+            if (indexFile != null) 
+            {
                 indexFile.unmap();
             }
         }

--- a/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsZoneReader.java
+++ b/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsZoneReader.java
@@ -1,0 +1,355 @@
+/*
+ * Copyright 2019 PixelsDB.
+ *
+ * This file is part of Pixels.
+ *
+ * Pixels is free software: you can redistribute it and/or modify
+ * it under the terms of the Affero GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * Pixels is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Affero GNU General Public License for more details.
+ *
+ * You should have received a copy of the Affero GNU General Public
+ * License along with Pixels.  If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package io.pixelsdb.pixels.cache;
+
+import io.pixelsdb.pixels.common.physical.natives.MemoryMappedFile;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.List;
+
+/**
+ * pixels zone reader.
+ * this file is derived from old version of PixelsCacheReader.java
+ * It is not thread safe.
+ *
+ * @author guodong
+ * @author hank
+ * @author alph00
+ */
+public class PixelsZoneReader implements AutoCloseable
+{
+    private static final Logger logger = LogManager.getLogger(PixelsZoneReader.class);
+
+    private final MemoryMappedFile zoneFile;
+    private final MemoryMappedFile indexFile;
+
+    /**
+     * <p>
+     *     A node can have at most 256 children, plus an edge (a segment of
+     *     lookup key). Each child is 8 bytes.
+     * </p>
+     * <p>
+     *     In pixels, where will be one PixelsZoneReader on each split. And each
+     *     split is supposed to be processed by one single thread. There are
+     *     typically 10 - 200 concurrent threads (splits) on a machine. So that it
+     *     is not a problem to allocate nodeData in each PixelsZoneReader instance.
+     *     By this, we can avoid frequent memory allocation in the search() method.
+     * </p>
+     * <p>
+     *     For the edge, although PixelsRadix can support 1MB edge length, we only
+     *     use 12 byte path (PixelsCacheKey). That means no edges can exceeds 12 bytes.
+     *     So that 16 bytes is more than enough.
+     * </p>
+     */
+    private final byte[] nodeData = new byte[256 * 8 + 16];
+    private final ByteBuffer childrenBuffer = ByteBuffer.wrap(nodeData);
+
+    private final ByteBuffer keyBuffer = ByteBuffer.allocate(PixelsCacheKey.SIZE).order(ByteOrder.BIG_ENDIAN);
+
+//    static
+//    {
+//        new Thread(cacheLogger).start();
+//    }
+
+    private PixelsZoneReader(MemoryMappedFile zoneFile, MemoryMappedFile indexFile)
+    {
+        this.zoneFile = zoneFile;
+        this.indexFile = indexFile;
+    }
+
+    public PixelsZoneReader(String zoneLocation, String indexLocation, long zoneSize, long indexSize) throws Exception {
+        this.zoneFile = new MemoryMappedFile(zoneLocation, zoneSize);
+        this.indexFile = new MemoryMappedFile(indexLocation, indexSize);
+    }   
+
+    public MemoryMappedFile getZoneFile() {
+        return zoneFile;
+    }
+
+    public MemoryMappedFile getIndexFile() {
+        return indexFile;
+    }
+
+    public static class Builder
+    {
+        private MemoryMappedFile builderZoneFile;
+        private MemoryMappedFile builderIndexFile;
+
+        private Builder()
+        {
+        }
+
+        public PixelsZoneReader.Builder setZoneFile(MemoryMappedFile zoneFile)
+        {
+//            requireNonNull(zoneFile, "zone file is null");
+            this.builderZoneFile = zoneFile;
+
+            return this;
+        }
+
+        public PixelsZoneReader.Builder setIndexFile(MemoryMappedFile indexFile)
+        {
+//            requireNonNull(indexFile, "index file is null");
+            this.builderIndexFile = indexFile;
+
+            return this;
+        }
+
+        public PixelsZoneReader build()
+        {
+            return new PixelsZoneReader(builderZoneFile, builderIndexFile);
+        }
+    }
+
+    public static PixelsZoneReader.Builder newBuilder()
+    {
+        return new PixelsZoneReader.Builder();
+    }
+
+    public ByteBuffer get(long blockId, short rowGroupId, short columnId)
+    {
+        return this.get(blockId, rowGroupId, columnId, true);
+    }
+
+    /**
+     * Read specified column chunk from zone.
+     * If zone is not hit, empty byte array is returned, and an access message is sent to the mq.
+     * If zone is hit, the column chunk content is returned as byte array.
+     * This method may return NULL value. Be careful dealing with null!!!
+     *
+     * @param blockId    block id
+     * @param rowGroupId row group id
+     * @param columnId   column id
+     * @param direct get direct byte buffer if true
+     * @return the column chunk content, or null if failed to read the zone
+     */
+    public ByteBuffer get(long blockId, short rowGroupId, short columnId, boolean direct)
+    {
+        // search index file for column chunk id
+        PixelsCacheKey.getBytes(keyBuffer, blockId, rowGroupId, columnId);
+
+        // check the rwFlag and increase readCount.
+        long lease = 0;
+        try
+        {
+            lease = PixelsZoneUtil.beginIndexRead(indexFile);
+        }
+        catch (InterruptedException e)
+        {
+            logger.error("Failed to get read permission on index.", e);
+            /**
+             * Issue #88:
+             * In case of failure (e.g. reaches max zone reader count),
+             * return null here to stop reading zone, then the content
+             * will be read from disk.
+             */
+            return null;
+        }
+
+        ByteBuffer content = null;
+        // search zone key
+//        long searchBegin = System.nanoTime();
+        PixelsCacheIdx zoneIdx = search(keyBuffer);
+//        long searchEnd = System.nanoTime();
+//        cacheLogger.addSearchLatency(searchEnd - searchBegin);
+//        logger.debug("[zone search]: " + (searchEnd - searchBegin));
+        // if found, read content from zone
+//        long readBegin = System.nanoTime();
+        if (zoneIdx != null)
+        {
+            if (direct)
+            {
+                // read content
+                content = zoneFile.getDirectByteBuffer(zoneIdx.offset, zoneIdx.length);
+            }
+            else
+            {
+                content = ByteBuffer.allocate(zoneIdx.length);
+                // read content
+                zoneFile.getBytes(zoneIdx.offset, content.array(), 0, zoneIdx.length);
+            }
+        }
+
+        boolean cacheReadSuccess = PixelsZoneUtil.endIndexRead(indexFile, lease);
+
+//        long readEnd = System.nanoTime();
+//        cacheLogger.addReadLatency(readEnd - readBegin);
+//        logger.debug("[zone read]: " + (readEnd - readBegin));
+        if (cacheReadSuccess)
+        {
+            return content;
+        }
+        return null;
+    }
+
+    public void batchGet(List<ColumnChunkId> columnChunkIds, byte[][] container)
+    {
+        // TODO batch get zone items. merge zone accesses to reduce the number of jni invocation.
+    }
+
+    /**
+     * This interface is only used by TESTS, DO NOT USE.
+     * It will be removed soon!
+     */
+    public PixelsCacheIdx search(long blockId, short rowGroupId, short columnId)
+    {
+        PixelsCacheKey.getBytes(keyBuffer, blockId, rowGroupId, columnId);
+
+        return search(keyBuffer);
+    }
+
+    /**
+     * Search key from radix tree.
+     * If found, update counter in zone idx.
+     * Else, return null
+     */
+    private PixelsCacheIdx search(ByteBuffer keyBuffer)
+    {
+        int dramAccessCounter = 0;
+        int radixLevel = 0;
+        final int keyLen = keyBuffer.position();
+        long currentNodeOffset = PixelsZoneUtil.INDEX_RADIX_OFFSET;
+        int bytesMatched = 0;
+        int bytesMatchedInNodeFound = 0;
+
+        // get root
+        // TODO: root currently does not have edge, which is not efficient in some cases.
+        int currentNodeHeader = indexFile.getInt(currentNodeOffset);
+        dramAccessCounter++;
+        int currentNodeChildrenNum = currentNodeHeader & 0x000001FF;
+        int currentNodeEdgeSize = (currentNodeHeader & 0x7FFFFE00) >>> 9;
+        if (currentNodeChildrenNum == 0 && currentNodeEdgeSize == 0)
+        {
+            return null;
+        }
+        indexFile.getBytes(currentNodeOffset + 4, this.nodeData, 0, currentNodeChildrenNum * 8);
+        dramAccessCounter++;
+        radixLevel++;
+
+        // search
+        // it can be more clear with a do while function
+        outer_loop:
+        while (bytesMatched < keyLen)
+        {
+            // search each child for the matching node
+            long matchingChildOffset = 0L;
+            childrenBuffer.position(0);
+            childrenBuffer.limit(currentNodeChildrenNum * 8);
+            // linearly scan all the children
+            for (int i = 0; i < currentNodeChildrenNum; i++)
+            {
+                // long is 8 byte, which is 64 bit
+                long child = childrenBuffer.getLong();
+                // first byte is matching byte
+                byte leader = (byte) ((child >>> 56) & 0xFF);
+                if (leader == keyBuffer.get(bytesMatched))
+                {
+                    // child last 7 bytes is grandson's offset, that is, the address is 7-bytes long
+                    matchingChildOffset = child & 0x00FFFFFFFFFFFFFFL;
+                    break;
+                }
+            }
+            if (matchingChildOffset == 0)
+            {
+                break;
+            }
+
+            currentNodeOffset = matchingChildOffset;
+            bytesMatchedInNodeFound = 0;
+            currentNodeHeader = indexFile.getInt(currentNodeOffset);
+            dramAccessCounter++;
+            currentNodeChildrenNum = currentNodeHeader & 0x000001FF;
+            currentNodeEdgeSize = (currentNodeHeader & 0x7FFFFE00) >>> 9;
+            // read the children and edge in one memory access.
+            indexFile.getBytes(currentNodeOffset + 4,
+                    this.nodeData, 0, currentNodeChildrenNum * 8 + currentNodeEdgeSize);
+            dramAccessCounter++;
+            int edgeEndOffset = currentNodeChildrenNum * 8 + currentNodeEdgeSize;
+            /**
+             * The first byte is matched in the child leader of the parent node,
+             * therefore we start the matching from the second byte in edge.
+             * this is useful for below `bytesMatchedInNodeFound == currentNodeEdgeSize`
+             */
+            bytesMatched++;
+            bytesMatchedInNodeFound++;
+            // now we are visiting the edge! rather than children data
+            // it seems between children and edge, there is a one byte gap?
+            // or the first byte of the edge does not matter here anyway
+            for (int i = currentNodeChildrenNum * 8 + 1; i < edgeEndOffset && bytesMatched < keyLen; i++)
+            {
+                // the edge is shared across this node, so the edge should be fully matched
+                if (this.nodeData[i] != keyBuffer.get(bytesMatched))
+                {
+                    break outer_loop;
+                }
+                bytesMatched++;
+                bytesMatchedInNodeFound++;
+            }
+
+            // only increase level when a child is really matched.
+            radixLevel++;
+        }
+
+        // if matches, node found.
+        if (bytesMatched == keyLen && bytesMatchedInNodeFound == currentNodeEdgeSize)
+        {
+            // if the current node is leaf node.
+            if (((currentNodeHeader >>> 31) & 1) > 0)
+            {
+                byte[] idx = new byte[12];
+                indexFile.getBytes(currentNodeOffset + 4 + (currentNodeChildrenNum * 8) + currentNodeEdgeSize,
+                        idx, 0, 12);
+                dramAccessCounter++;
+                PixelsCacheIdx zoneIdx = new PixelsCacheIdx(idx);
+                zoneIdx.dramAccessCount = dramAccessCounter;
+                zoneIdx.radixLevel = radixLevel;
+                return zoneIdx;
+            }
+        }
+        return null;
+    }
+
+    public void close()
+    {
+        try
+        {
+            if (zoneFile != null) {
+                zoneFile.unmap();
+            }
+        }
+        catch (Exception e)
+        {
+            logger.error("Failed to unmap zone file", e);
+        }
+        try
+        {
+            if (indexFile != null) {
+                indexFile.unmap();
+            }
+        }
+        catch (Exception e)
+        {
+            logger.error("Failed to unmap index file", e);
+        }
+    }
+}

--- a/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsZoneUtil.java
+++ b/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsZoneUtil.java
@@ -33,11 +33,11 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 /**
- * Created at: 2024/1/20
- *
+ * @create 2024-01-20
  * @author alph00
  */
-class PixelsZoneUtil {
+class PixelsZoneUtil
+{
     private final static Logger logger = LogManager.getLogger(PixelsZoneUtil.class);
 
     /**
@@ -75,8 +75,10 @@ class PixelsZoneUtil {
      */
     public static final int ZONE_READ_LEASE_MS = 100;
 
-    static {
-        if (MemoryMappedFile.getOrder() == ByteOrder.LITTLE_ENDIAN) {
+    static
+    {
+        if (MemoryMappedFile.getOrder() == ByteOrder.LITTLE_ENDIAN) 
+        {
             /**
              * If the index file is in little-endian, rw flag is in the lowest
              * byte of v, while reader count is in the highest three bytes.
@@ -86,7 +88,9 @@ class PixelsZoneUtil {
             READER_COUNT_INC = 0x00000100;
             ZERO_READER_COUNT_WITH_RW_FLAG = 0x00000001;
             READER_COUNT_RIGHT_SHIFT_BITS = 8;
-        } else {
+        } 
+        else 
+        {
             /**
              * If the index file is in big-endian, rw flag is in the highest
              * bytes of v, while reader count is in the lowest three bytes.
@@ -99,35 +103,42 @@ class PixelsZoneUtil {
         }
     }
 
-    public enum ZoneStatus {
+    public enum ZoneStatus 
+    {
         INCONSISTENT((short) -1), EMPTY((short) 0), OK((short) 1);
 
         private final short id;
 
-        ZoneStatus(short id) {
+        ZoneStatus(short id) 
+        {
             this.id = id;
         }
 
-        public short getId() {
+        public short getId() 
+        {
             return id;
         }
     }
 
-    public enum ZoneType {
+    public enum ZoneType 
+    {
         LAZY((short) 0), SWAP((short) 1), EAGER((short) 2);
 
         private final short id;
 
-        ZoneType(short id) {
+        ZoneType(short id) 
+        {
             this.id = id;
         }
 
-        public short getId() {
+        public short getId() 
+        {
             return id;
         }
     }
 
-    public static void initializeGlobalIndex(MemoryMappedFile indexFile, PixelsBucketToZoneMap bucketToZoneMap) {
+    public static void initializeGlobalIndex(MemoryMappedFile indexFile, PixelsBucketToZoneMap bucketToZoneMap) 
+    {
         // init index
         setMagic(indexFile);
         clearIndexRWAndCount(indexFile);
@@ -135,7 +146,8 @@ class PixelsZoneUtil {
         bucketToZoneMap.initialize();
     }
 
-    public static void initializeLazy(MemoryMappedFile indexFile, MemoryMappedFile zoneFile) {
+    public static void initializeLazy(MemoryMappedFile indexFile, MemoryMappedFile zoneFile) 
+    {
         // init index
         setMagic(indexFile);
         clearIndexRWAndCount(indexFile);
@@ -147,7 +159,8 @@ class PixelsZoneUtil {
         setType(zoneFile, ZoneType.LAZY.getId());
     }
 
-    public static void initializeSwap(MemoryMappedFile indexFile, MemoryMappedFile zoneFile) {
+    public static void initializeSwap(MemoryMappedFile indexFile, MemoryMappedFile zoneFile) 
+    {
         // init index
         setMagic(indexFile);
         clearIndexRWAndCount(indexFile);
@@ -159,37 +172,44 @@ class PixelsZoneUtil {
         setType(zoneFile, ZoneType.SWAP.getId());
     }
 
-    public static void setIndexVersion(MemoryMappedFile indexFile, int version) {
+    public static void setIndexVersion(MemoryMappedFile indexFile, int version) 
+    {
         indexFile.setIntVolatile(10, version);
     }
 
-    public static int getIndexVersion(MemoryMappedFile indexFile) {
+    public static int getIndexVersion(MemoryMappedFile indexFile) 
+    {
         return indexFile.getIntVolatile(10);
     }
 
-    private static void setMagic(MemoryMappedFile file) {
+    private static void setMagic(MemoryMappedFile file) 
+    {
         file.setBytes(0, Constants.FILE_MAGIC.getBytes(StandardCharsets.UTF_8));
     }
 
-    public static String getMagic(MemoryMappedFile file) {
+    public static String getMagic(MemoryMappedFile file) 
+    {
         byte[] magic = new byte[6];
         file.getBytes(0, magic, 0, 6);
         return new String(magic, StandardCharsets.UTF_8);
     }
 
-    public static String getMagic(RandomAccessFile file) throws IOException {
+    public static String getMagic(RandomAccessFile file) throws IOException 
+    {
         byte[] magic = new byte[6];
         file.seek(0);
         file.readFully(magic, 0, 6);
         return new String(magic, StandardCharsets.UTF_8);
     }
 
-    public static boolean checkMagic(MemoryMappedFile file) {
+    public static boolean checkMagic(MemoryMappedFile file) 
+    {
         String magic = getMagic(file);
         return magic.equalsIgnoreCase(Constants.FILE_MAGIC);
     }
 
-    private static void clearIndexRWAndCount(MemoryMappedFile indexFile) {
+    private static void clearIndexRWAndCount(MemoryMappedFile indexFile) 
+    {
         indexFile.setIntVolatile(6, 0);
     }
 
@@ -199,7 +219,8 @@ class PixelsZoneUtil {
      * @param indexFile the index file to be read.
      * @return the radix tree read from index file.
      */
-    public static PixelsRadix loadRadixIndex(MemoryMappedFile indexFile) throws CacheException {
+    public static PixelsRadix loadRadixIndex(MemoryMappedFile indexFile) throws CacheException 
+    {
         PixelsRadix radix = new PixelsRadix();
         readRadix(indexFile, PixelsZoneUtil.INDEX_RADIX_OFFSET, radix.getRoot(), 1);
         return radix;
@@ -214,18 +235,22 @@ class PixelsZoneUtil {
      * @param level      the current level of the node, starts from 1 for root of the tree.
      */
     private static void readRadix(MemoryMappedFile indexFile, long nodeOffset,
-                                  RadixNode node, int level) throws CacheException {
+                                  RadixNode node, int level) throws CacheException 
+    {
         long[] children = readNode(indexFile, nodeOffset, node, level);
 
-        if (node.isKey()) {
+        if (node.isKey()) 
+        {
             return;
         }
 
-        if (children == null) {
+        if (children == null) 
+        {
             throw new CacheException("Can not read node normally.");
         }
 
-        for (long childId : children) {
+        for (long childId : children) 
+        {
             // offset is in the lowest 56 bits, the highest 8 bits leader is discarded.
             long childOffset = childId & 0x00FFFFFFFFFFFFFFL;
             RadixNode childNode = new RadixNode();
@@ -244,8 +269,10 @@ class PixelsZoneUtil {
      * @return the children ids (1 byte leader + 7 bytes offset) of the node.
      */
     private static long[] readNode(MemoryMappedFile indexFile, long nodeOffset,
-                                   RadixNode node, int level) {
-        if (nodeOffset >= indexFile.getSize()) {
+                                   RadixNode node, int level) 
+    {
+        if (nodeOffset >= indexFile.getSize()) 
+        {
             logger.debug("Offset exceeds index size. Break. Current size: " + nodeOffset);
             return null;
         }
@@ -264,7 +291,8 @@ class PixelsZoneUtil {
          */
         ByteBuffer childrenBuffer = ByteBuffer.wrap(childrenData);
         long[] children = new long[nodeChildrenNum];
-        for (int i = 0; i < nodeChildrenNum; ++i) {
+        for (int i = 0; i < nodeChildrenNum; ++i) 
+        {
             children[i] = childrenBuffer.getLong();
         }
         dramAccessCounter++;
@@ -273,7 +301,8 @@ class PixelsZoneUtil {
         dramAccessCounter++;
         node.setEdge(edge);
 
-        if (((nodeHeader >>> 31) & 1) > 0) {
+        if (((nodeHeader >>> 31) & 1) > 0) 
+        {
             node.setKey(true);
             // read value
             byte[] idx = new byte[12];
@@ -284,54 +313,66 @@ class PixelsZoneUtil {
             cacheIdx.dramAccessCount = dramAccessCounter;
             cacheIdx.radixLevel = level;
             node.setValue(cacheIdx);
-        } else {
+        } 
+        else 
+        {
             node.setKey(false);
         }
 
         return children;
     }
 
-    public static void setStatus(MemoryMappedFile file, short status) {
+    public static void setStatus(MemoryMappedFile file, short status) 
+    {
         file.setShortVolatile(6, status);
     }
 
-    public static short getStatus(MemoryMappedFile file) {
+    public static short getStatus(MemoryMappedFile file) 
+    {
         return file.getShortVolatile(6);
     }
 
-    public static void setSize(MemoryMappedFile file, long size) {
+    public static void setSize(MemoryMappedFile file, long size) 
+    {
         file.setLongVolatile(8, size);
     }
 
-    public static long getSize(MemoryMappedFile file) {
+    public static long getSize(MemoryMappedFile file) 
+    {
         return file.getLongVolatile(8);
     }
 
-    public static void setType(MemoryMappedFile file, short type) {
+    public static void setType(MemoryMappedFile file, short type) 
+    {
         file.setShortVolatile(16, type);
     }
 
-    public static short getType(MemoryMappedFile file) {
+    public static short getType(MemoryMappedFile file) 
+    {
         return file.getShortVolatile(16);
     }
 
 /*
-    public static void setZoneTypeLazy(MemoryMappedFile file) {
+    public static void setZoneTypeLazy(MemoryMappedFile file) 
+    {
         setType(file, ZoneType.LAZY.getId());
     }
 */
 
 /*
-    public static void setZoneTypeSwap(MemoryMappedFile file) {
+    public static void setZoneTypeSwap(MemoryMappedFile file) 
+    {
         setType(file, ZoneType.SWAP.getId());
     }
 */
 
-    public static void setZoneTypeEager(MemoryMappedFile file) {
+    public static void setZoneTypeEager(MemoryMappedFile file) 
+    {
         setType(file, ZoneType.EAGER.getId());
     }
 
-    public static void beginIndexWrite(MemoryMappedFile indexFile) throws InterruptedException {
+    public static void beginIndexWrite(MemoryMappedFile indexFile) throws InterruptedException 
+    {
         // Set the rw flag.
         indexFile.setByteVolatile(6, (byte) 1);
         final int sleepMs = 10;
@@ -356,11 +397,13 @@ class PixelsZoneUtil {
     }
 
     // eliminate reader count, so writer only sleep for LEASE*2 time
-    public static void beginIndexWriteNoReaderCount(MemoryMappedFile indexFile) throws InterruptedException {
+    public static void beginIndexWriteNoReaderCount(MemoryMappedFile indexFile) throws InterruptedException 
+    {
         Thread.sleep(ZONE_READ_LEASE_MS * 2);
     }
 
-    public static void endIndexWrite(MemoryMappedFile indexFile) {
+    public static void endIndexWrite(MemoryMappedFile indexFile) 
+    {
         indexFile.setByteVolatile(6, (byte) 0);
     }
 
@@ -371,23 +414,28 @@ class PixelsZoneUtil {
      * @return the time in millis as the lease of this index read.
      * @throws InterruptedException
      */
-    public static long beginIndexRead(MemoryMappedFile indexFile) throws InterruptedException {
+    public static long beginIndexRead(MemoryMappedFile indexFile) throws InterruptedException 
+    {
         int v = indexFile.getIntVolatile(6);
         int readerCount = (v & READER_COUNT_MASK) >> READER_COUNT_RIGHT_SHIFT_BITS;
-        if (readerCount >= MAX_READER_COUNT) {
+        if (readerCount >= MAX_READER_COUNT) 
+        {
             throw new InterruptedException("Reaches the max concurrent read count.");
         }
         while ((v & RW_MASK) > 0 ||
                 // cas ensures that reading rw flag and increasing reader count is atomic.
-                indexFile.compareAndSwapInt(6, v, v + READER_COUNT_INC) == false) {
+                indexFile.compareAndSwapInt(6, v, v + READER_COUNT_INC) == false) 
+        {
             // We failed to get read lock or increase reader count.
-            if ((v & RW_MASK) > 0) {
+            if ((v & RW_MASK) > 0) 
+            {
                 // if there is an existing writer, sleep for 10ms.
                 Thread.sleep(10);
             }
             v = indexFile.getIntVolatile(6);
             readerCount = (v & READER_COUNT_MASK) >> READER_COUNT_RIGHT_SHIFT_BITS;
-            if (readerCount >= MAX_READER_COUNT) {
+            if (readerCount >= MAX_READER_COUNT) 
+            {
                 throw new InterruptedException("Reaches the max concurrent read count.");
             }
         }
@@ -395,18 +443,23 @@ class PixelsZoneUtil {
         return System.currentTimeMillis();
     }
 
-    public static long getReaderCount(MemoryMappedFile indexFile) {
+    public static long getReaderCount(MemoryMappedFile indexFile) 
+    {
         return (indexFile.getIntVolatile(6) & READER_COUNT_MASK) >> READER_COUNT_RIGHT_SHIFT_BITS;
     }
 
-    public static boolean endIndexRead(MemoryMappedFile indexFile, long lease) {
-        if (System.currentTimeMillis() - lease >= ZONE_READ_LEASE_MS) {
+    public static boolean endIndexRead(MemoryMappedFile indexFile, long lease) 
+    {
+        if (System.currentTimeMillis() - lease >= ZONE_READ_LEASE_MS) 
+        {
             return false;
         }
         int v = indexFile.getIntVolatile(6);
         // if reader count is already <= 0, nothing will be done.
-        while ((v & READER_COUNT_MASK) > 0) {
-            if (indexFile.compareAndSwapInt(6, v, v - READER_COUNT_INC)) {
+        while ((v & READER_COUNT_MASK) > 0) 
+        {
+            if (indexFile.compareAndSwapInt(6, v, v - READER_COUNT_INC)) 
+            {
                 // if v is not changed and the reader count is successfully decreased, break.
                 break;
             }
@@ -415,7 +468,8 @@ class PixelsZoneUtil {
         return true;
     }
     
-    public static void eliminateReaderCount(MemoryMappedFile indexFile) {
+    public static void eliminateReaderCount(MemoryMappedFile indexFile) 
+    {
         indexFile.setByteVolatile(6, (byte) 0);
     }
 }

--- a/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsZoneUtil.java
+++ b/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsZoneUtil.java
@@ -1,0 +1,421 @@
+/*
+ * Copyright 2024 PixelsDB.
+ *
+ * This file is part of Pixels.
+ *
+ * Pixels is free software: you can redistribute it and/or modify
+ * it under the terms of the Affero GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * Pixels is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Affero GNU General Public License for more details.
+ *
+ * You should have received a copy of the Affero GNU General Public
+ * License along with Pixels.  If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package io.pixelsdb.pixels.cache;
+
+import io.pixelsdb.pixels.common.exception.CacheException;
+import io.pixelsdb.pixels.common.physical.natives.MemoryMappedFile;
+import io.pixelsdb.pixels.common.utils.Constants;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+/**
+ * Created at: 2024/1/20
+ *
+ * @author alph00
+ */
+class PixelsZoneUtil {
+    private final static Logger logger = LogManager.getLogger(PixelsZoneUtil.class);
+
+    /**
+     * Issue #88:
+     * Do not use 2 ^ n - 1, it is not latex :)
+     * <p>
+     * Issue #91:
+     * Use three bytes, instead of two bytes, for reader count.
+     * The following masks and const numbers are also changed accordingly.
+     */
+    public static final int MAX_READER_COUNT = 0x007FFFFF;
+
+    /**
+     * The masks and const numbers are initialized according to the native endianness.
+     * The zone index is also read and write using native endianness.
+     */
+    public static final int RW_MASK;
+    public static final int READER_COUNT_MASK;
+    public static final int READER_COUNT_INC;
+    public static final int ZERO_READER_COUNT_WITH_RW_FLAG;
+    public static final int READER_COUNT_RIGHT_SHIFT_BITS;
+    /**
+     * We only use the first 14 bytes in the index {magic(6)+rw_flag(1)+reader_count(3)+version(4)}
+     * for metadata header, but we start radix tree from offset 16 for word alignment.
+     */
+    public static final int INDEX_RADIX_OFFSET = 16;
+    /**
+     * We use the first 18 bytes in the zone file {magic(6)+status(2)+size(8)+type(2)} for
+     * metadata header, but we start radix tree from offset 24 for word alignment.
+     */
+    public static final int ZONE_DATA_OFFSET = 24;
+
+    /**
+     * The length of zone read lease in millis.
+     */
+    public static final int ZONE_READ_LEASE_MS = 100;
+
+    static {
+        if (MemoryMappedFile.getOrder() == ByteOrder.LITTLE_ENDIAN) {
+            /**
+             * If the index file is in little-endian, rw flag is in the lowest
+             * byte of v, while reader count is in the highest three bytes.
+             */
+            RW_MASK = 0x000000FF;
+            READER_COUNT_MASK = 0xFFFFFF00;
+            READER_COUNT_INC = 0x00000100;
+            ZERO_READER_COUNT_WITH_RW_FLAG = 0x00000001;
+            READER_COUNT_RIGHT_SHIFT_BITS = 8;
+        } else {
+            /**
+             * If the index file is in big-endian, rw flag is in the highest
+             * bytes of v, while reader count is in the lowest three bytes.
+             */
+            RW_MASK = 0xFF000000;
+            READER_COUNT_MASK = 0x00FFFFFF;
+            READER_COUNT_INC = 0x00000001;
+            ZERO_READER_COUNT_WITH_RW_FLAG = 0x01000000;
+            READER_COUNT_RIGHT_SHIFT_BITS = 0;
+        }
+    }
+
+    public enum ZoneStatus {
+        INCONSISTENT((short) -1), EMPTY((short) 0), OK((short) 1);
+
+        private final short id;
+
+        ZoneStatus(short id) {
+            this.id = id;
+        }
+
+        public short getId() {
+            return id;
+        }
+    }
+
+    public enum ZoneType {
+        LAZY((short) 0), SWAP((short) 1), EAGER((short) 2);
+
+        private final short id;
+
+        ZoneType(short id) {
+            this.id = id;
+        }
+
+        public short getId() {
+            return id;
+        }
+    }
+
+    public static void initializeGlobalIndex(MemoryMappedFile indexFile, PixelsBucketToZoneMap bucketToZoneMap) {
+        // init index
+        setMagic(indexFile);
+        clearIndexRWAndCount(indexFile);
+        setIndexVersion(indexFile, 0);
+        bucketToZoneMap.initialize();
+    }
+
+    public static void initializeLazy(MemoryMappedFile indexFile, MemoryMappedFile zoneFile) {
+        // init index
+        setMagic(indexFile);
+        clearIndexRWAndCount(indexFile);
+        // setIndexVersion(indexFile, 0);
+        // init zone
+        setMagic(zoneFile);
+        setStatus(zoneFile, PixelsZoneUtil.ZoneStatus.EMPTY.getId());
+        setSize(zoneFile, 0);
+        setType(zoneFile, ZoneType.LAZY.getId());
+    }
+
+    public static void initializeSwap(MemoryMappedFile indexFile, MemoryMappedFile zoneFile) {
+        // init index
+        setMagic(indexFile);
+        clearIndexRWAndCount(indexFile);
+        // setIndexVersion(indexFile, 0);
+        // init zone
+        setMagic(zoneFile);
+        setStatus(zoneFile, PixelsZoneUtil.ZoneStatus.EMPTY.getId());
+        setSize(zoneFile, 0);
+        setType(zoneFile, ZoneType.SWAP.getId());
+    }
+
+    public static void setIndexVersion(MemoryMappedFile indexFile, int version) {
+        indexFile.setIntVolatile(10, version);
+    }
+
+    public static int getIndexVersion(MemoryMappedFile indexFile) {
+        return indexFile.getIntVolatile(10);
+    }
+
+    private static void setMagic(MemoryMappedFile file) {
+        file.setBytes(0, Constants.FILE_MAGIC.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public static String getMagic(MemoryMappedFile file) {
+        byte[] magic = new byte[6];
+        file.getBytes(0, magic, 0, 6);
+        return new String(magic, StandardCharsets.UTF_8);
+    }
+
+    public static String getMagic(RandomAccessFile file) throws IOException {
+        byte[] magic = new byte[6];
+        file.seek(0);
+        file.readFully(magic, 0, 6);
+        return new String(magic, StandardCharsets.UTF_8);
+    }
+
+    public static boolean checkMagic(MemoryMappedFile file) {
+        String magic = getMagic(file);
+        return magic.equalsIgnoreCase(Constants.FILE_MAGIC);
+    }
+
+    private static void clearIndexRWAndCount(MemoryMappedFile indexFile) {
+        indexFile.setIntVolatile(6, 0);
+    }
+
+    /**
+     * Read radix from index file.
+     *
+     * @param indexFile the index file to be read.
+     * @return the radix tree read from index file.
+     */
+    public static PixelsRadix loadRadixIndex(MemoryMappedFile indexFile) throws CacheException {
+        PixelsRadix radix = new PixelsRadix();
+        readRadix(indexFile, PixelsZoneUtil.INDEX_RADIX_OFFSET, radix.getRoot(), 1);
+        return radix;
+    }
+
+    /**
+     * Read and construct the index from index file.
+     *
+     * @param indexFile  the index file to be read.
+     * @param nodeOffset the offset of the current root node of the free (or sub-tree).
+     * @param node       the current root node to be read from index file.
+     * @param level      the current level of the node, starts from 1 for root of the tree.
+     */
+    private static void readRadix(MemoryMappedFile indexFile, long nodeOffset,
+                                  RadixNode node, int level) throws CacheException {
+        long[] children = readNode(indexFile, nodeOffset, node, level);
+
+        if (node.isKey()) {
+            return;
+        }
+
+        if (children == null) {
+            throw new CacheException("Can not read node normally.");
+        }
+
+        for (long childId : children) {
+            // offset is in the lowest 56 bits, the highest 8 bits leader is discarded.
+            long childOffset = childId & 0x00FFFFFFFFFFFFFFL;
+            RadixNode childNode = new RadixNode();
+            readRadix(indexFile, childOffset, childNode, level + 1);
+            node.addChild(childNode, true);
+        }
+    }
+
+    /**
+     * Read the index node from index file.
+     *
+     * @param indexFile  the index file to be read.
+     * @param nodeOffset the offset of this node in index file.
+     * @param node       the node to be read from index file.
+     * @param level      the current level of this node.
+     * @return the children ids (1 byte leader + 7 bytes offset) of the node.
+     */
+    private static long[] readNode(MemoryMappedFile indexFile, long nodeOffset,
+                                   RadixNode node, int level) {
+        if (nodeOffset >= indexFile.getSize()) {
+            logger.debug("Offset exceeds index size. Break. Current size: " + nodeOffset);
+            return null;
+        }
+        int dramAccessCounter = 0;
+        node.offset = nodeOffset;
+        int nodeHeader = indexFile.getInt(nodeOffset);
+        dramAccessCounter++;
+        int nodeChildrenNum = nodeHeader & 0x000001FF;
+        int nodeEdgeSize = (nodeHeader & 0x7FFFFE00) >>> 9;
+
+        byte[] childrenData = new byte[nodeChildrenNum * 8];
+        indexFile.getBytes(nodeOffset + 4, childrenData, 0, nodeChildrenNum * 8);
+        /**
+         * To ensure the consistent endian (big-endian) in Java,
+         * we use ByteBuffer to wrap the bytes instead of directly getLong() from indexFile.
+         */
+        ByteBuffer childrenBuffer = ByteBuffer.wrap(childrenData);
+        long[] children = new long[nodeChildrenNum];
+        for (int i = 0; i < nodeChildrenNum; ++i) {
+            children[i] = childrenBuffer.getLong();
+        }
+        dramAccessCounter++;
+        byte[] edge = new byte[nodeEdgeSize];
+        indexFile.getBytes(nodeOffset + 4 + nodeChildrenNum * 8, edge, 0, nodeEdgeSize);
+        dramAccessCounter++;
+        node.setEdge(edge);
+
+        if (((nodeHeader >>> 31) & 1) > 0) {
+            node.setKey(true);
+            // read value
+            byte[] idx = new byte[12];
+            indexFile.getBytes(nodeOffset + 4 + (nodeChildrenNum * 8) + nodeEdgeSize,
+                    idx, 0, 12);
+            dramAccessCounter++;
+            PixelsCacheIdx cacheIdx = new PixelsCacheIdx(idx);
+            cacheIdx.dramAccessCount = dramAccessCounter;
+            cacheIdx.radixLevel = level;
+            node.setValue(cacheIdx);
+        } else {
+            node.setKey(false);
+        }
+
+        return children;
+    }
+
+    public static void setStatus(MemoryMappedFile file, short status) {
+        file.setShortVolatile(6, status);
+    }
+
+    public static short getStatus(MemoryMappedFile file) {
+        return file.getShortVolatile(6);
+    }
+
+    public static void setSize(MemoryMappedFile file, long size) {
+        file.setLongVolatile(8, size);
+    }
+
+    public static long getSize(MemoryMappedFile file) {
+        return file.getLongVolatile(8);
+    }
+
+    public static void setType(MemoryMappedFile file, short type) {
+        file.setShortVolatile(16, type);
+    }
+
+    public static short getType(MemoryMappedFile file) {
+        return file.getShortVolatile(16);
+    }
+
+/*
+    public static void setZoneTypeLazy(MemoryMappedFile file) {
+        setType(file, ZoneType.LAZY.getId());
+    }
+*/
+
+/*
+    public static void setZoneTypeSwap(MemoryMappedFile file) {
+        setType(file, ZoneType.SWAP.getId());
+    }
+*/
+
+    public static void setZoneTypeEager(MemoryMappedFile file) {
+        setType(file, ZoneType.EAGER.getId());
+    }
+
+    public static void beginIndexWrite(MemoryMappedFile indexFile) throws InterruptedException {
+        // Set the rw flag.
+        indexFile.setByteVolatile(6, (byte) 1);
+        final int sleepMs = 10;
+        int waitMs = 0;
+        while ((indexFile.getIntVolatile(6) & READER_COUNT_MASK) > 0) // polling to see if something is finished
+        {
+            /**
+             * Wait for the existing readers to finish.
+             * As rw flag has been set, there will be no new readers,
+             * the existing readers should finished zone reading in
+             * 10s (10000ms). If the reader can not finish zone reading
+             * in 10s, it is considered as failed.
+             */
+            Thread.sleep(sleepMs);
+            waitMs += sleepMs;
+            if (waitMs > ZONE_READ_LEASE_MS) {
+                // clear reader count to continue writing.
+                indexFile.setIntVolatile(6, ZERO_READER_COUNT_WITH_RW_FLAG);
+                break;
+            }
+        }
+    }
+
+    // eliminate reader count, so writer only sleep for LEASE*2 time
+    public static void beginIndexWriteNoReaderCount(MemoryMappedFile indexFile) throws InterruptedException {
+        Thread.sleep(ZONE_READ_LEASE_MS * 2);
+    }
+
+    public static void endIndexWrite(MemoryMappedFile indexFile) {
+        indexFile.setByteVolatile(6, (byte) 0);
+    }
+
+    /**
+     * Begin index read. This method will wait for the writer to finish.
+     *
+     * @param indexFile
+     * @return the time in millis as the lease of this index read.
+     * @throws InterruptedException
+     */
+    public static long beginIndexRead(MemoryMappedFile indexFile) throws InterruptedException {
+        int v = indexFile.getIntVolatile(6);
+        int readerCount = (v & READER_COUNT_MASK) >> READER_COUNT_RIGHT_SHIFT_BITS;
+        if (readerCount >= MAX_READER_COUNT) {
+            throw new InterruptedException("Reaches the max concurrent read count.");
+        }
+        while ((v & RW_MASK) > 0 ||
+                // cas ensures that reading rw flag and increasing reader count is atomic.
+                indexFile.compareAndSwapInt(6, v, v + READER_COUNT_INC) == false) {
+            // We failed to get read lock or increase reader count.
+            if ((v & RW_MASK) > 0) {
+                // if there is an existing writer, sleep for 10ms.
+                Thread.sleep(10);
+            }
+            v = indexFile.getIntVolatile(6);
+            readerCount = (v & READER_COUNT_MASK) >> READER_COUNT_RIGHT_SHIFT_BITS;
+            if (readerCount >= MAX_READER_COUNT) {
+                throw new InterruptedException("Reaches the max concurrent read count.");
+            }
+        }
+        // return lease
+        return System.currentTimeMillis();
+    }
+
+    public static long getReaderCount(MemoryMappedFile indexFile) {
+        return (indexFile.getIntVolatile(6) & READER_COUNT_MASK) >> READER_COUNT_RIGHT_SHIFT_BITS;
+    }
+
+    public static boolean endIndexRead(MemoryMappedFile indexFile, long lease) {
+        if (System.currentTimeMillis() - lease >= ZONE_READ_LEASE_MS) {
+            return false;
+        }
+        int v = indexFile.getIntVolatile(6);
+        // if reader count is already <= 0, nothing will be done.
+        while ((v & READER_COUNT_MASK) > 0) {
+            if (indexFile.compareAndSwapInt(6, v, v - READER_COUNT_INC)) {
+                // if v is not changed and the reader count is successfully decreased, break.
+                break;
+            }
+            v = indexFile.getIntVolatile(6);
+        }
+        return true;
+    }
+    
+    public static void eliminateReaderCount(MemoryMappedFile indexFile) {
+        indexFile.setByteVolatile(6, (byte) 0);
+    }
+}

--- a/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsZoneWriter.java
+++ b/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsZoneWriter.java
@@ -28,11 +28,11 @@ import java.nio.ByteOrder;
 import java.util.List;
 
 /**
- * Created at: 2024/1/17
- *
+ * @create 2024-01-17
  * @author alph00
  */
-public class PixelsZoneWriter {
+public class PixelsZoneWriter 
+{
     private final static Logger logger = LogManager.getLogger(PixelsZoneWriter.class);
     private final MemoryMappedFile zoneFile;
     private final int zoneId;
@@ -44,55 +44,70 @@ public class PixelsZoneWriter {
     private ByteBuffer nodeBuffer = ByteBuffer.allocate(8 * 256);
     private ByteBuffer cacheIdxBuffer = ByteBuffer.allocate(PixelsCacheIdx.SIZE);
 
-    public PixelsZoneWriter(String builderZoneLocation, String builderIndexLocation, long builderZoneSize, long builderIndexSize, int zoneId) throws Exception {
+    public PixelsZoneWriter(String builderZoneLocation, String builderIndexLocation, long builderZoneSize, long builderIndexSize, int zoneId) throws Exception 
+    {
         this.nodeBuffer.order(ByteOrder.BIG_ENDIAN);
         this.zoneFile = new MemoryMappedFile(builderZoneLocation, builderZoneSize);
         this.indexFile = new MemoryMappedFile(builderIndexLocation, builderIndexSize);
         this.zoneId = zoneId;
     }
 
-    public void buildLazy(PixelsCacheConfig cacheConfig) throws Exception {
+    public void buildLazy(PixelsCacheConfig cacheConfig) throws Exception 
+    {
         radix = new PixelsRadix();
         PixelsZoneUtil.initializeLazy(indexFile, zoneFile);
     }
 
-    public void buildLazy() throws Exception {
+    public void buildLazy() throws Exception 
+    {
         radix = new PixelsRadix();
         PixelsZoneUtil.initializeLazy(indexFile, zoneFile);
     }
 
-    public void buildSwap(PixelsCacheConfig cacheConfig) throws Exception {
+    public void buildSwap(PixelsCacheConfig cacheConfig) throws Exception 
+    {
         radix = new PixelsRadix();
         PixelsZoneUtil.initializeSwap(indexFile, zoneFile);
     }
 
-    public void loadIndex() throws Exception {
+    public void loadIndex() throws Exception 
+    {
         radix = PixelsZoneUtil.loadRadixIndex(indexFile);
     }
 
-    public MemoryMappedFile getIndexFile() {
+    public MemoryMappedFile getIndexFile() 
+    {
         return indexFile;
     }
 
-    public PixelsRadix getRadix() {
+    public PixelsRadix getRadix() 
+    {
         return radix;
     }
 
-    public MemoryMappedFile getZoneFile() {
+    public MemoryMappedFile getZoneFile() 
+    {
         return zoneFile;
     }
 
-    public PixelsZoneUtil.ZoneType getZoneType() {
-        if (PixelsZoneUtil.getType(this.zoneFile) == PixelsZoneUtil.ZoneType.LAZY.getId()) {
+    public PixelsZoneUtil.ZoneType getZoneType() 
+    {
+        if (PixelsZoneUtil.getType(this.zoneFile) == PixelsZoneUtil.ZoneType.LAZY.getId()) 
+        {
             return PixelsZoneUtil.ZoneType.LAZY;
-        } else if (PixelsZoneUtil.getType(this.zoneFile) == PixelsZoneUtil.ZoneType.SWAP.getId()) {
+        } 
+        else if (PixelsZoneUtil.getType(this.zoneFile) == PixelsZoneUtil.ZoneType.SWAP.getId()) 
+        {
             return PixelsZoneUtil.ZoneType.SWAP;
-        } else {
+        } 
+        else 
+        {
             return PixelsZoneUtil.ZoneType.EAGER;
         }
     }
 
-    public boolean isZoneEmpty() {
+    public boolean isZoneEmpty() 
+    {
         return PixelsZoneUtil.getStatus(this.zoneFile) == PixelsZoneUtil.ZoneStatus.EMPTY.getId() &&
                 PixelsZoneUtil.getSize(this.zoneFile) == 0;
     }
@@ -100,12 +115,14 @@ public class PixelsZoneWriter {
     /**
      * Flush out index to index file from start.
      */
-    public void flushIndex() {
+    public void flushIndex() 
+    {
         // set index content offset, skip the index header.
         currentIndexOffset = PixelsZoneUtil.INDEX_RADIX_OFFSET;
         allocatedIndexOffset = PixelsZoneUtil.INDEX_RADIX_OFFSET;
         // if root contains nodes, which means the tree is not empty,then write nodes.
-        if (radix.getRoot().getSize() != 0) {
+        if (radix.getRoot().getSize() != 0) 
+        {
             writeRadix(radix.getRoot());
         }
     }
@@ -113,9 +130,12 @@ public class PixelsZoneWriter {
     /**
      * Write radix tree node.
      */
-    private void writeRadix(RadixNode node) {
-        if (flushNode(node)) {
-            for (RadixNode n : node.getChildren().values()) {
+    private void writeRadix(RadixNode node) 
+    {
+        if (flushNode(node)) 
+        {
+            for (RadixNode n : node.getChildren().values()) 
+            {
                 writeRadix(n);
             }
         }
@@ -127,15 +147,20 @@ public class PixelsZoneWriter {
      * Header: isKey(1 bit) + edgeSize(22 bits) + childrenSize(9 bits)
      * Child: leader(1 byte) + child_offset(7 bytes)
      */
-    private boolean flushNode(RadixNode node) {
+    private boolean flushNode(RadixNode node) 
+    {
         nodeBuffer.clear();
-        if (currentIndexOffset >= indexFile.getSize()) {
+        if (currentIndexOffset >= indexFile.getSize()) 
+        {
             logger.debug("Offset exceeds index size. Break. Current size: " + currentIndexOffset);
             return false;
         }
-        if (node.offset == 0) {
+        if (node.offset == 0) 
+        {
             node.offset = currentIndexOffset;
-        } else {
+        } 
+        else 
+        {
             currentIndexOffset = node.offset;
         }
         allocatedIndexOffset += node.getLengthInBytes();
@@ -143,13 +168,15 @@ public class PixelsZoneWriter {
         int edgeSize = node.getEdge().length;
         header = header | (edgeSize << 9);
         int isKeyMask = 1 << 31;
-        if (node.isKey()) {
+        if (node.isKey()) 
+        {
             header = header | isKeyMask;
         }
         header = header | node.getChildren().size();
         indexFile.setInt(currentIndexOffset, header);  // header
         currentIndexOffset += 4;
-        for (Byte key : node.getChildren().keySet()) {   // children
+        for (Byte key : node.getChildren().keySet()) 
+        {   // children
             RadixNode n = node.getChild(key);
             int len = n.getLengthInBytes();
             n.offset = allocatedIndexOffset;
@@ -158,8 +185,6 @@ public class PixelsZoneWriter {
             childId = childId | ((long) key << 56);  // leader
             childId = childId | n.offset;  // offset
             nodeBuffer.putLong(childId);
-//            indexFile.putLong(currentIndexOffset, childId);
-//            currentIndexOffset += 8;
         }
         byte[] nodeBytes = new byte[node.getChildren().size() * 8];
         nodeBuffer.flip();
@@ -168,7 +193,8 @@ public class PixelsZoneWriter {
         currentIndexOffset += nodeBytes.length;
         indexFile.setBytes(currentIndexOffset, node.getEdge()); // edge
         currentIndexOffset += node.getEdge().length;
-        if (node.isKey()) {  // value
+        if (node.isKey()) 
+        {  // value
             node.getValue().getBytes(cacheIdxBuffer);
             indexFile.setBytes(currentIndexOffset, cacheIdxBuffer.array());
             currentIndexOffset += 12;
@@ -176,7 +202,8 @@ public class PixelsZoneWriter {
         return true;
     }
 
-    public void close() throws Exception {
+    public void close() throws Exception 
+    {
         indexFile.unmap();
         zoneFile.unmap();
     }
@@ -184,9 +211,11 @@ public class PixelsZoneWriter {
     /**
      * Traverse radix to get all cached values, and put them into cachedColumnChunks list.
      */
-    private void traverseRadix(List<PixelsCacheIdx> cacheIdxes) {
+    private void traverseRadix(List<PixelsCacheIdx> cacheIdxes) 
+    {
         RadixNode root = radix.getRoot();
-        if (root.getSize() == 0) {
+        if (root.getSize() == 0) 
+        {
             return;
         }
         visitRadix(cacheIdxes, root);
@@ -197,26 +226,32 @@ public class PixelsZoneWriter {
      * Maybe considering using a stack to store edge values along the visitation path.
      * Push edges in as going deeper, and pop out as going shallower.
      */
-    private void visitRadix(List<PixelsCacheIdx> cacheIdxes, RadixNode node) {
-        if (node.isKey()) {
+    private void visitRadix(List<PixelsCacheIdx> cacheIdxes, RadixNode node) 
+    {
+        if (node.isKey()) 
+        {
             PixelsCacheIdx value = node.getValue();
             PixelsCacheIdx idx = new PixelsCacheIdx(value.offset, value.length);
             cacheIdxes.add(idx);
         }
-        for (RadixNode n : node.getChildren().values()) {
+        for (RadixNode n : node.getChildren().values()) 
+        {
             visitRadix(cacheIdxes, n);
         }
     }
 
-    public int getZoneId() {
+    public int getZoneId() 
+    {
         return zoneId;
     }
 
     /**
      * Change zone type from lazy to swap.
      */
-    public void changeZoneTypeL2S() {
-        if (getZoneType() != PixelsZoneUtil.ZoneType.LAZY) {
+    public void changeZoneTypeL2S() 
+    {
+        if (getZoneType() != PixelsZoneUtil.ZoneType.LAZY) 
+        {
             logger.info("L2S conversion requires LAZY zone, but the zone is not LAZY");
         }
         PixelsZoneUtil.setType(zoneFile, PixelsZoneUtil.ZoneType.SWAP.getId());
@@ -229,8 +264,10 @@ public class PixelsZoneWriter {
     /**
      * Change zone type from swap to lazy.
      */
-    public void changeZoneTypeS2L() {
-        if (getZoneType() != PixelsZoneUtil.ZoneType.SWAP) {
+    public void changeZoneTypeS2L() 
+    {
+        if (getZoneType() != PixelsZoneUtil.ZoneType.SWAP) 
+        {
             logger.info("S2L conversion requires SWAP zone, but the zone is not SWAP");
         }
         PixelsZoneUtil.setType(zoneFile, PixelsZoneUtil.ZoneType.LAZY.getId());

--- a/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsZoneWriter.java
+++ b/pixels-cache/src/main/java/io/pixelsdb/pixels/cache/PixelsZoneWriter.java
@@ -1,0 +1,251 @@
+/*
+ * Copyright 2024 PixelsDB.
+ *
+ * This file is part of Pixels.
+ *
+ * Pixels is free software: you can redistribute it and/or modify
+ * it under the terms of the Affero GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * Pixels is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Affero GNU General Public License for more details.
+ *
+ * You should have received a copy of the Affero GNU General Public
+ * License along with Pixels.  If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package io.pixelsdb.pixels.cache;
+
+import io.pixelsdb.pixels.common.physical.natives.MemoryMappedFile;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.List;
+
+/**
+ * Created at: 2024/1/17
+ *
+ * @author alph00
+ */
+public class PixelsZoneWriter {
+    private final static Logger logger = LogManager.getLogger(PixelsZoneWriter.class);
+    private final MemoryMappedFile zoneFile;
+    private final int zoneId;
+    private final MemoryMappedFile indexFile;
+    private PixelsRadix radix;
+    private long currentIndexOffset;
+    private long allocatedIndexOffset = PixelsZoneUtil.INDEX_RADIX_OFFSET;
+    private long cacheOffset = PixelsZoneUtil.ZONE_DATA_OFFSET; // this is only used in the write() method.
+    private ByteBuffer nodeBuffer = ByteBuffer.allocate(8 * 256);
+    private ByteBuffer cacheIdxBuffer = ByteBuffer.allocate(PixelsCacheIdx.SIZE);
+
+    public PixelsZoneWriter(String builderZoneLocation, String builderIndexLocation, long builderZoneSize, long builderIndexSize, int zoneId) throws Exception {
+        this.nodeBuffer.order(ByteOrder.BIG_ENDIAN);
+        this.zoneFile = new MemoryMappedFile(builderZoneLocation, builderZoneSize);
+        this.indexFile = new MemoryMappedFile(builderIndexLocation, builderIndexSize);
+        this.zoneId = zoneId;
+    }
+
+    public void buildLazy(PixelsCacheConfig cacheConfig) throws Exception {
+        radix = new PixelsRadix();
+        PixelsZoneUtil.initializeLazy(indexFile, zoneFile);
+    }
+
+    public void buildLazy() throws Exception {
+        radix = new PixelsRadix();
+        PixelsZoneUtil.initializeLazy(indexFile, zoneFile);
+    }
+
+    public void buildSwap(PixelsCacheConfig cacheConfig) throws Exception {
+        radix = new PixelsRadix();
+        PixelsZoneUtil.initializeSwap(indexFile, zoneFile);
+    }
+
+    public void loadIndex() throws Exception {
+        radix = PixelsZoneUtil.loadRadixIndex(indexFile);
+    }
+
+    public MemoryMappedFile getIndexFile() {
+        return indexFile;
+    }
+
+    public PixelsRadix getRadix() {
+        return radix;
+    }
+
+    public MemoryMappedFile getZoneFile() {
+        return zoneFile;
+    }
+
+    public PixelsZoneUtil.ZoneType getZoneType() {
+        if (PixelsZoneUtil.getType(this.zoneFile) == PixelsZoneUtil.ZoneType.LAZY.getId()) {
+            return PixelsZoneUtil.ZoneType.LAZY;
+        } else if (PixelsZoneUtil.getType(this.zoneFile) == PixelsZoneUtil.ZoneType.SWAP.getId()) {
+            return PixelsZoneUtil.ZoneType.SWAP;
+        } else {
+            return PixelsZoneUtil.ZoneType.EAGER;
+        }
+    }
+
+    public boolean isZoneEmpty() {
+        return PixelsZoneUtil.getStatus(this.zoneFile) == PixelsZoneUtil.ZoneStatus.EMPTY.getId() &&
+                PixelsZoneUtil.getSize(this.zoneFile) == 0;
+    }
+
+    /**
+     * Flush out index to index file from start.
+     */
+    public void flushIndex() {
+        // set index content offset, skip the index header.
+        currentIndexOffset = PixelsZoneUtil.INDEX_RADIX_OFFSET;
+        allocatedIndexOffset = PixelsZoneUtil.INDEX_RADIX_OFFSET;
+        // if root contains nodes, which means the tree is not empty,then write nodes.
+        if (radix.getRoot().getSize() != 0) {
+            writeRadix(radix.getRoot());
+        }
+    }
+
+    /**
+     * Write radix tree node.
+     */
+    private void writeRadix(RadixNode node) {
+        if (flushNode(node)) {
+            for (RadixNode n : node.getChildren().values()) {
+                writeRadix(n);
+            }
+        }
+    }
+
+    /**
+     * Flush node content to the index file based on {@code currentIndexOffset}.
+     * Header(4 bytes) + [Child(8 bytes)]{n} + edge(variable size) + value(optional).
+     * Header: isKey(1 bit) + edgeSize(22 bits) + childrenSize(9 bits)
+     * Child: leader(1 byte) + child_offset(7 bytes)
+     */
+    private boolean flushNode(RadixNode node) {
+        nodeBuffer.clear();
+        if (currentIndexOffset >= indexFile.getSize()) {
+            logger.debug("Offset exceeds index size. Break. Current size: " + currentIndexOffset);
+            return false;
+        }
+        if (node.offset == 0) {
+            node.offset = currentIndexOffset;
+        } else {
+            currentIndexOffset = node.offset;
+        }
+        allocatedIndexOffset += node.getLengthInBytes();
+        int header = 0;
+        int edgeSize = node.getEdge().length;
+        header = header | (edgeSize << 9);
+        int isKeyMask = 1 << 31;
+        if (node.isKey()) {
+            header = header | isKeyMask;
+        }
+        header = header | node.getChildren().size();
+        indexFile.setInt(currentIndexOffset, header);  // header
+        currentIndexOffset += 4;
+        for (Byte key : node.getChildren().keySet()) {   // children
+            RadixNode n = node.getChild(key);
+            int len = n.getLengthInBytes();
+            n.offset = allocatedIndexOffset;
+            allocatedIndexOffset += len;
+            long childId = 0L;
+            childId = childId | ((long) key << 56);  // leader
+            childId = childId | n.offset;  // offset
+            nodeBuffer.putLong(childId);
+//            indexFile.putLong(currentIndexOffset, childId);
+//            currentIndexOffset += 8;
+        }
+        byte[] nodeBytes = new byte[node.getChildren().size() * 8];
+        nodeBuffer.flip();
+        nodeBuffer.get(nodeBytes);
+        indexFile.setBytes(currentIndexOffset, nodeBytes); // children
+        currentIndexOffset += nodeBytes.length;
+        indexFile.setBytes(currentIndexOffset, node.getEdge()); // edge
+        currentIndexOffset += node.getEdge().length;
+        if (node.isKey()) {  // value
+            node.getValue().getBytes(cacheIdxBuffer);
+            indexFile.setBytes(currentIndexOffset, cacheIdxBuffer.array());
+            currentIndexOffset += 12;
+        }
+        return true;
+    }
+
+    public void close() throws Exception {
+        indexFile.unmap();
+        zoneFile.unmap();
+    }
+
+    /**
+     * Traverse radix to get all cached values, and put them into cachedColumnChunks list.
+     */
+    private void traverseRadix(List<PixelsCacheIdx> cacheIdxes) {
+        RadixNode root = radix.getRoot();
+        if (root.getSize() == 0) {
+            return;
+        }
+        visitRadix(cacheIdxes, root);
+    }
+
+    /**
+     * Visit radix recursively in depth first way.
+     * Maybe considering using a stack to store edge values along the visitation path.
+     * Push edges in as going deeper, and pop out as going shallower.
+     */
+    private void visitRadix(List<PixelsCacheIdx> cacheIdxes, RadixNode node) {
+        if (node.isKey()) {
+            PixelsCacheIdx value = node.getValue();
+            PixelsCacheIdx idx = new PixelsCacheIdx(value.offset, value.length);
+            cacheIdxes.add(idx);
+        }
+        for (RadixNode n : node.getChildren().values()) {
+            visitRadix(cacheIdxes, n);
+        }
+    }
+
+    public int getZoneId() {
+        return zoneId;
+    }
+
+    /**
+     * Change zone type from lazy to swap.
+     */
+    public void changeZoneTypeL2S() {
+        if (getZoneType() != PixelsZoneUtil.ZoneType.LAZY) {
+            logger.info("L2S conversion requires LAZY zone, but the zone is not LAZY");
+        }
+        PixelsZoneUtil.setType(zoneFile, PixelsZoneUtil.ZoneType.SWAP.getId());
+        PixelsZoneUtil.setSize(zoneFile, 0);
+        PixelsZoneUtil.setStatus(zoneFile, PixelsZoneUtil.ZoneStatus.EMPTY.getId());
+        radix.removeAll();
+        radix = new PixelsRadix();
+    }
+
+    /**
+     * Change zone type from swap to lazy.
+     */
+    public void changeZoneTypeS2L() {
+        if (getZoneType() != PixelsZoneUtil.ZoneType.SWAP) {
+            logger.info("S2L conversion requires SWAP zone, but the zone is not SWAP");
+        }
+        PixelsZoneUtil.setType(zoneFile, PixelsZoneUtil.ZoneType.LAZY.getId());
+    }
+
+
+    /**
+     * Currently, this is an interface for unit tests.
+     * This method only updates index content and cache content (without touching headers)
+     */
+    public void write(PixelsCacheKey key, byte[] value)
+    {
+        PixelsCacheIdx cacheIdx = new PixelsCacheIdx(cacheOffset, value.length);
+        zoneFile.setBytes(cacheOffset, value);
+        cacheOffset += value.length;
+        radix.put(key, cacheIdx);
+    }
+}

--- a/pixels-cache/src/test/java/io/pixelsdb/pixels/cache/TestPixelsCacheReader.java
+++ b/pixels-cache/src/test/java/io/pixelsdb/pixels/cache/TestPixelsCacheReader.java
@@ -23,6 +23,8 @@ import io.pixelsdb.pixels.common.physical.natives.MemoryMappedFile;
 import org.junit.Test;
 
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
 
 /**
  * @author guodong
@@ -37,9 +39,9 @@ public class TestPixelsCacheReader
         PixelsCacheKey key = new PixelsCacheKey(1073747711, (short) 0, (short) 191);
         PixelsCacheReader cacheReader = PixelsCacheReader
                 .newBuilder()
-                .setIndexFile(indexFile)
+                .setIndexFile(new ArrayList<>(Arrays.asList(indexFile)))
                 .build();
-        System.out.println(cacheReader.search(key.blockId, key.rowGroupId, key.columnId));
+        System.out.println(cacheReader.get(key.blockId, key.rowGroupId, key.columnId, false));
     }
 
     @Test
@@ -51,8 +53,8 @@ public class TestPixelsCacheReader
             MemoryMappedFile indexFile = new MemoryMappedFile("/Users/Jelly/Desktop/pixels.index", 64000000L);
             PixelsCacheReader cacheReader = PixelsCacheReader
                     .newBuilder()
-                    .setIndexFile(indexFile)
-                    .setCacheFile(cacheFile)
+                    .setIndexFile(new ArrayList<>(Arrays.asList(indexFile)))
+                    .setCacheFile(new ArrayList<>(Arrays.asList(cacheFile)))
                     .build();
             String path = "/pixels/pixels/test_105/2121211211212.pxl";
             int index = 0;
@@ -60,7 +62,7 @@ public class TestPixelsCacheReader
             {
                 for (short j = 0; j < 64; j++)
                 {
-                    ByteBuffer value = cacheReader.get(-1, i, j);
+                    ByteBuffer value = cacheReader.get(-1, i, j, false);
                     if (value != null)
                     {
                         assert value.getInt() == index;

--- a/pixels-cache/src/test/java/io/pixelsdb/pixels/cache/TestPixelsCacheWriter.java
+++ b/pixels-cache/src/test/java/io/pixelsdb/pixels/cache/TestPixelsCacheWriter.java
@@ -56,11 +56,15 @@ public class TestPixelsCacheWriter
                 }
             }
             cacheWriter.flush();
-            PixelsRadix radix = cacheWriter.getRadix();
-            radix.printStats();
-
-            PixelsRadix radix1 = PixelsCacheUtil.loadRadixIndex(cacheWriter.getIndexFile());
-            radix1.printStats();
+            for (PixelsZoneWriter zone : cacheWriter.getZones()) {
+                PixelsRadix radix = zone.getRadix();
+                radix.printStats();
+            }
+            
+            for (PixelsZoneWriter zone : cacheWriter.getZones()) {
+                PixelsRadix radix1 = PixelsCacheUtil.loadRadixIndex(zone.getIndexFile());
+                radix1.printStats();
+            }
         }
         catch (Exception e)
         {

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/natives/MemoryMappedFile.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/natives/MemoryMappedFile.java
@@ -542,6 +542,10 @@ public class MemoryMappedFile
         return size;
     }
 
+    public String getName() {
+        return loc;
+    }
+
     public long getAddress() { return addr; }
 
 }

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/utils/Constants.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/utils/Constants.java
@@ -50,6 +50,7 @@ public final class Constants
     public static final int HOSTNAME_INDEX_IN_CACHE_LOCATION_LITERAL = 3;
     public static final String HEARTBEAT_COORDINATOR_LITERAL = "heartbeat_coordinator_";
     public static final String HEARTBEAT_WORKER_LITERAL = "heartbeat_worker_";
+    public static final String CACHE_EXPAND_OR_SHRINK_LITERAL = "cache_expand_or_shrink"; // expand or shrink;1:expand, 2:shrink
 
     public static final String PARTITION_OPERATOR_NAME = "partition";
     public static final String PARTITION_JOIN_OPERATOR_NAME = "partition_join";

--- a/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/cache/CacheWorker.java
+++ b/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/cache/CacheWorker.java
@@ -108,6 +108,8 @@ public class CacheWorker implements Server
                         .setCacheSize(cacheConfig.getCacheSize())
                         .setIndexLocation(cacheConfig.getIndexLocation())
                         .setIndexSize(cacheConfig.getIndexSize())
+                        .setZoneNum(cacheConfig.getZoneNum())
+                        .setSwapZoneNum(cacheConfig.getSwapZoneNum())
                         .setOverwrite(false)
                         .setHostName(hostName)
                         .setCacheConfig(cacheConfig)
@@ -116,8 +118,8 @@ public class CacheWorker implements Server
 
                 // 2. update cache if necessary.
                 // If the cache is new created using start-vm.sh script, the local cache version would be zero.
-                localCacheVersion = PixelsCacheUtil.getIndexVersion(cacheWriter.getIndexFile(), cacheWriter.getCacheFile());
-                logger.debug("Local cache version: " + localCacheVersion);
+                localCacheVersion = PixelsCacheUtil.getIndexVersion(cacheWriter.getIndexFile(), cacheWriter);
+                logger.debug("Local cache global version: " + localCacheVersion);
                 // If Pixels has been reset by reset-pixels.sh, the cache version in etcd would be zero too.
                 KeyValue globalCacheVersionKV = EtcdUtil.Instance().getKeyValue(Constants.CACHE_VERSION_LITERAL);
                 if (globalCacheVersionKV != null)

--- a/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/cache/CacheWorker.java
+++ b/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/cache/CacheWorker.java
@@ -27,6 +27,7 @@ import io.etcd.jetcd.watch.WatchEvent;
 import io.pixelsdb.pixels.cache.PixelsCacheConfig;
 import io.pixelsdb.pixels.cache.PixelsCacheUtil;
 import io.pixelsdb.pixels.cache.PixelsCacheWriter;
+import io.pixelsdb.pixels.cache.CacheScalingOperation;
 import io.pixelsdb.pixels.common.exception.MetadataException;
 import io.pixelsdb.pixels.common.metadata.MetadataService;
 import io.pixelsdb.pixels.common.metadata.SchemaTableName;
@@ -119,7 +120,6 @@ public class CacheWorker implements Server
                 // 2. update cache if necessary.
                 // If the cache is new created using start-vm.sh script, the local cache version would be zero.
                 localCacheVersion = PixelsCacheUtil.getIndexVersion(cacheWriter.getIndexFile(), cacheWriter);
-                logger.debug("Local cache global version: " + localCacheVersion);
                 // If Pixels has been reset by reset-pixels.sh, the cache version in etcd would be zero too.
                 KeyValue globalCacheVersionKV = EtcdUtil.Instance().getKeyValue(Constants.CACHE_VERSION_LITERAL);
                 if (globalCacheVersionKV != null)
@@ -258,6 +258,44 @@ public class CacheWorker implements Server
                         }
                     }
                 });
+        // watcher for cache expand or shrink.
+        Watch.Watcher cacheScalingWatcher = EtcdUtil.Instance().getClient().getWatchClient().watch(
+                ByteSequence.from(Constants.CACHE_EXPAND_OR_SHRINK_LITERAL, StandardCharsets.UTF_8),
+                WatchOption.DEFAULT, watchResponse ->
+                {
+                    for (WatchEvent event : watchResponse.getEvents())
+                    {
+                        if (event.getEventType() == WatchEvent.EventType.PUT)
+                        {
+                            if (cacheStatus.get() == CacheWorkerStatus.READY.StatusCode)
+                            {
+                                String value = event.getKeyValue().getValue().toString(StandardCharsets.UTF_8);
+                                int cacheScalingOperation = Integer.parseInt(value);
+                                if (cacheScalingOperation == CacheScalingOperation.EXPAND.Operation)
+                                {
+                                    try {
+                                        cacheWriter.expand();
+                                    } catch (Exception e) {
+                                        logger.error("Failed to expand cache.", e);
+                                    }
+                                } else if (cacheScalingOperation == CacheScalingOperation.SHRINK.Operation)
+                                {
+                                    try {
+                                        cacheWriter.shrink();
+                                    } catch (Exception e) {
+                                        logger.error("Failed to shrink cache.", e);
+                                    }
+                                }
+                            } else if (cacheStatus.get() == CacheWorkerStatus.UPDATING.StatusCode)
+                            {
+                                // The local cache is updating, ignore expand or shrink.
+                                logger.warn("The local cache is updating, ignore the expand event.");
+                            } else {
+                                logger.warn("The local cache is not ready, ignore the expand event.");
+                            }
+                        }
+                    }
+                });
         try
         {
             // Wait for this cache worker to be shutdown.
@@ -271,6 +309,10 @@ public class CacheWorker implements Server
             if (watcher != null)
             {
                 watcher.close();
+            }
+            if (cacheScalingWatcher != null)
+            {
+                cacheScalingWatcher.close();
             }
         }
     }


### PR DESCRIPTION
commit 1st: implements a multi-zone non-blocking caching framework
commit 2nd: implements online cache scaling
commit 3rd: handles the deprecation of the cacheBorder parameter

NOTE:  This feature is compatible with the pixels-trino/Trino-405 branch at present.

Cache Online Scaling Feature Usage Notes:
i.   CacheWorker monitors the cache_expand_or_shrink field in ETCD to perform cache expansion or shrink operations. The field values are interpreted as follows:
         0: No scaling operation (default state)
         1: Trigger cache expansion (scale out)
         2: Trigger cache shrink(scale in)
e.g.    etcdctl --endpoints=cds01:2379 put cache_expand_or_shrink 1
ii.   The scaling operation does not aim to change the config file, once the PixelsWorker restarts, the scaling is no longer in effect.
iii.   "shrink" can not be used together with "expand" in the same PixelsWorker life cycle.