### PR TITLE
[Issue #967] no mandatory use of a unified netty version

### DIFF
--- a/pixels-cache/pom.xml
+++ b/pixels-cache/pom.xml
@@ -30,24 +30,6 @@
             <artifactId>jetcd-core</artifactId>
             <optional>true</optional>
         </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-codec-http2</artifactId>
-            <version>${dep.netty.version}</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-transport-native-unix-common</artifactId>
-            <version>${dep.netty.version}</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-handler-proxy</artifactId>
-            <version>${dep.netty.version}</version>
-            <optional>true</optional>
-        </dependency>
 
         <dependency>
             <groupId>com.alibaba</groupId>

--- a/pixels-cli/pom.xml
+++ b/pixels-cli/pom.xml
@@ -95,24 +95,6 @@
             <artifactId>jetcd-core</artifactId>
             <optional>true</optional>
         </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-codec-http2</artifactId>
-            <version>${dep.netty.version}</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-transport-native-unix-common</artifactId>
-            <version>${dep.netty.version}</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-handler-proxy</artifactId>
-            <version>${dep.netty.version}</version>
-            <optional>true</optional>
-        </dependency>
 
         <!-- grpc -->
         <dependency>

--- a/pixels-daemon/pom.xml
+++ b/pixels-daemon/pom.xml
@@ -96,24 +96,6 @@
             <artifactId>jetcd-core</artifactId>
             <optional>true</optional>
         </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-codec-http2</artifactId>
-            <version>${dep.netty.version}</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-transport-native-unix-common</artifactId>
-            <version>${dep.netty.version}</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-handler-proxy</artifactId>
-            <version>${dep.netty.version}</version>
-            <optional>true</optional>
-        </dependency>
 
         <!-- trino-jdbc -->
         <dependency>

--- a/pixels-executor/pom.xml
+++ b/pixels-executor/pom.xml
@@ -63,24 +63,6 @@
             <artifactId>jetcd-core</artifactId>
             <optional>true</optional>
         </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-codec-http2</artifactId>
-            <version>${dep.netty.version}</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-transport-native-unix-common</artifactId>
-            <version>${dep.netty.version}</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-handler-proxy</artifactId>
-            <version>${dep.netty.version}</version>
-            <optional>true</optional>
-        </dependency>
     </dependencies>
 
     <build>

--- a/pixels-index/pixels-index-rocksdb/pom.xml
+++ b/pixels-index/pixels-index-rocksdb/pom.xml
@@ -49,24 +49,6 @@
             <artifactId>jetcd-core</artifactId>
             <optional>true</optional>
         </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-codec-http2</artifactId>
-            <version>${dep.netty.version}</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-transport-native-unix-common</artifactId>
-            <version>${dep.netty.version}</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-handler-proxy</artifactId>
-            <version>${dep.netty.version}</version>
-            <optional>true</optional>
-        </dependency>
 
         <dependency>
             <groupId>io.grpc</groupId>

--- a/pixels-index/pixels-index-rockset/pom.xml
+++ b/pixels-index/pixels-index-rockset/pom.xml
@@ -34,24 +34,6 @@
             <groupId>io.etcd</groupId>
             <artifactId>jetcd-core</artifactId>
         </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-codec-http2</artifactId>
-            <version>${dep.netty.version}</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-transport-native-unix-common</artifactId>
-            <version>${dep.netty.version}</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-handler-proxy</artifactId>
-            <version>${dep.netty.version}</version>
-            <optional>true</optional>
-        </dependency>
 
         <dependency>
             <groupId>io.grpc</groupId>

--- a/pixels-planner/pom.xml
+++ b/pixels-planner/pom.xml
@@ -62,24 +62,6 @@
             <artifactId>jetcd-core</artifactId>
             <optional>true</optional>
         </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-codec-http2</artifactId>
-            <version>${dep.netty.version}</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-transport-native-unix-common</artifactId>
-            <version>${dep.netty.version}</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-handler-proxy</artifactId>
-            <version>${dep.netty.version}</version>
-            <optional>true</optional>
-        </dependency>
 
         <!-- grpc -->
         <dependency>

--- a/pixels-storage/pixels-storage-hdfs/pom.xml
+++ b/pixels-storage/pixels-storage-hdfs/pom.xml
@@ -36,24 +36,6 @@
             <artifactId>jetcd-core</artifactId>
             <optional>true</optional>
         </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-codec-http2</artifactId>
-            <version>${dep.netty.version}</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-transport-native-unix-common</artifactId>
-            <version>${dep.netty.version}</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-handler-proxy</artifactId>
-            <version>${dep.netty.version}</version>
-            <optional>true</optional>
-        </dependency>
 
         <!-- hadoop -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -351,18 +351,6 @@
                         <groupId>org.slf4j</groupId>
                         <artifactId>slf4j-api</artifactId>
                     </exclusion>
-                    <exclusion>
-                        <groupId>io.netty</groupId>
-                        <artifactId>netty-codec-http2</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>io.netty</groupId>
-                        <artifactId>netty-transport-native-unix-common</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>io.netty</groupId>
-                        <artifactId>netty-handler-proxy</artifactId>
-                    </exclusion>
                 </exclusions>
             </dependency>
 
@@ -507,16 +495,6 @@
                 <groupId>org.apache.hadoop</groupId>
                 <artifactId>hadoop-common</artifactId>
                 <version>${dep.hadoop.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>io.netty</groupId>
-                        <artifactId>netty-handler</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>io.netty</groupId>
-                        <artifactId>netty-transport-native-epoll</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.hadoop</groupId>
@@ -640,36 +618,6 @@
                 <groupId>org.asynchttpclient</groupId>
                 <artifactId>async-http-client</artifactId>
                 <version>${dep.asynchttpclient.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>io.netty</groupId>
-                        <artifactId>netty-codec-http</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>io.netty</groupId>
-                        <artifactId>netty-codec-socks</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>io.netty</groupId>
-                        <artifactId>netty-handler-proxy</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>io.netty</groupId>
-                        <artifactId>netty-handler</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>io.netty</groupId>
-                        <artifactId>netty-transport-native-epoll</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>io.netty</groupId>
-                        <artifactId>netty-transport-native-kqueue</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>io.netty</groupId>
-                        <artifactId>netty-codec-http2</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Except for modifying `dep.netty.version` and `dep.awssdk.version`, withdraw the rest of [Commit 836db14](https://github.com/pixelsdb/pixels/commit/836db145d08d0b0f32853fb1355a45bae5c621f4).