### PR TITLE
[Issue #1186] avoid reading duplicated versions in the getRowIds methods of rocksdb index and mapdb index

### DIFF
--- a/pixels-index/pixels-index-mapdb/src/main/java/io/pixelsdb/pixels/index/mapdb/MapDBIndex.java
+++ b/pixels-index/pixels-index-mapdb/src/main/java/io/pixelsdb/pixels/index/mapdb/MapDBIndex.java
@@ -34,9 +34,7 @@ import org.mapdb.DBMaker;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static io.pixelsdb.pixels.index.mapdb.MapDBThreadResources.EMPTY_VALUE_BUFFER;
@@ -149,7 +147,7 @@ public class MapDBIndex implements SinglePointIndex
         {
             return ImmutableList.of(getUniqueRowId(key));
         }
-        ImmutableList.Builder<Long> builder = ImmutableList.builder();
+        Set<Long> rowIds = new HashSet<>();
         ByteBuffer lowerBound = toKeyBuffer(key);
         ByteBuffer upperBound = toUpperBoundKeyBuffer(key);
         Iterator<ByteBuffer> iterator = indexMap.keyIterator(lowerBound, true, upperBound, true);
@@ -161,9 +159,10 @@ public class MapDBIndex implements SinglePointIndex
             {
                 break;
             }
-            builder.add(rowId);
+            // Issue #1186: index keys with the same row id are considered as different versions of the same entry
+            rowIds.add(rowId);
         }
-        return builder.build();
+        return ImmutableList.copyOf(rowIds);
     }
 
     @Override

--- a/pixels-index/pixels-index-rocksdb/src/test/java/io/pixelsdb/pixels/index/rocksdb/TestRocksDBIndexExtensive.java
+++ b/pixels-index/pixels-index-rocksdb/src/test/java/io/pixelsdb/pixels/index/rocksdb/TestRocksDBIndexExtensive.java
@@ -28,6 +28,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.rocksdb.RocksDBException;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -93,6 +94,35 @@ public class TestRocksDBIndexExtensive
                 .setIndexKey(createIndexKey(keyValue, timestamp))
                 .setRowId(rowId)
                 .build();
+    }
+
+    @Test
+    public void testPerformance() throws SinglePointIndexException
+    {
+        long startTime = System.currentTimeMillis();
+        for (long i = 0; i < 1000000L; ++i)
+        {
+            IndexProto.IndexKey key = createIndexKey("key" + i, 1000L);
+            uniqueIndex.putEntry(key, i);
+        }
+        System.out.println("put 1M entries in: " + (System.currentTimeMillis() - startTime) + " ms");
+        startTime = System.currentTimeMillis();
+        for (long i = 0; i < 1000000L; ++i)
+        {
+            IndexProto.IndexKey key = createIndexKey("key" + i, 1001L);
+            uniqueIndex.updatePrimaryEntry(key, i+1);
+        }
+        System.out.println("update 1M entries in: " + (System.currentTimeMillis() - startTime) + " ms");
+        List<IndexProto.IndexKey> indexKeys = new ArrayList<>(1000000);
+        startTime = System.currentTimeMillis();
+        for (long i = 0; i < 1000000L; ++i)
+        {
+            IndexProto.IndexKey key = createIndexKey("key" + i, 1002L);
+            indexKeys.add(key);
+            uniqueIndex.deleteEntry(key);
+        }
+        System.out.println("delete 1M entries in: " + (System.currentTimeMillis() - startTime) + " ms");
+        uniqueIndex.purgeEntries(indexKeys);
     }
 
     // Test basic properties


### PR DESCRIPTION
Close #1186.