### PR TITLE
[Issue #998] exclude non-regular files when compacting

### DIFF
--- a/pixels-cli/src/main/java/io/pixelsdb/pixels/cli/executor/CompactExecutor.java
+++ b/pixels-cli/src/main/java/io/pixelsdb/pixels/cli/executor/CompactExecutor.java
@@ -102,7 +102,18 @@ public class CompactExecutor implements CommandExecutor
         Storage compactStorage = StorageFactory.Instance().getStorage(layout.getCompactPathUris()[0]);
         long blockSize = Long.parseLong(configFactory.getProperty("block.size"));
         short replication = Short.parseShort(configFactory.getProperty("block.replication"));
+
+        // Issue #998: compact need to exclude empty files
         List<Status> statuses = orderStorage.listStatus(layout.getOrderedPathUris());
+        Iterator<Status> statusIterator = statuses.iterator();
+        while (statusIterator.hasNext())
+        {
+            if (metadataService.getFileType(statusIterator.next().getPath()) == File.Type.EMPTY)
+            {
+                statusIterator.remove();
+            }
+        }
+
         List<Path> targetPaths = layout.getCompactPaths();
         ConcurrentLinkedQueue<File> compactFiles = new ConcurrentLinkedQueue<>();
         ConcurrentLinkedQueue<Path> compactPaths = new ConcurrentLinkedQueue<>();

--- a/pixels-cli/src/main/java/io/pixelsdb/pixels/cli/executor/CompactExecutor.java
+++ b/pixels-cli/src/main/java/io/pixelsdb/pixels/cli/executor/CompactExecutor.java
@@ -108,7 +108,7 @@ public class CompactExecutor implements CommandExecutor
         Iterator<Status> statusIterator = statuses.iterator();
         while (statusIterator.hasNext())
         {
-            if (metadataService.getFileType(statusIterator.next().getPath()) == File.Type.EMPTY)
+            if (metadataService.getFileType(statusIterator.next().getPath()) != File.Type.REGULAR)
             {
                 statusIterator.remove();
             }

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/error/ErrorCode.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/error/ErrorCode.java
@@ -75,13 +75,14 @@ public class ErrorCode
     public static final int METADATA_ADD_FILE_FAILED = (ERROR_BASE_METADATA + 43);
     public static final int METADATA_GET_FILES_FAILED = (ERROR_BASE_METADATA + 44);
     public static final int METADATA_GET_FILE_ID_FAILED = (ERROR_BASE_METADATA + 45);
-    public static final int METADATA_UPDATE_FILE_FAILED = (ERROR_BASE_METADATA + 46);
-    public static final int METADATA_DELETE_FILES_FAILED = (ERROR_BASE_METADATA + 47);
-    public static final int METADATA_ADD_SINGLE_POINT_INDEX_FAILED = (ERROR_BASE_METADATA + 48);
-    public static final int METADATA_SINGLE_POINT_INDEX_NOT_FOUND = (ERROR_BASE_METADATA + 49);
-    public static final int METADATA_UPDATE_SINGLE_POINT_INDEX_FAILED = (ERROR_BASE_METADATA + 50);
-    public static final int METADATA_DELETE_SINGLE_POINT_INDEX_FAILED = (ERROR_BASE_METADATA + 51);
-    public static final int METADATA_ADD_RETINA_BUFFER_FAILED = (ERROR_BASE_METADATA + 52);
+    public static final int METADATA_GET_FILE_TYPE_FAILED = (ERROR_BASE_METADATA + 46);
+    public static final int METADATA_UPDATE_FILE_FAILED = (ERROR_BASE_METADATA + 47);
+    public static final int METADATA_DELETE_FILES_FAILED = (ERROR_BASE_METADATA + 48);
+    public static final int METADATA_ADD_SINGLE_POINT_INDEX_FAILED = (ERROR_BASE_METADATA + 49);
+    public static final int METADATA_SINGLE_POINT_INDEX_NOT_FOUND = (ERROR_BASE_METADATA + 50);
+    public static final int METADATA_UPDATE_SINGLE_POINT_INDEX_FAILED = (ERROR_BASE_METADATA + 51);
+    public static final int METADATA_DELETE_SINGLE_POINT_INDEX_FAILED = (ERROR_BASE_METADATA + 52);
+    public static final int METADATA_ADD_RETINA_BUFFER_FAILED = (ERROR_BASE_METADATA + 53);
     // end error code for metadata rpc
 
     // begin error code for shared memory message queue

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/metadata/MetadataService.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/metadata/MetadataService.java
@@ -1343,6 +1343,38 @@ public class MetadataService
         }
     }
 
