### PR TITLE
[Issue #1094] resolve conflicting log libraries

### DIFF
--- a/pixels-amphi/README.md
+++ b/pixels-amphi/README.md
@@ -135,7 +135,7 @@ The `SchemaData` field comes from the cache plan generated in the previous step.
 
 To start the download process, simply run the following command:
 ```bash
-java -jar pixels-amphi-*.jar --config <config_file_path>
+java -jar pixels-amphi-*-full.jar --config <config_file_path>
 ```
 
 Please note that depended on the network bandwidth, the download process may take a while. To quickly test the system, you can also directly download the full dataset and skip this step. The system will still work as if only the cached columns are stored in the local storage.
@@ -147,7 +147,7 @@ After the preparations in the previous steps, now we have:
 - pixels server running in the cloud
 - pixels amphi worker to perform adaptive query processing
 
-We have add the executable to run the benchmark task ([benchmark source code](../cpp/pixels-amphi-worker/benchmark/benchmark.cpp)). We can now perform the task by running: 
+We have added the executable to run the benchmark task ([benchmark source code](../cpp/pixels-amphi-worker/benchmark/benchmark.cpp)). We can now perform the task by running: 
 ```bash
 ./benchmark <worker_config_path> <experiment_config_path>
 ```

--- a/pixels-amphi/pom.xml
+++ b/pixels-amphi/pom.xml
@@ -18,6 +18,7 @@
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <main.class>io.pixelsdb.pixels.amphi.downloader.DownloadProcess</main.class>
     </properties>
 
     <dependencies>
@@ -32,26 +33,14 @@
         <dependency>
             <groupId>io.pixelsdb</groupId>
             <artifactId>pixels-storage-s3</artifactId>
-            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>io.pixelsdb</groupId>
             <artifactId>pixels-storage-localfs</artifactId>
-            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>io.pixelsdb</groupId>
             <artifactId>pixels-parser</artifactId>
-        </dependency>
-
-        <!-- apache calcite -->
-        <dependency>
-            <groupId>org.apache.calcite</groupId>
-            <artifactId>calcite-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.calcite</groupId>
-            <artifactId>calcite-plus</artifactId>
         </dependency>
 
         <!-- apache-parquet -->
@@ -112,7 +101,55 @@
     </dependencies>
 
     <build>
+        <finalName>pixels-amphi-${project.version}</finalName>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+            </resource>
+        </resources>
+
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>${maven.plugin.shade.version}</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <finalName>pixels-amphi-${project.version}</finalName>
+                            <outputDirectory>${project.basedir}/target</outputDirectory>
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
+                            <shadedClassifierName>full</shadedClassifierName>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <transformers>
+                                <!-- ServicesResourceTransformer merges the resources in META-INF/services -->
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>${main.class}</mainClass>
+                                    <manifestEntries>
+                                        <Add-Opens>java.base/sun.nio.ch java.base/java.nio</Add-Opens>
+                                        <Multi-Release>true</Multi-Release>
+                                    </manifestEntries>
+                                </transformer>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
@@ -140,37 +177,12 @@
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <version>${maven.plugin.shade.version}</version>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven.plugin.compiler.version}</version>
                 <configuration>
-                    <createDependencyReducedPom>false</createDependencyReducedPom>
+                    <source>8</source>
+                    <target>8</target>
                 </configuration>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                        <configuration>
-                            <transformers>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                                    <mainClass>io.pixelsdb.pixels.amphi.downloader.DownloadProcess</mainClass>
-                                </transformer>
-                            </transformers>
-                            <filters>
-                                <filter>
-                                    <artifact>*:*</artifact>
-                                    <excludes>
-                                        <exclude>META-INF/*.SF</exclude>
-                                        <exclude>META-INF/*.DSA</exclude>
-                                        <exclude>META-INF/*.RSA</exclude>
-                                    </excludes>
-                                </filter>
-                            </filters>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/pixels-amphi/src/main/java/io/pixelsdb/pixels/amphi/downloader/DownloadProcess.java
+++ b/pixels-amphi/src/main/java/io/pixelsdb/pixels/amphi/downloader/DownloadProcess.java
@@ -42,7 +42,8 @@ import java.util.stream.Collectors;
 /**
  * Built as the main method to download partial data to the local storage.
  */
