### PR TITLE
[Issue #1167] allow pasting multiple lines of commands at once in the pixels CLI

### DIFF
--- a/pixels-cli/src/main/java/io/pixelsdb/pixels/cli/Main.java
+++ b/pixels-cli/src/main/java/io/pixelsdb/pixels/cli/Main.java
@@ -92,7 +92,7 @@ public class Main
         reader.setOpt(LineReader.Option.BRACKETED_PASTE);
 
         String prompt = "pixels> ";
-        String multiLineInput;
+        String multiLineInput = "";
 
         while (true)
         {
@@ -102,7 +102,7 @@ public class Main
             } catch (UserInterruptException e)
             {
                 // Ctrl+C
-                continue;
+                System.exit(130);
             } catch (EndOfFileException e)
             {
                 // Issue #631: in case of input from a file, exit at EOF.
@@ -128,7 +128,7 @@ public class Main
                         inputStr.equalsIgnoreCase("-q"))
                 {
                     System.out.println("Bye.");
-                    break;
+                    return;
                 }
 
                 if (inputStr.equalsIgnoreCase("help") || inputStr.equalsIgnoreCase("-h"))


### PR DESCRIPTION
Complete the following modifications to pixels cli:
1. Enable multi-line input
2. Exit the program with Ctrl+C, status code 130