### PR TITLE
[Issue #1248] fix missing RetinaService resolution when querying tables without primary index

### DIFF
--- a/pixels-cli/src/main/java/io/pixelsdb/pixels/cli/load/SimplePixelsConsumer.java
+++ b/pixels-cli/src/main/java/io/pixelsdb/pixels/cli/load/SimplePixelsConsumer.java
@@ -126,7 +126,7 @@
          {
              targetDirPath += "/";
          }
-         String targetFileName = Constants.LOAD_DEFAULT_RETINA_PREFIX + DateUtil.getCurTime() + ".pxl";
+         String targetFileName = Constants.LOAD_DEFAULT_RETINA_PREFIX + "_" + DateUtil.getCurTime() + ".pxl";
          String targetFilePath = targetDirPath + targetFileName;
 
          pixelsWriter = PixelsWriterImpl.newBuilder()

--- a/pixels-common/src/main/java/io/pixelsdb/pixels/common/utils/Constants.java
+++ b/pixels-common/src/main/java/io/pixelsdb/pixels/common/utils/Constants.java
@@ -98,7 +98,7 @@ public final class Constants
 
     public static final String CF_OUTPUT_STATE_KEY_PREFIX = "pixels_turbo_cf_output";
 
-    public static final String LOAD_DEFAULT_RETINA_PREFIX = "default_retina_";
+    public static final String LOAD_DEFAULT_RETINA_PREFIX = "default-retina";
 
     public static final int LEASE_TIME_SKEW_MS = 500;
     public static final int LEASE_NETWORK_LATENCY_MS = 500;


### PR DESCRIPTION
Fix an issue where the corresponding RetinaService cannot be resolved when querying tables that do not have a primary index.