### PR TITLE
[Issue #570] Add GitHub Workflows for Build, Daily Release, and PR Checks

### DIFF
--- a/.github/workflows/build-pixels.yml
+++ b/.github/workflows/build-pixels.yml
@@ -1,0 +1,117 @@
+name: Build Pixels
+
+on:
+  workflow_call:
+    inputs:
+      build_type:
+        required: false
+        default: "default"
+        type: string
+      skip_package:
+        required: false
+        default: false
+        type: boolean
+    outputs:
+      package_path:
+        description: "The tar.gz package path"
+        value: ${{ jobs.build.outputs.package_path }}
+      commit_hash:
+        description: "Commit hash of the build"
+        value: ${{ jobs.build.outputs.commit_hash }}
+      java_version:
+        description: "Java version"
+        value: ${{ jobs.build.outputs.java_version }}
+      cmake_version:
+        description: "CMake version"
+        value: ${{ jobs.build.outputs.cmake_version }}
+      cxx_version:
+        description: "C++ version"
+        value: ${{ jobs.build.outputs.cxx_version }}
+      build_date:
+        description: "Build date"
+        value: ${{ jobs.build.outputs.build_date }}
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      package_path: ${{ steps.package.outputs.package_path }}
+      commit_hash: ${{ steps.env_info.outputs.commit_hash }}
+      java_version: ${{ steps.env_info.outputs.java_version }}
+      cmake_version: ${{ steps.env_info.outputs.cmake_version }}
+      cxx_version: ${{ steps.env_info.outputs.cxx_version }}
+      build_date: ${{ steps.env_info.outputs.build_date }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Java 8
+        uses: actions/setup-java@v4
+        with:
+          java-version: '8'
+          distribution: 'temurin'
+
+      - name: Set PIXELS_HOME
+        run: |
+          export PIXELS_HOME="${{ github.workspace }}/pixels_home"
+          mkdir -p "$PIXELS_HOME/lib"
+          echo "PIXELS_HOME=$PIXELS_HOME" >> $GITHUB_ENV
+
+      - name: Cache Maven dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Cache MySQL Connector/J
+        id: cache-mysql
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/mysql-connector
+          key: mysql-connector-j-9.1.0
+
+      - name: Download MySQL Connector/J
+        if: ${{ steps.cache-mysql.outputs.cache-hit != 'true' && !inputs.skip_package }}
+        run: |
+          mkdir -p "${{ github.workspace }}/mysql-connector"
+          wget -q https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-j-9.1.0.tar.gz -O "${{ github.workspace }}/mysql-connector/mysql.tar.gz"
+          tar -xzf "${{ github.workspace }}/mysql-connector/mysql.tar.gz" -C "${{ github.workspace }}/mysql-connector"
+
+      - name: Prepare Pixels Lib
+        if: ${{ !inputs.skip_package }}
+        run: |
+          MYSQL_JAR=$(find "${{ github.workspace }}/mysql-connector" -maxdepth 2 -name "mysql-connector-j-*.jar" | head -n 1)
+          cp "$MYSQL_JAR" "$PIXELS_HOME/lib/"
+
+      - name: Build Pixels
+        run: bash ./install.sh
+
+      - name: Get environment info
+        id: env_info
+        run: |
+          BUILD_DATE=$(date -u +'%Y-%m-%d')
+          echo "commit_hash=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+          echo "java_version=$(java -version 2>&1 | head -n 1)" >> $GITHUB_OUTPUT
+          echo "cmake_version=$(cmake --version | head -n 1)" >> $GITHUB_OUTPUT
+          echo "cxx_version=$(g++ --version | head -n 1)" >> $GITHUB_OUTPUT
+          echo "build_date=${BUILD_DATE}" >> $GITHUB_OUTPUT
+
+      - name: Prepare release package
+        id: package
+        if: ${{ !inputs.skip_package }}
+        run: |
+          cd "${PIXELS_HOME}/.."
+          PACKAGE_PATH="pixels-${{ steps.env_info.outputs.build_date }}.tar.gz"
+          tar czf "${PACKAGE_PATH}" "$(basename $PIXELS_HOME)"
+          echo "package_path=${PACKAGE_PATH}" >> $GITHUB_OUTPUT
+
+      - name: Upload build artifact
+        if: ${{ !inputs.skip_package }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: pixels-package
+          path: ${{ steps.package.outputs.package_path }}

--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -1,0 +1,70 @@
+name: Pixels Daily Build and Release
+
+on:
+  schedule:
+    - cron: '30 1 * * *'
+  workflow_dispatch:
+
+jobs:
+  remove:
+    uses: ./.github/workflows/remove-daily-latest.yml
+    secrets:
+      gh_token: ${{ secrets.PIXELS_DEVELOP }}
+
+  build:
+    uses: ./.github/workflows/build-pixels.yml
+    with:
+      build_type: "daily"
+      skip_package: false
+
+  release:
+    needs: [remove, build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download build artifact
+        uses: actions/download-artifact@v5
+        with:
+          name: pixels-package
+          path: ./downloaded_package
+
+      - name: Update daily-latest tag to latest commit
+        run: |
+          git tag -d daily-latest || true
+          git push origin --delete daily-latest || true
+          git tag daily-latest
+          git push origin daily-latest
+        env:
+          GH_TOKEN: ${{ secrets.PIXELS_DEVELOP }}
+
+      - name: Create or Update Daily Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: daily-latest
+          name: "Pixels Daily Build ${{ needs.build.outputs.build_date }}"
+          body: |
+            Automated daily build created at ${{ needs.build.outputs.build_date }}.
+            Environment:
+            - Commit: ${{ needs.build.outputs.commit_hash }}
+            - Java: ${{ needs.build.outputs.java_version }}
+            - CMake: ${{ needs.build.outputs.cmake_version }}
+            - C++: ${{ needs.build.outputs.cxx_version }}
+          files: ./downloaded_package/pixels-*.tar.gz
+          prerelease: true
+          draft: false
+        env:
+          GH_TOKEN: ${{ secrets.PIXELS_DEVELOP }}
+
+  cleanup-artifact:
+    needs: [release]
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Remove old artifacts
+        uses: c-hive/gha-remove-artifacts@v1
+        with:
+          github_token: ${{ secrets.PIXELS_DEVELOP }}
+          age: '1 day'

--- a/.github/workflows/pr-build-check.yml
+++ b/.github/workflows/pr-build-check.yml
@@ -1,0 +1,14 @@
+name: Pull Request Build Check
+
+on:
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  verify:
+    uses: ./.github/workflows/build-pixels.yml
+    with:
+      build_type: "pr"
+      skip_package: true

--- a/.github/workflows/remove-daily-latest.yml
+++ b/.github/workflows/remove-daily-latest.yml
@@ -1,0 +1,26 @@
+name: Remove daily-latest release
+
+on:
+  workflow_dispatch:
+  workflow_call:
+    secrets:
+      gh_token:
+        required: true
+
+jobs:
+  remove-daily-latest-assets:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Remove old assets from daily-latest
+        run: |
+          assets=$(gh release view daily-latest --json assets --jq '.assets[].name')
+          for a in $assets; do
+            gh release delete-asset daily-latest "$a" -y
+          done
+        env:
+          GH_TOKEN: ${{ secrets.gh_token }}

--- a/README.md
+++ b/README.md
@@ -62,6 +62,16 @@ and build it using `mvn package` in the local git repository.
 > a later JDK (e.g., Trino 405/466 requires JDK17.0.3+/23.0.0+) and Maven.
 > It is fine to build the query engine integration (e.g., `pixels-trino`) with the same or higher versions of JDK and Maven than Pixels.
 
+### Daily Build Release
+
+If you want to try the latest daily build of Pixels without building from source, you can download it from the automated daily releases:
+
+[![Pixels Daily Build](https://github.com/pixelsdb/pixels/actions/workflows/daily-build.yml/badge.svg)](https://github.com/pixelsdb/pixels/releases/tag/daily-latest)
+
+- The daily build includes the latest changes from the repository.  
+- Suitable for testing and early feedback, not recommended for production use.  
+- Contains pre-built `pixels-daemon` and `pixels-cli` jar files, ready to use.
+
 
 ## Develop Pixels in IntelliJ
 


### PR DESCRIPTION
To use these workflows, we need to generate a fine-grained token via [Fine-grained Personal Access Tokens](https://github.com/settings/personal-access-tokens)

1. Under Repository access, select `Only select repositories` and choose the Pixels repository.
2. Under Permissions, grant `Contents`: Read and write access.
3. Add the generated token to the repository's secrets with the key `PIXELS_DEVELOP`
---

This PR introduces GitHub workflows to automate the build and release process for Pixels:

- Build Workflow: 
    - The Build Workflow uses the `./install.sh` script and packages the contents of `PIXELS_HOME` as an artifact.

- Daily Build & Release Workflow: 
    - Uses the build artifacts to create a daily release automatically.
    - Triggered daily at 01:30 UTC and publishes the artifact under tag `daily-latest`
    - The effect can be previewed at: [Release Pixels Daily Build 2025-10-16 · AntiO2/pixels](https://github.com/AntiO2/pixels/releases/tag/daily-latest)

- PR Check Workflow: Triggered on PR creation and ensures that the project can build successfully.

These workflows aim to streamline development, reduce manual effort, and ensure consistent build and release procedures.

---

When the Maven cache is valid, each build takes about 2.5 minutes, and each release takes about 4 minutes.
If the Maven dependencies cache expires, it requires an additional 1 minute.
Each month, we can use up to 2000 minutes of workflow time for free. In other words, we can perform daily releases and run approximately 600 PR checks each month.