### PR TITLE
[Issue #912] minor revision for rocksdb index

### DIFF
--- a/pixels-common/src/test/java/io/pixelsdb/pixels/common/index/LocalIndexServiceTest.java
+++ b/pixels-common/src/test/java/io/pixelsdb/pixels/common/index/LocalIndexServiceTest.java
@@ -29,7 +29,8 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.*;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-class LocalIndexServiceTest {
+class LocalIndexServiceTest
+{
 
     private static LocalIndexService indexService;
     private static final long TABLE_ID = 1L;

--- a/pixels-index/pixels-index-rocksdb/src/main/java/io/pixelsdb/pixels/index/rocksdb/RocksDBIndex.java
+++ b/pixels-index/pixels-index-rocksdb/src/main/java/io/pixelsdb/pixels/index/rocksdb/RocksDBIndex.java
@@ -20,6 +20,7 @@
 package io.pixelsdb.pixels.index.rocksdb;
 
 import com.google.common.collect.ImmutableList;
+import com.google.protobuf.ByteString;
 import io.pixelsdb.pixels.common.exception.MainIndexException;
 import io.pixelsdb.pixels.common.exception.SinglePointIndexException;
 import io.pixelsdb.pixels.common.index.MainIndex;
@@ -106,7 +107,7 @@ public class RocksDBIndex implements SinglePointIndex
     public long getUniqueRowId(IndexProto.IndexKey key)
     {
         // Get prefix
-        byte[] keyBytes = toByteArray(key);
+        byte[] keyBytes = toKeyBytes(key);
         long timestamp = key.getTimestamp();
         setIteratorBounds(readOptions, keyBytes, timestamp+1);
         long rowId = -1L;
@@ -130,7 +131,7 @@ public class RocksDBIndex implements SinglePointIndex
     public List<Long> getRowIds(IndexProto.IndexKey key)
     {
         ImmutableList.Builder<Long> builder = ImmutableList.builder();
-        byte[] keyBytes = toByteArray(key);
+        byte[] keyBytes = toKeyBytes(key);
         long timestamp = key.getTimestamp();
         setIteratorBounds(readOptions, keyBytes, timestamp+1);
         // Use RocksDB iterator for prefix search
@@ -170,7 +171,7 @@ public class RocksDBIndex implements SinglePointIndex
         try
         {
             // Convert IndexKey to byte array
-            byte[] keyBytes = toByteArray(key);
+            byte[] keyBytes = toKeyBytes(key);
             // Convert rowId to byte array
             byte[] valueBytes = ByteBuffer.allocate(Long.BYTES).putLong(rowId).array();
             if (unique)
@@ -181,7 +182,7 @@ public class RocksDBIndex implements SinglePointIndex
             else
             {
                 // Create composite key
-                byte[] nonUniqueKey = toNonUniqueKey(key, rowId);
+                byte[] nonUniqueKey = toNonUniqueKeyBytes(key, rowId);
                 // Store in RocksDB
                 rocksDB.put(nonUniqueKey, new byte[0]);
             }
@@ -208,7 +209,7 @@ public class RocksDBIndex implements SinglePointIndex
                 IndexProto.IndexKey key = entry.getIndexKey();
                 long rowId = entry.getRowId();
                 // Convert IndexKey to byte array
-                byte[] keyBytes = toByteArray(key);
+                byte[] keyBytes = toKeyBytes(key);
                 // Convert rowId to byte array
                 byte[] valueBytes = ByteBuffer.allocate(Long.BYTES).putLong(rowId).array();
                 // Write to RocksDB
@@ -238,7 +239,7 @@ public class RocksDBIndex implements SinglePointIndex
                 IndexProto.IndexKey key = entry.getIndexKey();
                 long rowId = entry.getRowId();
                 // Convert IndexKey to byte array
-                byte[] keyBytes = toByteArray(key);
+                byte[] keyBytes = toKeyBytes(key);
                 // Convert rowId to byte array
                 byte[] valueBytes = ByteBuffer.allocate(Long.BYTES).putLong(rowId).array();
                 if(unique)
@@ -248,7 +249,7 @@ public class RocksDBIndex implements SinglePointIndex
                 }
                 else
                 {
-                    byte[] nonUniqueKey = toNonUniqueKey(key, rowId);
+                    byte[] nonUniqueKey = toNonUniqueKeyBytes(key, rowId);
                     writeBatch.put(nonUniqueKey, new byte[0]);
                 }
             }
@@ -270,7 +271,7 @@ public class RocksDBIndex implements SinglePointIndex
             // Get previous rowId and rowLocation
             long prevRowId = getUniqueRowId(key);
             // Convert key and new rowId to bytes
-            byte[] keyBytes = toByteArray(key);
+            byte[] keyBytes = toKeyBytes(key);
             byte[] valueBytes = ByteBuffer.allocate(Long.BYTES).putLong(rowId).array();
             // Write to RocksDB
             rocksDB.put(keyBytes, valueBytes);
@@ -290,7 +291,7 @@ public class RocksDBIndex implements SinglePointIndex
         {
             ImmutableList.Builder<Long> builder = ImmutableList.builder();
             // Convert key and new rowId to bytes
-            byte[] keyBytes = toByteArray(key);
+            byte[] keyBytes = toKeyBytes(key);
             byte[] valueBytes = ByteBuffer.allocate(Long.BYTES).putLong(rowId).array();
 
             if(unique)
@@ -305,7 +306,7 @@ public class RocksDBIndex implements SinglePointIndex
                 // Get previous rowIds
                 builder.addAll(this.getRowIds(key));
                 // Write to RocksDB
-                byte[] nonUniqueKey = toNonUniqueKey(key, rowId);
+                byte[] nonUniqueKey = toNonUniqueKeyBytes(key, rowId);
                 rocksDB.put(nonUniqueKey, new byte[0]);
             }
             return builder.build();
@@ -330,7 +331,7 @@ public class RocksDBIndex implements SinglePointIndex
                 IndexProto.IndexKey key = entry.getIndexKey();
                 long rowId = entry.getRowId();
                 // Convert IndexKey and new rowId to byte array
-                byte[] keyBytes = toByteArray(key);
+                byte[] keyBytes = toKeyBytes(key);
                 byte[] valueBytes = ByteBuffer.allocate(Long.BYTES).putLong(rowId).array();
                 // Get prev rowId
                 builder.add(this.getUniqueRowId(key));
@@ -360,7 +361,7 @@ public class RocksDBIndex implements SinglePointIndex
                 IndexProto.IndexKey key = entry.getIndexKey();
                 long rowId = entry.getRowId();
                 // Convert IndexKey and new rowId to byte array
-                byte[] keyBytes = toByteArray(key);
+                byte[] keyBytes = toKeyBytes(key);
                 byte[] valueBytes = ByteBuffer.allocate(Long.BYTES).putLong(rowId).array();
 
                 if(unique)
@@ -375,7 +376,7 @@ public class RocksDBIndex implements SinglePointIndex
                     // Get previous rowIds from index
                     builder.addAll(this.getRowIds(key));
                     // Write to RocksDB
-                    byte[] nonUniqueKey = toNonUniqueKey(key, rowId);
+                    byte[] nonUniqueKey = toNonUniqueKeyBytes(key, rowId);
                     writeBatch.put(nonUniqueKey, new byte[0]);
                 }
             }
@@ -395,7 +396,7 @@ public class RocksDBIndex implements SinglePointIndex
         long rowId = getUniqueRowId(key);
         try
         {
-            byte[] keyBytes = toByteArray(key);
+            byte[] keyBytes = toKeyBytes(key);
             byte[] newValue = ByteBuffer.allocate(Long.BYTES).putLong(-1L).array(); // -1 means a tombstone
             rocksDB.put(keyBytes, newValue);
             return rowId;
@@ -413,7 +414,7 @@ public class RocksDBIndex implements SinglePointIndex
         ImmutableList.Builder<Long> builder = ImmutableList.builder();
         try
         {
-            byte[] keyBytes = toByteArray(key);
+            byte[] keyBytes = toKeyBytes(key);
             byte[] newValue = ByteBuffer.allocate(Long.BYTES).putLong(-1L).array(); // -1 means a tombstone
 
             if(unique)
@@ -436,7 +437,7 @@ public class RocksDBIndex implements SinglePointIndex
                     return ImmutableList.of();
                 }
                 builder.addAll(rowIds);
-                byte[] nonUniqueKey = toNonUniqueKey(key, -1L);
+                byte[] nonUniqueKey = toNonUniqueKeyBytes(key, -1L);
                 rocksDB.put(nonUniqueKey, new byte[0]);
             }
             return builder.build();
@@ -457,7 +458,7 @@ public class RocksDBIndex implements SinglePointIndex
             // Delete single point index
             for(IndexProto.IndexKey key : keys)
             {
-                byte[] keyBytes = toByteArray(key);
+                byte[] keyBytes = toKeyBytes(key);
                 byte[] newValue = ByteBuffer.allocate(Long.BYTES).putLong(-1L).array(); // -1 means a tombstone
 
                 if(unique)
@@ -480,7 +481,7 @@ public class RocksDBIndex implements SinglePointIndex
                         return ImmutableList.of();
                     }
                     builder.addAll(rowIds);
-                    byte[] nonUniqueKey = toNonUniqueKey(key, -1L);
+                    byte[] nonUniqueKey = toNonUniqueKeyBytes(key, -1L);
                     writeBatch.put(nonUniqueKey, new byte[0]);
                 }
             }
