### PR TITLE
[Issue #1162] special characters used as delimiters (such as |) must be escaped

### DIFF
--- a/pixels-cli/src/main/java/io/pixelsdb/pixels/cli/load/PixelsConsumer.java
+++ b/pixels-cli/src/main/java/io/pixelsdb/pixels/cli/load/PixelsConsumer.java
@@ -49,6 +49,7 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Pattern;
 
 /**
  * @author: tao
@@ -190,7 +191,7 @@ public class PixelsConsumer extends Consumer
                         rowBatch.size++;
                         rowCounter++;
 
-                        String[] colsInLine = line.split(regex);
+                        String[] colsInLine = line.split(Pattern.quote(regex));
                         for (int i = 0; i < columnVectors.length - 1; i++)
                         {
                             try


### PR DESCRIPTION
<img width="2335" height="246" alt="image" src="https://github.com/user-attachments/assets/87b8e82a-44fb-4909-9e63-70dc1de9427e" />