### PR TITLE
[Issue #1099] Increase DEFAULT_AI_STEP and simplify trans commit protocol

### DIFF
--- a/pixels-cli/src/main/java/io/pixelsdb/pixels/cli/executor/LoadExecutor.java
+++ b/pixels-cli/src/main/java/io/pixelsdb/pixels/cli/executor/LoadExecutor.java
@@ -111,7 +111,7 @@ public class LoadExecutor implements CommandExecutor
             System.err.println(command + " failed");
         }
 
-        transService.commitTrans(context.getTransId(), context.getTimestamp());
+        transService.commitTrans(context.getTransId());
 
         long endTime = System.currentTimeMillis();
         System.out.println("Text files in '" + origin + "' are loaded by " + threadNum +

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/transaction/TransService.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/transaction/TransService.java
@@ -175,10 +175,10 @@ public class TransService
         return contexts.build();
     }
 
-    public boolean commitTrans(long transId, long timestamp) throws TransException
+    public boolean commitTrans(long transId) throws TransException
     {
         TransProto.CommitTransRequest request = TransProto.CommitTransRequest.newBuilder()
-                .setTransId(transId).setTimestamp(timestamp).build();
+                .setTransId(transId).build();
         TransProto.CommitTransResponse response = this.stub.commitTrans(request);
         if (response.getErrorCode() != ErrorCode.SUCCESS)
         {
@@ -193,19 +193,18 @@ public class TransService
      * Commit a batch of transactions and return whether the execution succeeded.
      * If execution fails, specific error logs can be obtained from the transService logs,
      * such as the transaction does not exist or the commit fails.
-     * @param transIds
-     * @param timestamps
-     * @return Whether each transaction was successfully committed.
+     * @param transIds transaction ids of the transactions to commit
+     * @return Whether each transaction was successfully committed
      * @throws TransException
      */
-    public List<Boolean> commitTransBatch(List<Long> transIds, List<Long> timestamps) throws TransException
+    public List<Boolean> commitTransBatch(List<Long> transIds) throws TransException
     {
-        if (transIds == null || timestamps == null || transIds.size() != timestamps.size())
+        if (transIds == null || transIds.isEmpty())
         {
-            throw new IllegalArgumentException("invalid transaction ids or timestamps");
+            throw new IllegalArgumentException("transIds is null or empty");
         }
         TransProto.CommitTransBatchRequest request = TransProto.CommitTransBatchRequest.newBuilder()
-                .addAllTransIds(transIds).addAllTimestamps(timestamps).build();
+                .addAllTransIds(transIds).build();
         TransProto.CommitTransBatchResponse response = this.stub.commitTransBatch(request);
         if (response.getErrorCode() == ErrorCode.TRANS_INVALID_ARGUMENT) // other error codes are not thrown as exceptions
         {

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/utils/Constants.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/utils/Constants.java
@@ -20,7 +20,7 @@
 package io.pixelsdb.pixels.common.utils;
 
 /**
- * @author guodong
+ * @author guodong, hank
  */
 public final class Constants
 {
@@ -82,7 +82,8 @@ public final class Constants
      * The prefix for read-write lock used in etcd auto-increment id.
      */
     public static final String AI_LOCK_PATH_PREFIX = "/ai_lock_/";
-    public static final long AI_DEFAULT_STEP = 1000; // Issue #729: should be large enough to reach 1M tps
+    // Issue #1099: increase from 1000 to 10000 to improve transaction-begin throughput
+    public static final long AI_DEFAULT_STEP = 10000;
     public static final String AI_TRANS_ID_KEY = "trans_id";
     public static final String AI_TRANS_TS_KEY = "trans_ts";
 

--- a/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/transaction/TransServiceImpl.java
+++ b/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/transaction/TransServiceImpl.java
@@ -244,7 +244,6 @@ public class TransServiceImpl extends TransServiceGrpc.TransServiceImplBase
         responseObserver.onCompleted();
     }
 
-
     @Override
     public void rollbackTrans(TransProto.RollbackTransRequest request,
                               StreamObserver<TransProto.RollbackTransResponse> responseObserver)

--- a/proto/transaction.proto
+++ b/proto/transaction.proto
@@ -86,7 +86,6 @@ message BeginTransBatchResponse {
 
 message CommitTransRequest {
     uint64 transId = 1;
-    uint64 timestamp = 2;
 }
 
 message CommitTransResponse {
@@ -95,7 +94,6 @@ message CommitTransResponse {
 
 message CommitTransBatchRequest {
     repeated uint64 transIds = 1;
-    repeated uint64 timestamps = 2;
 }
 
 message CommitTransBatchResponse {


### PR DESCRIPTION
Increase DEFAULT_AI_STEP from 1000 to 10000 and remove timestamp from the trans commit and trans commit batch rpc methods.