@@ -503,7 +504,7 @@ public class RocksDBIndex implements SinglePointIndex
             // Delete from RocksDB
             for(IndexProto.IndexKey key : indexKeys)
             {
-                byte[] keyBytes = toByteArray(key);
+                byte[] keyBytes = toKeyBytes(key);
 
                 if(unique)  // only unique may be primary index
                 {
@@ -519,7 +520,7 @@ public class RocksDBIndex implements SinglePointIndex
                 else
                 {
                     // Purged Index entries must be deleted first
-                    byte[] nonUniqueKey = toNonUniqueKey(key, -1L);
+                    byte[] nonUniqueKey = toNonUniqueKeyBytes(key, -1L);
                     writeBatch.delete(nonUniqueKey);
                 }
             }
@@ -573,7 +574,7 @@ public class RocksDBIndex implements SinglePointIndex
         return true;
     }
 
-    private static void writeLongBE(byte[] buf, int offset, long value)
+    protected static void writeLongBE(byte[] buf, int offset, long value)
     {
         buf[offset]     = (byte)(value >>> 56);
         buf[offset + 1] = (byte)(value >>> 48);
@@ -585,52 +586,37 @@ public class RocksDBIndex implements SinglePointIndex
         buf[offset + 7] = (byte)(value);
     }
 
