### PR TITLE
[Issue #1094] avoid inheriting log4j-slf4j-impl dependency from storage-s3 to other modules

### DIFF
--- a/pixels-amphi/src/main/java/io/pixelsdb/pixels/amphi/coordinator/Coordinator.java
+++ b/pixels-amphi/src/main/java/io/pixelsdb/pixels/amphi/coordinator/Coordinator.java
@@ -32,8 +32,8 @@ import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.parser.SqlParseException;
 import org.apache.calcite.sql.parser.SqlParser;
 import org.apache.calcite.sql.parser.impl.SqlParserImpl;
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
 import java.util.List;

--- a/pixels-server/pom.xml
+++ b/pixels-server/pom.xml
@@ -52,13 +52,6 @@
         <dependency>
             <groupId>io.pixelsdb</groupId>
             <artifactId>pixels-amphi</artifactId>
-            <exclusions>
-                <exclusion>
-                    <!-- log4j-slf4j-impl conflicts with the log4j-to-slf4j used by spring boot-->
-                    <groupId>org.apache.logging.log4j</groupId>
-                    <artifactId>log4j-slf4j-impl</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <!-- trino-jdbc -->
@@ -117,10 +110,16 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-security</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>jul-to-slf4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-to-slf4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- specify the unified versions of slf4j and log4j for spring-boot-starter-web -->
         <dependency>
@@ -132,6 +131,10 @@
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-to-slf4j</artifactId>
             <version>${dep.log4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
 
         <!-- grpc -->

--- a/pixels-storage/pixels-storage-s3/pom.xml
+++ b/pixels-storage/pixels-storage-s3/pom.xml
@@ -59,11 +59,13 @@
             <!-- this is only for third-party libs that use slf4j -->
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <!-- this is only for third-party libs that use log4j-1 -->
             <groupId>org.slf4j</groupId>
             <artifactId>log4j-over-slf4j</artifactId>
+            <optional>true</optional>
         </dependency>
 
         <!-- hadoop -->


### PR DESCRIPTION
log4j-slf4j-impl may cause conflicts with other modules, such as pixels-trino, regarding logging.