### PR TITLE
[Issue #1254] implement multi-threaded flush

### DIFF
--- a/pixels-common/src/main/resources/pixels.properties
+++ b/pixels-common/src/main/resources/pixels.properties
@@ -275,6 +275,8 @@ retina.buffer.memTable.size=10240
 retina.buffer.object.storage.scheme=s3
 # the folder path for retina buffer object storage
 retina.buffer.object.storage.folder=s3://object-storage
+# number of threads to flush shared storage
+retina.buffer.object.flush.threads=4
 # default encoding level is EL2
 retina.buffer.flush.encodingLevel=2
 # default no nulls padding

--- a/pixels-retina/src/main/java/io/pixelsdb/pixels/retina/PixelsWriteBuffer.java
+++ b/pixels-retina/src/main/java/io/pixelsdb/pixels/retina/PixelsWriteBuffer.java
@@ -77,7 +77,7 @@ public class PixelsWriteBuffer
     private final Storage targetCompactStorage;
     private final RowIdAllocator rowIdAllocator;
     /**
-     * Allocate unique identifier for data (MemTable/MinioEntry).
+     * Allocate unique identifier for data (MemTable/ObjectEntry).
      * There is no need to use atomic variables because
      * there are write locks in all concurrent situations.
      */
@@ -97,9 +97,9 @@ public class PixelsWriteBuffer
     private volatile SuperVersion currentVersion;
 
     // backend flush thread
-    private final ExecutorService flushMinioExecutor;
-    private final ScheduledExecutorService flushDiskExecutor;
-    private ScheduledFuture<?> flushDiskFuture;
+    private final ExecutorService flushObjectExecutor;
+    private final ScheduledExecutorService flushFileExecutor;
+    private ScheduledFuture<?> flushFileFuture;
 
     // lock for SuperVersion switch
     private final ReadWriteLock versionLock = new ReentrantReadWriteLock();
@@ -107,7 +107,16 @@ public class PixelsWriteBuffer
     private int currentMemTableCount;
     private final Queue<FileWriterManager> fileWriterManagers;
     private FileWriterManager currentFileWriterManager;
-    private AtomicLong maxObjectKey;
+
+    /**
+     * Issue #1254: Multi-threaded flush
+     * Add `outOfOrderFlushedIds` to store flushed IDs, and `continuousFlushedId`
+     * to represent the maximum value of consecutively flushed IDs.
+     */
+    private AtomicLong continuousFlushedId;
+    private final PriorityQueue<Long> outOfOrderFlushedIds;
+    private final Object flushLock = new Object();
+
     private String retinaHostName;
 
     public PixelsWriteBuffer(long tableId, TypeDescription schema, Path targetOrderedDirPath,
@@ -138,11 +147,12 @@ public class PixelsWriteBuffer
         this.immutableMemTables = new ArrayList<>();
         this.objectEntries = new ArrayList<>();
 
-        this.flushMinioExecutor = Executors.newSingleThreadExecutor();
-        this.flushDiskExecutor = Executors.newSingleThreadScheduledExecutor();
+        this.flushObjectExecutor = Executors.newFixedThreadPool(Integer.parseInt(configFactory.getProperty("retina.buffer.object.flush.threads")));
+        this.flushFileExecutor = Executors.newSingleThreadScheduledExecutor();
 
         this.fileWriterManagers = new ConcurrentLinkedQueue<>();
-        this.maxObjectKey = new AtomicLong(-1);
+        this.continuousFlushedId = new AtomicLong(-1);
+        this.outOfOrderFlushedIds = new PriorityQueue<>();
 
         this.retinaHostName = retinaHostName;
         this.objectStorageManager = ObjectStorageManager.Instance();
@@ -164,7 +174,7 @@ public class PixelsWriteBuffer
         this.currentVersion = new SuperVersion(activeMemTable, immutableMemTables, objectEntries);
         this.rowIdAllocator = new RowIdAllocator(tableId, this.memTableSize, IndexServiceProvider.ServiceMode.local);
 
-        startFlushMinioToDiskScheduler(Long.parseLong(configFactory.getProperty("retina.buffer.flush.interval")));
+        startFlushObjectToFileScheduler(Long.parseLong(configFactory.getProperty("retina.buffer.flush.interval")));
     }
 
     /**
@@ -257,7 +267,7 @@ public class PixelsWriteBuffer
             this.currentVersion = new SuperVersion(this.activeMemTable, this.immutableMemTables, this.objectEntries);
             oldVersion.unref();
 
-            triggerFlushToMinio(oldMemTable);
+            triggerFlushToObject(oldMemTable);
         } catch (Exception e)
         {
             throw new RetinaException("Failed to switch memtable", e);
@@ -267,12 +277,12 @@ public class PixelsWriteBuffer
         }
     }
 
-    private void triggerFlushToMinio(MemTable flushMemTable)
+    private void triggerFlushToObject(MemTable flushMemTable)
     {
-        flushMinioExecutor.submit(() -> {
+        flushObjectExecutor.submit(() -> {
             try
             {
-                // put into minio
+                // put into object storage
                 long id = flushMemTable.getId();
                 this.objectStorageManager.write(this.tableId, id, flushMemTable.serialize());
 
@@ -280,7 +290,23 @@ public class PixelsWriteBuffer
                         flushMemTable.getStartIndex(), flushMemTable.getLength());
                 objectEntry.ref();
 
-                this.maxObjectKey.updateAndGet(current -> Math.max(current, id));
+                // update watermark
+                synchronized (flushLock)
+                {
+                    long nextId = continuousFlushedId.get() + 1;
+                    if (id == nextId)
+                    {
+                        continuousFlushedId.incrementAndGet();
+                        while (!outOfOrderFlushedIds.isEmpty() && outOfOrderFlushedIds.peek() == continuousFlushedId.get() + 1)
+                        {
+                            outOfOrderFlushedIds.poll();
+                            continuousFlushedId.incrementAndGet();
+                        }
+                    } else
+                    {
+                        outOfOrderFlushedIds.add(id);
+                    }
+                }
 
                 // update SuperVersion
                 versionLock.writeLock().lock();
@@ -328,19 +354,19 @@ public class PixelsWriteBuffer
 
     /**
      * Determine whether the last data block managed by fileWriterManager has
-     * been written to MinIO. If it has been written, execute the file write
+     * been written to Object. If it has been written, execute the file write
      * operation and delete the corresponding ObjectEntry in the unified view.
      */
-    private void startFlushMinioToDiskScheduler(long intervalSeconds)
+    private void startFlushObjectToFileScheduler(long intervalSeconds)
     {
-        this.flushDiskFuture = this.flushDiskExecutor.scheduleWithFixedDelay(() -> {
+        this.flushFileFuture = this.flushFileExecutor.scheduleWithFixedDelay(() -> {
             try
             {
                 Iterator<FileWriterManager> iterator = this.fileWriterManagers.iterator();
                 while (iterator.hasNext())
                 {
                     FileWriterManager fileWriterManager = iterator.next();
-                    if (fileWriterManager.getLastBlockId() <= this.maxObjectKey.get())
+                    if (fileWriterManager.getLastBlockId() <= this.continuousFlushedId.get())
                     {
                         CompletableFuture<Void> finished = fileWriterManager.finish();
                         iterator.remove();
@@ -383,33 +409,33 @@ public class PixelsWriteBuffer
     public void close() throws RetinaException
     {
         // First, shut down the flush process to prevent changes to the data view.
-        this.flushMinioExecutor.shutdown();
+        this.flushObjectExecutor.shutdown();
         try
         {
-            if (!this.flushMinioExecutor.awaitTermination(60, TimeUnit.SECONDS))
+            if (!this.flushObjectExecutor.awaitTermination(60, TimeUnit.SECONDS))
             {
-                this.flushMinioExecutor.shutdownNow();
+                this.flushObjectExecutor.shutdownNow();
             }
         } catch (InterruptedException e)
         {
-            this.flushMinioExecutor.shutdownNow();
+            this.flushObjectExecutor.shutdownNow();
             Thread.currentThread().interrupt();
-            throw new RetinaException("Close process was interrupted while waiting for flushMinioExecutor", e);
+            throw new RetinaException("Close process was interrupted while waiting for flushObjectExecutor", e);
         }
-        if (this.flushDiskFuture != null)
+        if (this.flushFileFuture != null)
         {
-            this.flushDiskFuture.cancel(false);
+            this.flushFileFuture.cancel(false);
         }
-        this.flushDiskExecutor.shutdown();
+        this.flushFileExecutor.shutdown();
         try
         {
-            if (!this.flushDiskExecutor.awaitTermination(60, TimeUnit.SECONDS))
+            if (!this.flushFileExecutor.awaitTermination(60, TimeUnit.SECONDS))
             {
-                this.flushDiskExecutor.shutdownNow();
+                this.flushFileExecutor.shutdownNow();
             }
         } catch (InterruptedException e)
         {
-            this.flushDiskExecutor.shutdownNow();
+            this.flushFileExecutor.shutdownNow();
             Thread.currentThread().interrupt();
             throw new RetinaException("Close process was interrupted while waiting for flushDiskExecutor", e);
         }
@@ -418,7 +444,7 @@ public class PixelsWriteBuffer
         List<CompletableFuture<Void>> futures = new ArrayList<>();
         try
         {
-            long maxObjectKey = this.maxObjectKey.get();
+            long maxObjectKey = this.continuousFlushedId.get();
 
             // process current fileWriterManager
             this.currentFileWriterManager.setLastBlockId(maxObjectKey);
@@ -442,7 +468,7 @@ public class PixelsWriteBuffer
                 firstBlockId = fileWriterManager.getFirstBlockId();
                 long lastBlockId = fileWriterManager.getLastBlockId();
 
-                // all written to minio
+                // all written to object
                 if (lastBlockId <= maxObjectKey)
                 {
                     futures.add(fileWriterManager.finish());
@@ -461,7 +487,7 @@ public class PixelsWriteBuffer
                         }
                     }
 
-                    // elements in minio will be processed in finish() later
+                    // elements in object will be processed in finish() later
                     fileWriterManager.setLastBlockId(maxObjectKey);
                     futures.add(fileWriterManager.finish());
                 }


### PR DESCRIPTION
`pixels-storage-s3` is already supported fragmented uploads. So just implement immutable-memtable's multi-threaded flush.