### PR TITLE
[Issue #1099] use trans id as trans timestamp for non-readonly trans and optimize locks

### DIFF
--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/lock/EtcdAutoIncrement.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/lock/EtcdAutoIncrement.java
@@ -209,7 +209,8 @@ public class EtcdAutoIncrement
                         throw new EtcdException("invalid segment for id key " + idKey + " from etcd");
                     }
                     processor.process(segment);
-                } else
+                }
+                else
                 {
                     throw new EtcdException("the key value of the id " + idKey + " does not exist in etcd");
                 }
@@ -236,7 +237,8 @@ public class EtcdAutoIncrement
             try
             {
                 aiLock.unlock();
-            } catch (EtcdException e)
+            }
+            catch (EtcdException e)
             {
                 throw new EtcdException("failed to release write lock", e);
             }

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/lock/PersistentAutoIncrement.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/lock/PersistentAutoIncrement.java
@@ -113,9 +113,6 @@ public class PersistentAutoIncrement
 
     /**
      * Get the current value of this auto increment and increase it by the given batch size.
-     * <br/>
-     * <b>Note: It is recommended that the etcdStep in the constructor of this class is significantly larger than
-     * the batchSize here. Thus, the etcd overhead would not be significant.</b>
      * @param batchSize the given batch size
      * @return the current value of this auto increment.
      * @throws EtcdException when fail to interact with the backing etcd instance.

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/utils/Constants.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/utils/Constants.java
@@ -85,7 +85,6 @@ public final class Constants
     // Issue #1099: increase from 1000 to 10000 to improve transaction-begin throughput
     public static final long AI_DEFAULT_STEP = 10000;
     public static final String AI_TRANS_ID_KEY = "trans_id";
-    public static final String AI_TRANS_TS_KEY = "trans_ts";
     public static final String AI_ROW_ID_PREFIX = "row_id_";
 
     public static final String CF_OUTPUT_STATE_KEY_PREFIX = "pixels_turbo_cf_output";

--- a/pixels-common/src/test/java/io/pixelsdb/pixels/common/lock/TestPersistentAutoIncrement.java
+++ b/pixels-common/src/test/java/io/pixelsdb/pixels/common/lock/TestPersistentAutoIncrement.java
@@ -32,7 +32,7 @@ public class TestPersistentAutoIncrement
     @Test
     public void test() throws EtcdException
     {
-        PersistentAutoIncrement pai = new PersistentAutoIncrement(Constants.AI_TRANS_TS_KEY, true);
+        PersistentAutoIncrement pai = new PersistentAutoIncrement(Constants.AI_TRANS_ID_KEY, true);
         for (int i = 0; i < 2048; ++i)
         {
             System.out.println(pai.getAndIncrement());

--- a/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/transaction/TransContextManager.java
+++ b/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/transaction/TransContextManager.java
@@ -165,7 +165,7 @@ public class TransContextManager
 
     private boolean _terminateTrans(long transId, TransProto.TransStatus status)
     {
-        System.out.println("thread " + Thread.currentThread().getName() + " terminate trans " + context.getTransId());
+        System.out.println("thread " + Thread.currentThread().getName() + " terminate trans " + transId);
         TransContext context = this.transIdToContext.get(transId);
         if (context != null)
         {

--- a/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/transaction/TransContextManager.java
+++ b/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/transaction/TransContextManager.java
@@ -99,7 +99,7 @@ public class TransContextManager
 
     private void _addTransContext(TransContext context)
     {
-        System.out.println("thread " + Thread.currentThread().getName() + " add trans " + context.getTransId());
+        //System.out.println("thread " + Thread.currentThread().getName() + " add trans " + context.getTransId());
         this.transIdToContext.put(context.getTransId(), context);
         if (context.isReadOnly())
         {
@@ -165,7 +165,7 @@ public class TransContextManager
 
     private boolean _terminateTrans(long transId, TransProto.TransStatus status)
     {
-        System.out.println("thread " + Thread.currentThread().getName() + " terminate trans " + transId);
+        // System.out.println("thread " + Thread.currentThread().getName() + " terminate trans " + transId);
         TransContext context = this.transIdToContext.get(transId);
         if (context != null)
         {
@@ -178,7 +178,7 @@ public class TransContextManager
             else
             {
                 // only clear the context of write transactions
-                this.transIdToContext.remove(context.getTransId());
+                // this.transIdToContext.remove(context.getTransId());
                 this.runningWriteTrans.remove(context);
                 String traceId = this.transIdToTraceId.remove(context.getTransId());
                 if (traceId != null)
@@ -278,7 +278,7 @@ public class TransContextManager
 
     public boolean isTransExist(long transId)
     {
-        System.out.println("thread " + Thread.currentThread().getName() + " check trans " + transId + " exists " + this.transIdToContext.containsKey(transId));
+        //System.out.println("thread " + Thread.currentThread().getName() + " check trans " + transId + " exists " + this.transIdToContext.containsKey(transId));
         return this.transIdToContext.containsKey(transId);
     }
 

--- a/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/transaction/TransContextManager.java
+++ b/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/transaction/TransContextManager.java
@@ -99,7 +99,6 @@ public class TransContextManager
 
     private void _addTransContext(TransContext context)
     {
-        //System.out.println("thread " + Thread.currentThread().getName() + " add trans " + context.getTransId());
         this.transIdToContext.put(context.getTransId(), context);
         if (context.isReadOnly())
         {
@@ -165,7 +164,6 @@ public class TransContextManager
 
     private boolean _terminateTrans(long transId, TransProto.TransStatus status)
     {
-        // System.out.println("thread " + Thread.currentThread().getName() + " terminate trans " + transId);
         TransContext context = this.transIdToContext.get(transId);
         if (context != null)
         {
@@ -278,7 +276,6 @@ public class TransContextManager
 
     public boolean isTransExist(long transId)
     {
-        //System.out.println("thread " + Thread.currentThread().getName() + " check trans " + transId + " exists " + this.transIdToContext.containsKey(transId));
         return this.transIdToContext.containsKey(transId);
     }
 

--- a/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/transaction/TransContextManager.java
+++ b/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/transaction/TransContextManager.java
@@ -99,6 +99,7 @@ public class TransContextManager
 
     private void _addTransContext(TransContext context)
     {
+        System.out.println("thread " + Thread.currentThread().getName() + " add trans " + context.getTransId());
         this.transIdToContext.put(context.getTransId(), context);
         if (context.isReadOnly())
         {
@@ -164,6 +165,7 @@ public class TransContextManager
 
     private boolean _terminateTrans(long transId, TransProto.TransStatus status)
     {
+        System.out.println("thread " + Thread.currentThread().getName() + " terminate trans " + context.getTransId());
         TransContext context = this.transIdToContext.get(transId);
         if (context != null)
         {
@@ -276,6 +278,7 @@ public class TransContextManager
 
     public boolean isTransExist(long transId)
     {
+        System.out.println("thread " + Thread.currentThread().getName() + " check trans " + transId + " exists " + this.transIdToContext.containsKey(transId));
         return this.transIdToContext.containsKey(transId);
     }
 

--- a/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/transaction/TransContextManager.java
+++ b/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/transaction/TransContextManager.java
@@ -178,7 +178,7 @@ public class TransContextManager
             else
             {
                 // only clear the context of write transactions
-                // this.transIdToContext.remove(context.getTransId());
+                this.transIdToContext.remove(context.getTransId());
                 this.runningWriteTrans.remove(context);
                 String traceId = this.transIdToTraceId.remove(context.getTransId());
                 if (traceId != null)

--- a/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/transaction/TransServiceImpl.java
+++ b/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/transaction/TransServiceImpl.java
@@ -144,9 +144,9 @@ public class TransServiceImpl extends TransServiceGrpc.TransServiceImplBase
             if (request.getReadOnly())
             {
                 long timestamp = highWatermark.get();
-                for (int i = 0; i < numTrans; i++)
+                for (int i = 0; i < numTrans; i++, transId++)
                 {
-                    response.addTransIds(transId++).addTimestamps(timestamp);
+                    response.addTransIds(transId).addTimestamps(timestamp);
                     TransContext context = new TransContext(transId, timestamp, true);
                     TransContextManager.Instance().addTransContext(context);
                 }
@@ -154,16 +154,17 @@ public class TransServiceImpl extends TransServiceGrpc.TransServiceImplBase
             else
             {
                 long timestamp = transTimestamp.getAndIncrement(numTrans);
-                for (int i = 0; i < numTrans; i++)
+                for (int i = 0; i < numTrans; i++, transId++, timestamp++)
                 {
-                    response.addTransIds(transId++).addTimestamps(timestamp++);
+                    response.addTransIds(transId).addTimestamps(timestamp);
                     TransContext context = new TransContext(transId, timestamp, false);
                     TransContextManager.Instance().addTransContext(context);
                 }
             }
             response.setExactNumTrans(request.getExpectNumTrans());
             response.setErrorCode(ErrorCode.SUCCESS);
-        } catch (EtcdException e)
+        }
+        catch (EtcdException e)
         {
             response.setErrorCode(ErrorCode.TRANS_GENERATE_ID_OR_TS_FAILED);
             logger.error("failed to generate transaction id or timestamp", e);

--- a/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/transaction/TransServiceImpl.java
+++ b/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/transaction/TransServiceImpl.java
@@ -52,6 +52,8 @@ public class TransServiceImpl extends TransServiceGrpc.TransServiceImplBase
 
     /**
      * transId is monotonically increasing.
+     * <br/>
+     * Issue #1099:
      * For non-readonly transactions, transId is also used as the transaction timestamp.
      * For readonly transactions, the current high watermark is used as the transaction timestamp.
      */


### PR DESCRIPTION
1. For non-readonly transactions, we use trans id as the trans timestamp in the transaction server, this reduces the etcd access and locks;
2. We get a trans id range from PersistentAutoIncrement at onece for beginTransBatch;
3. We use add batch and commit batch in TransContextManager for beginTransBatch and commitTransBatch.
4. We replace StampedLock with ReentrantReadWriteLock in TransContextManager, this was a concurrency bug.