-    // Convert IndexKey to byte array
-    private static byte[] toByteArray(IndexProto.IndexKey key)
+    protected static byte[] toBytes(long indexId, ByteString key, long postValue)
     {
-        byte[] keyBytes = key.getKey().toByteArray();
-        int totalLength = Long.BYTES + keyBytes.length + Long.BYTES;
-
+        int keySize = key.size();
+        int totalLength = Long.BYTES + keySize + Long.BYTES;
         byte[] compositeKey = new byte[totalLength];
         int pos = 0;
-
         // Write indexId (8 bytes, big endian)
-        long indexId = key.getIndexId();
         writeLongBE(compositeKey, pos, indexId);
         pos += 8;
         // Write key bytes (variable length)
-        System.arraycopy(keyBytes, 0, compositeKey, pos, keyBytes.length);
-        pos += keyBytes.length;
-        // Write timestamp (8 bytes, big endian)
-        long timestamp = key.getTimestamp();
-        writeLongBE(compositeKey, pos, timestamp);
-
+        key.copyTo(compositeKey, pos);
+        pos += keySize;
+        // Write post value (8 bytes, big endian)
+        writeLongBE(compositeKey, pos, postValue);
         return compositeKey;
+    }
+
+    // Convert IndexKey to byte array
+    protected static byte[] toKeyBytes(IndexProto.IndexKey key)
+    {
+        return toBytes(key.getIndexId(), key.getKey(), key.getTimestamp());
     }
 
     // Create composite key with rowId