-public class DownloadProcess {
+public class DownloadProcess
+{
     public static void main(String[] args) throws IOException, IllegalArgumentException, MetadataException
     {
         // Load configuration
@@ -180,8 +181,7 @@ public class DownloadProcess {
         }
     }
 
-    private static String readConfigFile(String filePath)
-            throws IOException
+    private static String readConfigFile(String filePath) throws IOException
     {
         try
         {

--- a/pixels-cli/pom.xml
+++ b/pixels-cli/pom.xml
@@ -18,7 +18,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <mainClass>io.pixelsdb.pixels.cli.Main</mainClass>
+        <main.class>io.pixelsdb.pixels.cli.Main</main.class>
         <maven.deploy.skip>true</maven.deploy.skip>
         <maven.install.skip>true</maven.install.skip>
 
@@ -105,7 +105,7 @@
     </dependencies>
 
     <build>
-        <finalName>pixels-cli</finalName>
+        <finalName>pixels-cli-${project.version}</finalName>
         <resources>
             <resource>
                 <directory>src/main/resources</directory>
@@ -124,7 +124,7 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
-                            <finalName>pixels-cli</finalName>
+                            <finalName>pixels-cli-${project.version}</finalName>
                             <outputDirectory>${project.basedir}/target</outputDirectory>
                             <shadedArtifactAttached>true</shadedArtifactAttached>
                             <shadedClassifierName>full</shadedClassifierName>
@@ -142,7 +142,7 @@
                                 <!-- ServicesResourceTransformer merges the resources in META-INF/services -->
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                                    <mainClass>${mainClass}</mainClass>
+                                    <mainClass>${main.class}</mainClass>
                                     <manifestEntries>
                                         <Add-Opens>java.base/sun.nio.ch java.base/java.nio</Add-Opens>
                                         <Multi-Release>true</Multi-Release>

--- a/pixels-daemon/pom.xml
+++ b/pixels-daemon/pom.xml
@@ -18,7 +18,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <mainClass>io.pixelsdb.pixels.daemon.DaemonMain</mainClass>
+        <main.class>io.pixelsdb.pixels.daemon.DaemonMain</main.class>
     </properties>
 
     <dependencies>
@@ -159,7 +159,7 @@
     </dependencies>
 
     <build>
-        <finalName>pixels-daemon</finalName>
+        <finalName>pixels-daemon-${project.version}</finalName>
         <resources>
             <resource>
                 <directory>src/main/resources</directory>
@@ -177,7 +177,7 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
-                            <finalName>pixels-daemon</finalName>
+                            <finalName>pixels-daemon-${project.version}</finalName>
                             <outputDirectory>${project.basedir}/target</outputDirectory>
                             <shadedArtifactAttached>true</shadedArtifactAttached>
                             <shadedClassifierName>full</shadedClassifierName>
@@ -195,7 +195,7 @@
                                 <!-- ServicesResourceTransformer merges the resources in META-INF/services -->
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                                    <mainClass>${mainClass}</mainClass>
+                                    <mainClass>${main.class}</mainClass>
                                     <manifestEntries>
                                         <Add-Opens>java.base/sun.nio.ch java.base/java.nio</Add-Opens>
                                         <Multi-Release>true</Multi-Release>

--- a/pixels-parser/pom.xml
+++ b/pixels-parser/pom.xml
@@ -38,6 +38,16 @@
             <groupId>org.apache.calcite</groupId>
             <artifactId>calcite-plus</artifactId>
         </dependency>
+
+        <!-- use the unified versions of commons-logging and slf4j for calcite-core -->
+        <dependency>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pixels-server/pom.xml
+++ b/pixels-server/pom.xml
@@ -22,9 +22,10 @@
         <maven.deploy.skip>true</maven.deploy.skip>
         <maven.install.skip>true</maven.install.skip>
 
+        <maven.plugin.asciidoctor.version>2.2.1</maven.plugin.asciidoctor.version>
+
         <!-- web frameworks and packaging -->
         <dep.spring.boot.version>2.7.10</dep.spring.boot.version>
-        <dep.asciidoctor.version>2.2.1</dep.asciidoctor.version>
         <dep.grpc.spring.boot.starter.version>2.14.0.RELEASE</dep.grpc.spring.boot.starter.version>
         <!-- this is from spring-boot-dependencies-2.7.10.pom -->
         <dep.spring-restdocs.version>2.0.7.RELEASE</dep.spring-restdocs.version>
@@ -53,15 +54,11 @@
             <artifactId>pixels-amphi</artifactId>
             <exclusions>
                 <exclusion>
-                    <groupId>io.netty</groupId>
-                    <artifactId>netty-common</artifactId>
+                    <!-- log4j-slf4j-impl conflicts with the log4j-to-slf4j used by spring boot-->
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-slf4j-impl</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-common</artifactId>
         </dependency>
 
         <!-- trino-jdbc -->
@@ -115,6 +112,7 @@
             <artifactId>spring-boot-starter-tomcat</artifactId>
             <scope>provided</scope>
         </dependency>
+
         <!-- rest and security -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -124,6 +122,18 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
+        <!-- specify the unified versions of slf4j and log4j for spring-boot-starter-web -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jul-to-slf4j</artifactId>
+            <version>${dep.slf4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-to-slf4j</artifactId>
+            <version>${dep.log4j.version}</version>
+        </dependency>
+
         <!-- grpc -->
         <dependency>
             <groupId>net.devh</groupId>
@@ -176,7 +186,7 @@
             <plugin>
                 <groupId>org.asciidoctor</groupId>
                 <artifactId>asciidoctor-maven-plugin</artifactId>
-                <version>${dep.asciidoctor.version}</version>
+                <version>${maven.plugin.asciidoctor.version}</version>
                 <executions>
                     <execution>
                         <id>generate-docs</id>

--- a/pixels-server/src/main/resources/templates/login.html
+++ b/pixels-server/src/main/resources/templates/login.html
@@ -14,9 +14,6 @@
         <div class="row justify-content-center">
             <div class="col-md-7 col-lg-5">
                 <div class="login-wrap p-4 p-md-5">
-                    <div class="icon d-flex align-items-center justify-content-center">
-                        <span class="fa fa-user-o"></span>
-                    </div>
                     <h3 class="text-center mb-4">Sign In to Pixels</h3>
                     <form action="#" class="login-form">
                         <div class="form-group">

--- a/pixels-turbo/pixels-worker-vhive/pom.xml
+++ b/pixels-turbo/pixels-worker-vhive/pom.xml
@@ -106,7 +106,7 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
-                            <finalName>pixels-worker-vhive-jar-with-dependencies</finalName>
+                            <finalName>pixels-worker-vhive-with-deps</finalName>
                             <transformers>
                                 <!-- ServicesResourceTransformer merges the resources in META-INF/services -->
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>

--- a/pom.xml
+++ b/pom.xml
@@ -131,14 +131,16 @@
         <dep.commons-net.version>3.9.0</dep.commons-net.version>
 
         <!-- logging -->
-        <dep.log4j.version>2.17.1</dep.log4j.version>
-        <!-- we only use log4j in pixels, the following are for third-party libs -->
+        <!-- log4j-2.18.0 is compatible with slf4j-1.7.36 -->
+        <dep.log4j.version>2.18.0</dep.log4j.version>
+        <!-- we only use log4j in pixels, the following are for third-party libraries -->
         <dep.commons-logging.version>1.2</dep.commons-logging.version>
-        <dep.slf4j.version>1.7.25</dep.slf4j.version>
+        <!-- slf4j-1.7.36 is compatible with 1.7.x that is widely used in third-party libraries -->
+        <dep.slf4j.version>1.7.36</dep.slf4j.version>
 
         <!-- testing -->
-        <dep.junit.version>4.13.1</dep.junit.version>
-        <dep.junit.platform.version>1.6.2</dep.junit.platform.version>
+        <dep.junit4.version>4.13.2</dep.junit4.version>
+        <dep.junit.platform.version>1.8.2</dep.junit.platform.version>
         <dep.mockito.version>4.5.1</dep.mockito.version>
         <dep.junit.jupiter.version>5.8.2</dep.junit.jupiter.version>
     </properties>
@@ -832,6 +834,7 @@
                 <artifactId>log4j-api</artifactId>
                 <version>${dep.log4j.version}</version>
             </dependency>
+            <!-- the following logging libraries are only used for third-party libraries when needed -->
             <dependency>
                 <!-- the default binding from slf4j to log4j-2, be careful of other conflict bindings -->
                 <groupId>org.apache.logging.log4j</groupId>
@@ -843,6 +846,16 @@
                 <groupId>org.slf4j</groupId>
                 <artifactId>log4j-over-slf4j</artifactId>
                 <version>${dep.slf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>${dep.slf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-logging</groupId>
+                <artifactId>commons-logging</artifactId>
+                <version>${dep.commons-logging.version}</version>
             </dependency>
 
             <!--profiling-->
@@ -861,7 +874,7 @@
             <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
-                <version>${dep.junit.version}</version>
+                <version>${dep.junit4.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
This resolves the problems with pixels-server, which is caused by the conflicting log libraries in pixels-amphi and pixels-parser.
We also update the pom of pixels-amphi, making other components such as pixels-server dependent on the origin instead of the uber jar of pixels-amphi