### PR TITLE
[Issue #1138] RocksDB index cannot retrieve unique row ID after put operation

### DIFF
--- a/pixels-common/src/main/resources/pixels.properties
+++ b/pixels-common/src/main/resources/pixels.properties
@@ -4,7 +4,7 @@ pixels.var.dir=/home/pixels/opt/pixels/var/
 # metadata database connection properties
 metadata.db.driver=com.mysql.cj.jdbc.Driver
 metadata.db.user=pixels
-metadata.db.password=password123456Q%
+metadata.db.password=password
 metadata.db.url=jdbc:mysql://localhost:3306/pixels_metadata?useUnicode=true&characterEncoding=UTF-8&zeroDateTimeBehavior=convertToNull
 # metadata server host and port
 metadata.server.port=18888

--- a/pixels-index/pixels-index-rocksdb/src/main/java/io/pixelsdb/pixels/index/rocksdb/ReadOptionsThreadFactory.java
+++ b/pixels-index/pixels-index-rocksdb/src/main/java/io/pixelsdb/pixels/index/rocksdb/ReadOptionsThreadFactory.java
@@ -1,3 +1,22 @@
+/*
+ * Copyright 2025 PixelsDB.
+ *
+ * This file is part of Pixels.
+ *
+ * Pixels is free software: you can redistribute it and/or modify
+ * it under the terms of the Affero GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * Pixels is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Affero GNU General Public License for more details.
+ *
+ * You should have received a copy of the Affero GNU General Public
+ * License along with Pixels.  If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
 package io.pixelsdb.pixels.index.rocksdb;
 
 import org.rocksdb.ReadOptions;


### PR DESCRIPTION
use ThreadLocal readOptions to make it thread-safe.