### PR TITLE
[Issue #960] use mmap/munmap in standary c library for memory mapped file

### DIFF
--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/natives/DirectIoLib.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/natives/DirectIoLib.java
@@ -199,6 +199,10 @@ public class DirectIoLib
 
     private static native Pointer malloc(long size);
 
+    private static native Pointer mmap(Pointer addr, long len, int prot, int flags, int fd, long off);
+
+    private static native int munmap(Pointer addr, long len);
+
     /**
      * @param ptr The pointer to the hunk of memory which needs freeing
      */

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/natives/DirectIoLib.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/natives/DirectIoLib.java
@@ -30,7 +30,6 @@ import org.apache.logging.log4j.Logger;
 import java.io.FileDescriptor;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
-import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
@@ -62,7 +61,6 @@ public class DirectIoLib
      */
     public static final boolean DirectIoEnabled;
 
-    private static Field jnaPointerPeer = null;
     private static Method directByteBufferAddress = null;
     private static Constructor<?> directByteBufferRConstructor = null;
 
@@ -73,6 +71,10 @@ public class DirectIoLib
     private static final int O_TRUNC = 01000;
     private static final int O_DIRECT = 040000;
     private static final int O_SYNC = 04000000;
+    private static final int PROT_READ = 0x1;
+    private static final int PROT_WRITE = 0x2;
+    private static final int MAP_SHARED = 0x1;
+    private static final int MAP_FAILED = -1;
 
     static
     {
@@ -109,8 +111,6 @@ public class DirectIoLib
                 }
                 directByteBufferRConstructor.setAccessible(true);
 
-                jnaPointerPeer = Class.forName("com.sun.jna.Pointer").getDeclaredField("peer");
-                jnaPointerPeer.setAccessible(true);
                 // sun.nio.ch.DirectBuffer is the parent of java.nio.DirectByteBuffer(R)
                 directByteBufferAddress = Class.forName("sun.nio.ch.DirectBuffer").getDeclaredMethod("address");
                 directByteBufferAddress.setAccessible(true);
@@ -199,20 +199,20 @@ public class DirectIoLib
 
     private static native Pointer malloc(long size);
 
+    /**
+     * @param ptr The pointer to the chunk of memory which needs freeing
+     */
+    public static native void free(Pointer ptr);
+
     private static native Pointer mmap(Pointer addr, long len, int prot, int flags, int fd, long off);
 
     private static native int munmap(Pointer addr, long len);
-
-    /**
-     * @param ptr The pointer to the hunk of memory which needs freeing
-     */
-    public static native void free(Pointer ptr);
 
     private static native String strerror(int errnum);
 
     public static long getAddress(Pointer pointer) throws IllegalAccessException
     {
-        return (Long) jnaPointerPeer.get(pointer);
+        return Pointer.nativeValue(pointer);
     }
 
     public static long getAddress(ByteBuffer byteBuffer) throws InvocationTargetException, IllegalAccessException
@@ -358,6 +358,51 @@ public class DirectIoLib
         } catch (Throwable e)
         {
             throw new IOException("error opening " + path + ", got " + getLastError(), e);
+        }
+    }
+
+    /**
+     * Create a shared virtual address mapping that is backed by the file at the given path. Updates to the mapping are
+     * visible to other processes mapping the same region, and are carried through to the backed file. This method can
+     * be used to build shared memory between processes.
+     * @param path the backed file path
+     * @param length the length of the memory mapping
+     * @param offset the offset in the file where the mapping starts
+     * @param readOnly whether the memory region is mapped as read only
+     * @return the address where the mapping starts in virtual memory space
+     * @throws IOException if failed to map the memory region
+     */
+    public static long mmap(String path, long length, long offset, boolean readOnly) throws IOException
+    {
+        int fd = open(path, readOnly);
+        int prot = PROT_READ;
+        if (!readOnly)
+        {
+            prot |= PROT_WRITE;
+        }
+        Pointer addr = mmap(null, length, prot, MAP_SHARED, fd, offset);
+        if (Pointer.nativeValue(addr) == MAP_FAILED)
+        {
+            throw new IOException("mmap failed, got " + getLastError());
+        }
+        // After the mmap() returns, fd can be closed immediately without invalidating the mapping.
+        close(fd);
+        return Pointer.nativeValue(addr);
+    }
+
+    /**
+     * Unmap the mapped virtual memory region.
+     * @param addr the start address of the mapped region
+     * @param length the length of the mapped region
+     * @throws IOException if failed to unmap the memory region
+     */
+    public static void munmap(long addr, long length) throws IOException
+    {
+        Pointer paddr = new Pointer(addr);
+        int ret = munmap(paddr, length);
+        if (ret != 0)
+        {
+            throw new IOException("munmap failed, got " + getLastError());
         }
     }
 

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/natives/MemoryMappedFile.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/physical/natives/MemoryMappedFile.java
@@ -78,6 +78,7 @@ public class MemoryMappedFile
         }
         try
         {
+            // Issue #960: use custom mmap implementation instead of FileChannel.map for JDK compatibility.
             this.addr = DirectIoLib.mmap(this.loc, this.size, 0L, false);
             if (this.addr < 0)
             {

--- a/pixels-common/src/test/java/io/pixelsdb/pixels/common/physical/TestJNA.java
+++ b/pixels-common/src/test/java/io/pixelsdb/pixels/common/physical/TestJNA.java
@@ -30,8 +30,8 @@ import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
 
 /**
- * Created at: 02/02/2023
- * Author: hank
+ * @author hank
+ * @create 2023-02-02
  */
 public class TestJNA
 {

--- a/pixels-common/src/test/java/io/pixelsdb/pixels/common/physical/natives/TestMemFile.java
+++ b/pixels-common/src/test/java/io/pixelsdb/pixels/common/physical/natives/TestMemFile.java
@@ -17,9 +17,8 @@
  * License along with Pixels.  If not, see
  * <https://www.gnu.org/licenses/>.
  */
-package io.pixelsdb.pixels.cache;
+package io.pixelsdb.pixels.common.physical.natives;
 
-import io.pixelsdb.pixels.common.physical.natives.MemoryMappedFile;
 import org.junit.Test;
 
 import java.io.File;
@@ -31,29 +30,38 @@ import java.util.Map;
 import java.util.Random;
 
 /**
- * @author: tao
- * @date: Create in 2019-02-21 16:41
+ * @author tao
+ * @create 2019-02-21 16:41
  **/
 public class TestMemFile
 {
     String path = "/dev/shm/pixels.cache";
 
     @Test
-    public void testRound4096() {
+    public void testRound4096()
+    {
         assert (MemoryMappedFile.roundTo4096(0) == 0);
         assert (MemoryMappedFile.roundTo4096(1) == 4096);
         assert (MemoryMappedFile.roundTo4096(4097) == 8192);
         assert (MemoryMappedFile.roundTo4096(4096 * 37 + 2048) == 4096 * 38);
         assert (MemoryMappedFile.roundTo4096(4096 * 37 - 1453) == 4096 * 37);
-
     }
 
     @Test
-    public void testWriteSize() throws Exception {
-        MemoryMappedFile file = new MemoryMappedFile("/scratch/yeeef/pixels-cache/__test", 4 * 1024 * 1024);
+    public void testWrite() throws Exception
+    {
+        MemoryMappedFile file = new MemoryMappedFile(this.path, 4L * 1024 * 1024 * 1024);
         file.setInt(2 * 1024 * 1024, 1);
         System.out.println(file.getInt(2 * 1024 * 1024));
+        file.unmap();
+    }
 
+    @Test
+    public void testRead() throws Exception
+    {
+        MemoryMappedFile file = new MemoryMappedFile(this.path, 4L * 1024 * 1024 * 1024);
+        System.out.println(file.getInt(2 * 1024 * 1024));
+        file.unmap();
     }
 
     @Test
@@ -77,15 +85,14 @@ public class TestMemFile
         long start = System.nanoTime();
         for (int i = 0; i < 100; ++i)
         {
-            MemoryMappedFile mem = new MemoryMappedFile(path, 1024L*1024L);
+            MemoryMappedFile mem = new MemoryMappedFile(path, 1024L * 1024L);
         }
         long duration = System.nanoTime() - start;
         System.out.println((duration/1000) + " us");
     }
 
     @Test
-    public void testMulti()
-            throws Exception
+    public void testMulti() throws Exception
     {
         MemoryMappedFile mem = new MemoryMappedFile(path, 1024L * 1024L * 10L);
         Map<Integer, byte[]> kvMap = new HashMap<>();
@@ -114,8 +121,7 @@ public class TestMemFile
         System.out.println("Read cost time: " + (endReadTime - startReadTime));
     }
 
-    private void write(Map<Integer, byte[]> kvMap)
-            throws Exception
+    private void write(Map<Integer, byte[]> kvMap) throws Exception
     {
         new File(path);
 
@@ -141,15 +147,13 @@ public class TestMemFile
     }
 
     @Test
-    public void test()
-            throws Exception
+    public void test() throws Exception
     {
         write(ByteOrder.BIG_ENDIAN, 0xffff0000ffff0000L);
         read();
     }
 
-    public void write(ByteOrder byteOrder, long repeatLong)
-            throws Exception
+    public void write(ByteOrder byteOrder, long repeatLong) throws Exception
     {
         new File(path);
 
@@ -165,8 +169,7 @@ public class TestMemFile
         }
     }
 
-    public void read()
-            throws Exception
+    public void read() throws Exception
     {
         MemoryMappedFile mem = new MemoryMappedFile(path, 1024L * 1024L * 10L);
         byte[] res = new byte[8];
@@ -208,7 +211,7 @@ public class TestMemFile
                     try
                     {
                         System.out.println(
-                                "ERROR in read: 值不相同\n" + Arrays.toString(value) + "\n" + Arrays.toString(oldValue));
+                                "ERROR in read: inconsistent value\n" + Arrays.toString(value) + "\n" + Arrays.toString(oldValue));
                         System.exit(-1);
                     }
                     catch (Exception e)
@@ -221,6 +224,5 @@ public class TestMemFile
             System.out.println(Thread.currentThread().getName() + "," + len + " end");
         }
     }
-
 }
 

--- a/pixels-common/src/test/java/io/pixelsdb/pixels/common/physical/natives/TestMemFileConcurrentRW.java
+++ b/pixels-common/src/test/java/io/pixelsdb/pixels/common/physical/natives/TestMemFileConcurrentRW.java
@@ -17,20 +17,18 @@
  * License along with Pixels.  If not, see
  * <https://www.gnu.org/licenses/>.
  */
-package io.pixelsdb.pixels.cache;
+package io.pixelsdb.pixels.common.physical.natives;
 
-import io.pixelsdb.pixels.common.physical.natives.MemoryMappedFile;
 import org.junit.Test;
 
 /**
- * Created at: 18-10-24
- * Author: hank
+ * @author hank
+ * @create 2018-10-24
  */
 public class TestMemFileConcurrentRW
 {
     @Test
-    public void testRead()
-            throws Exception
+    public void testRead() throws Exception
     {
         long start = System.nanoTime();
         MemoryMappedFile mem = new MemoryMappedFile("/dev/shm/test", 1024L * 1024L * 256L);
@@ -43,8 +41,7 @@ public class TestMemFileConcurrentRW
     }
 
     @Test
-    public void testWrite()
-            throws Exception
+    public void testWrite() throws Exception
     {
         long start = System.nanoTime();
         MemoryMappedFile mem = new MemoryMappedFile("/dev/shm/test", 1024L * 1024L * 256L);

--- a/pixels-common/src/test/java/io/pixelsdb/pixels/common/physical/natives/TestMemFileWrite.java
+++ b/pixels-common/src/test/java/io/pixelsdb/pixels/common/physical/natives/TestMemFileWrite.java
@@ -17,9 +17,8 @@
  * License along with Pixels.  If not, see
  * <https://www.gnu.org/licenses/>.
  */
-package io.pixelsdb.pixels.cache;
+package io.pixelsdb.pixels.common.physical.natives;
 
-import io.pixelsdb.pixels.common.physical.natives.MemoryMappedFile;
 import org.junit.Test;
 
 import java.io.File;
@@ -29,8 +28,7 @@ import java.nio.ByteOrder;
 public class TestMemFileWrite
 {
     @Test
-    public void test()
-            throws Exception
+    public void test() throws Exception
     {
         String path = "/Users/Jelly/Desktop/pixels.index";
         new File(path);

--- a/pixels-common/src/test/java/io/pixelsdb/pixels/common/physical/natives/TestNatives.java
+++ b/pixels-common/src/test/java/io/pixelsdb/pixels/common/physical/natives/TestNatives.java
@@ -27,8 +27,8 @@ import java.lang.reflect.InvocationTargetException;
 import java.nio.ByteBuffer;
 
 /**
- * Created at: 02/02/2023
- * Author: hank
+ * @author hank
+ * @create 2023-02-02
  */
 public class TestNatives
 {


### PR DESCRIPTION
This improves compatibility across different JDK versions and eliminates the 2GB size limitation of the underlying file.
Resolves #960.