### PR TITLE
[Issue #1038] support specifiying host name in http stream reader

### DIFF
--- a/pixels-storage/pixels-storage-http/src/main/java/io/pixelsdb/pixels/storage/http/io/HttpInputStream.java
+++ b/pixels-storage/pixels-storage-http/src/main/java/io/pixelsdb/pixels/storage/http/io/HttpInputStream.java
@@ -27,6 +27,7 @@ import org.apache.logging.log4j.Logger;
 import javax.net.ssl.SSLException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.UnknownHostException;
 import java.security.cert.CertificateException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
@@ -75,10 +76,15 @@ public class HttpInputStream extends InputStream
         this.httpServerFuture = CompletableFuture.runAsync(() -> {
             try
             {
-                this.httpServer.serve(port);
-            } catch (InterruptedException e)
+                this.httpServer.serve(host, port);
+            }
+            catch (InterruptedException e)
             {
                 logger.error("http server interrupted", e);
+            }
+            catch (UnknownHostException e)
+            {
+                logger.error("unknown host for http server", e);
             }
         }, this.executorService);
     }

--- a/pixels-storage/pixels-storage-http/src/main/java/io/pixelsdb/pixels/storage/http/io/HttpServer.java
+++ b/pixels-storage/pixels-storage-http/src/main/java/io/pixelsdb/pixels/storage/http/io/HttpServer.java
@@ -31,7 +31,10 @@ import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
 
+import javax.annotation.Nonnull;
 import javax.net.ssl.SSLException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.security.cert.CertificateException;
 
 /**
@@ -55,7 +58,7 @@ public final class HttpServer
         handler.setServerCloser(this::close);
     }
 
-    public void serve(int port) throws InterruptedException
+    public void serve(@Nonnull String host, int port) throws InterruptedException, UnknownHostException
     {
         bossGroup = new NioEventLoopGroup(1);
         workerGroup = new NioEventLoopGroup();
@@ -69,7 +72,7 @@ public final class HttpServer
                     .handler(new LoggingHandler(LogLevel.INFO))
                     .childHandler(this.initializer);
 
-            channel = b.bind(port).sync().channel();
+            channel = b.bind(InetAddress.getByName(host), port).sync().channel();
             channel.closeFuture().sync();
         }
         finally


### PR DESCRIPTION
Previously, the hostname was ignored.
Resolves #1038.