-    private static byte[] toNonUniqueKey(IndexProto.IndexKey key, long rowId)
+    protected static byte[] toNonUniqueKeyBytes(IndexProto.IndexKey key, long rowId)
     {
-        byte[] keyBytes = key.getKey().toByteArray();
-        int totalLength = Long.BYTES + keyBytes.length + Long.BYTES; // indexId + key + rowId
-        byte[] compositeKey = new byte[totalLength];
-        int pos = 0;
-
-        // Copy indexId
-        long indexId = key.getIndexId();
-        writeLongBE(compositeKey, pos, indexId);
-        pos += 8;
-        // Copy keyBytes
-        System.arraycopy(keyBytes, 0, compositeKey, pos, keyBytes.length);
-        pos += keyBytes.length;
-        // Copy rowId
-        writeLongBE(compositeKey, pos, rowId);
-
-        return compositeKey;
+        return toBytes(key.getIndexId(), key.getKey(), rowId);
     }
 
     // Check if byte array starts with specified prefix
-    private boolean startsWith(byte[] array, byte[] keyBytes)
+    protected static boolean startsWith(byte[] array, byte[] keyBytes)
     {
         // prefix is indexId + key, without timestamp
         int prefixLength = keyBytes.length - Long.BYTES;
@@ -648,7 +634,7 @@ public class RocksDBIndex implements SinglePointIndex
         return true;
     }
 
-    private void setIteratorBounds(ReadOptions readOptions, byte[] keyBytes, long timestamp)
+    protected static void setIteratorBounds(ReadOptions readOptions, byte[] keyBytes, long timestamp)
     {
         // Build lower bound (timestamp = 0)
         int offset = keyBytes.length - 8;
@@ -658,7 +644,7 @@ public class RocksDBIndex implements SinglePointIndex
         }
         Slice lowerBound = new Slice(keyBytes);
         // Build upper bound (timestamp = timestamp + 1)
-        for (int i = 7; i >= 0; i--)
+        for (int i = Long.BYTES - 1; i >= 0; i--)
         {
             keyBytes[offset + i] = (byte)(timestamp & 0xFF);
             timestamp >>>= 8;
@@ -670,7 +656,7 @@ public class RocksDBIndex implements SinglePointIndex
     }
 
     // Extract rowId from key
-    private long extractRowIdFromKey(byte[] keyBytes)
+    protected static long extractRowIdFromKey(byte[] keyBytes)
     {
         // Extract rowId portion (last 8 bytes of key)
         byte[] rowIdBytes = new byte[Long.BYTES];

--- a/pixels-index/pixels-index-rocksdb/src/main/java/io/pixelsdb/pixels/index/rocksdb/RocksDBIndex.java
+++ b/pixels-index/pixels-index-rocksdb/src/main/java/io/pixelsdb/pixels/index/rocksdb/RocksDBIndex.java
@@ -318,8 +318,7 @@ public class RocksDBIndex implements SinglePointIndex
     }
 
     @Override
-    public List<Long> updatePrimaryEntries(List<IndexProto.PrimaryIndexEntry> entries)
-            throws SinglePointIndexException
+    public List<Long> updatePrimaryEntries(List<IndexProto.PrimaryIndexEntry> entries) throws SinglePointIndexException
     {
         try (WriteBatch writeBatch = new WriteBatch())
         {
@@ -464,18 +463,18 @@ public class RocksDBIndex implements SinglePointIndex
                 if(unique)
                 {
                     long rowId = getUniqueRowId(key);
-                    if(rowId < 0)   // indicates there is a transaction error, delete invalid index entry
+                    if(rowId < 0)  // indicates there is a transaction error, delete invalid index entry
                     {
                         // Return empty array if entry not found
                         return ImmutableList.of();
                     }
                     builder.add(rowId);
-                    writeBatch.put(keyBytes,newValue);
+                    writeBatch.put(keyBytes, newValue);
                 }
                 else
                 {
                     List<Long> rowIds = getRowIds(key);
-                    if(rowIds.isEmpty())    // indicates there is a transaction error, delete invalid index entry
+                    if(rowIds.isEmpty())  // indicates there is a transaction error, delete invalid index entry
                     {
                         // Return empty array if entry not found
                         return ImmutableList.of();


### PR DESCRIPTION
1. Avoid using write batch for single-point RocksDB writes.
2. Reduce memory copy in the conversion from index key to key bytes.
3. Reformat code and remove duplicated code segments.