+    /**
+     * Get the file type of the file given the full uri path containing the storage scheme prefix.
+     * @param filePathUri the file path uri containing the storage scheme prefix
+     * @return the id of the file, valid file id should be a positive integer
+     * @throws MetadataException if failed to request the file id
+     */
+    public File.Type getFileType(String filePathUri) throws MetadataException
+    {
+        String token = UUID.randomUUID().toString();
+        MetadataProto.GetFileTypeRequest request = MetadataProto.GetFileTypeRequest.newBuilder()
+                .setHeader(MetadataProto.RequestHeader.newBuilder().setToken(token))
+                .setFilePathUri(filePathUri).build();
+        try
+        {
+            MetadataProto.GetFileTypeResponse response = this.stub.getFileType(request);
+            if (response.getHeader().getErrorCode() != 0)
+            {
+                throw new MetadataException("error code=" + response.getHeader().getErrorCode()
+                        + ", error message=" + response.getHeader().getErrorMsg());
+            }
+            if (!response.getHeader().getToken().equals(token))
+            {
+                throw new MetadataException("response token does not match.");
+            }
+            return File.Type.valueOf(response.getFileType().getNumber());
+        }
+        catch (Exception e)
+        {
+            throw new MetadataException("failed to get file type", e);
+        }
+    }
+
     public List<File> getFiles(long pathId) throws MetadataException
     {
         String token = UUID.randomUUID().toString();

--- a/proto/metadata.proto
+++ b/proto/metadata.proto
@@ -65,6 +65,7 @@ service MetadataService {
     rpc AddFiles (AddFilesRequest) returns (AddFilesResponse);
     rpc GetFiles (GetFilesRequest) returns (GetFilesResponse);
     rpc GetFileId (GetFileIdRequest) returns (GetFileIdResponse);
+    rpc GetFileType (GetFileTypeRequest) returns (GetFileTypeResponse);
     rpc UpdateFile (UpdateFileRequest) returns (UpdateFileResponse);
     rpc DeleteFiles (DeleteFilesRequest) returns (DeleteFilesResponse);
     rpc CreatePeerPath (CreatePeerPathRequest) returns (CreatePeerPathResponse);
@@ -672,6 +673,16 @@ message GetFileIdRequest {
 message GetFileIdResponse {
     ResponseHeader header = 1;
     uint64 fileId = 2;
+}
+
+message GetFileTypeRequest {
+    RequestHeader header = 1;
+    string filePathUri = 2; // the uri of the file containing the storage scheme prefix
+}
+
+message GetFileTypeResponse {
+    ResponseHeader header = 1;
+    File.Type fileType = 2; // the type of the file, e.g., REGULAR or EMPTY
 }
 
 message UpdateFileRequest {


### PR DESCRIPTION
The creation of empty files: Retina's writer buffer needs to writer data from memory to file using PixelsWriter. When the writer is created, emoty files are generated. The information abour these files is stored in advance in the metadata and markd as EMPTY. After the file completes writting, it is marked as REGULAR.

To avoid reading these temporary files during compaction, non-regular file must be excluded. These empty files may have written partial data, resulting in a non-zero length, so they cannot be directly identified by file length and instread required reading the metadata.