### PR TITLE
[Issue #1082] support message grouping and terminating in S3QS

### DIFF
--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/PixelsWriterImpl.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/PixelsWriterImpl.java
@@ -344,12 +344,16 @@ public class PixelsWriterImpl implements PixelsWriter
             requireNonNull(this.builderStorage, "storage is not set");
             requireNonNull(this.builderFilePath, "file path is not set");
 
-            if(this.builderPhysicalWriter == null){
-                try {
+            if(this.builderPhysicalWriter == null)
+            {
+                try
+                {
                     this.builderPhysicalWriter = PhysicalWriterUtil.newPhysicalWriter(
                             this.builderStorage, this.builderFilePath, this.builderBlockSize, this.builderReplication,
                             this.builderBlockPadding, this.builderOverwrite);
-                } catch (IOException e) {
+                }
+                catch (IOException e)
+                {
                     LOGGER.error("Failed to create PhysicalWriter");
                     throw new PixelsWriterException(
                             "Failed to create PixelsWriter due to error of creating PhysicalWriter", e);
@@ -361,8 +365,6 @@ public class PixelsWriterImpl implements PixelsWriter
                             "Failed to create PixelsWriter due to error of creating PhysicalWriter");
                 }
             }
-
-
 
             return new PixelsWriterImpl(
                     builderSchema,

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/PixelsWriterStreamImpl.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/PixelsWriterStreamImpl.java
@@ -314,10 +314,13 @@ public class PixelsWriterStreamImpl implements PixelsWriter
             PhysicalWriter fsWriter = this.fsWriter;
             if (fsWriter == null)
             {
-                try {
+                try
+                {
                     fsWriter = PhysicalWriterUtil.newPhysicalWriter(
                             this.builderStorage, this.builderFilePath, null);
-                } catch (IOException e) {
+                }
+                catch (IOException e)
+                {
                     LOGGER.error("Failed to create PhysicalWriter");
                     throw new PixelsWriterException(
                             "Failed to create PixelsWriter due to error of creating PhysicalWriter", e);
@@ -604,7 +607,8 @@ public class PixelsWriterStreamImpl implements PixelsWriter
                 columnWriters[i] = newColumnWriter(children.get(i), columnWriterOption);
             }
             physicalWriter.flush();
-        } catch (IOException e)
+        }
+        catch (IOException e)
         {
             LOGGER.error(e.getMessage());
             throw e;

--- a/pixels-storage/pixels-storage-s3qs/src/main/java/io/pixelsdb/pixels/storage/s3qs/PhysicalS3QSReader.java
+++ b/pixels-storage/pixels-storage-s3qs/src/main/java/io/pixelsdb/pixels/storage/s3qs/PhysicalS3QSReader.java
@@ -74,7 +74,8 @@ public class PhysicalS3QSReader implements PhysicalReader
             this.buffer = responseBytes.asByteArrayUnsafe();
             this.length = this.buffer.length;
             this.position = 0;
-        } catch (Exception e)
+        }
+        catch (Exception e)
         {
             this.position = 0;
             throw new IOException("Failed to read object.", e);

--- a/pixels-storage/pixels-storage-s3qs/src/main/java/io/pixelsdb/pixels/storage/s3qs/PhysicalS3QSWriter.java
+++ b/pixels-storage/pixels-storage-s3qs/src/main/java/io/pixelsdb/pixels/storage/s3qs/PhysicalS3QSWriter.java
@@ -123,7 +123,9 @@ public class PhysicalS3QSWriter implements PhysicalWriter
             {
                 this.queue.push(this.pathStr);
             }
-        }catch (IOException e){
+        }
+        catch (IOException e)
+        {
             throw e;
         }
     }

--- a/pixels-storage/pixels-storage-s3qs/src/main/java/io/pixelsdb/pixels/storage/s3qs/S3Queue.java
+++ b/pixels-storage/pixels-storage-s3qs/src/main/java/io/pixelsdb/pixels/storage/s3qs/S3Queue.java
@@ -183,10 +183,13 @@ public class S3Queue implements Closeable
                             this.s3PathQueue.add(new AbstractMap.SimpleEntry<>(path, receiptHandle));
 
                             String countStr = message.attributes().get(APPROXIMATE_RECEIVE_COUNT);
-                            if (countStr == null) {
+                            if (countStr == null)
+                            {
                                 // If no value is returned, it may be because the property was not requested or the message does not contain that property.
                                 throw new TaskErrorException("ApproximateReceiveCount not returned");
-                            } else {
+                            }
+                            else
+                            {
                                 int count = Integer.parseInt(countStr);
                                 // because we can only promise two receipts can be handled
                                 if (count > 2) throw new TaskErrorException("Dead message occurred");
@@ -229,7 +232,8 @@ public class S3Queue implements Closeable
             SendMessageRequest request = SendMessageRequest.builder()
                     .queueUrl(queueUrl).messageBody(objectPath).build();
             sqsClient.sendMessage(request);
-        }catch (Exception e)
+        }
+        catch (Exception e)
         {
             throw new IOException("sqs: fail to send message.",e);
         }

--- a/pixels-storage/pixels-storage-s3qs/src/main/java/io/pixelsdb/pixels/storage/s3qs/S3QueueMessage.java
+++ b/pixels-storage/pixels-storage-s3qs/src/main/java/io/pixelsdb/pixels/storage/s3qs/S3QueueMessage.java
@@ -1,3 +1,22 @@
+/*
+ * Copyright 2025 PixelsDB.
+ *
+ * This file is part of Pixels.
+ *
+ * Pixels is free software: you can redistribute it and/or modify
+ * it under the terms of the Affero GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * Pixels is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Affero GNU General Public License for more details.
+ *
+ * You should have received a copy of the Affero GNU General Public
+ * License along with Pixels.  If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
 package io.pixelsdb.pixels.storage.s3qs;
 
 /**
@@ -15,19 +34,23 @@ public class S3QueueMessage
     private long timestamp = System.currentTimeMillis();
     private String metadata = "";
 
-    public S3QueueMessage() {
+    public S3QueueMessage()
+    {
     }
 
-    public S3QueueMessage(String objectPath) {
+    public S3QueueMessage(String objectPath)
+    {
         this.objectPath = objectPath;
         this.timestamp = System.currentTimeMillis();
     }
 
-    public String getObjectPath() {
+    public String getObjectPath() 
+    {
         return objectPath;
     }
 
-    public S3QueueMessage setObjectPath(String objectPath) {
+    public S3QueueMessage setObjectPath(String objectPath)
+    {
         this.objectPath = objectPath;
         return this;
     }
@@ -36,52 +59,63 @@ public class S3QueueMessage
         return this.workerNum;
     }
 
-    public S3QueueMessage setWorkerNum(int WorkerNum) {
+    public S3QueueMessage setWorkerNum(int WorkerNum)
+    {
         this.workerNum = WorkerNum;
         return this;
     }
 
-    public int getPartitionNum() {
+    public int getPartitionNum() 
+    {
         return this.partitionNum;
     }
 
-    public S3QueueMessage setPartitionNum(int PartitionNum) {
+    public S3QueueMessage setPartitionNum(int PartitionNum)
+    {
         this.partitionNum = PartitionNum;
         return this;
     }
 
-    public boolean getEndWork() {
+    public boolean getEndWork() 
+    {
         return this.endWork;
     }
 
-    public S3QueueMessage setEndwork(boolean endwork) {
+    public S3QueueMessage setEndwork(boolean endwork)
+    {
         this.endWork = endwork;
         return this;
     }
 
-    public String getReceiptHandle() {
+    public String getReceiptHandle() 
+    {
         return this.receiptHandle;
     }
 
-    public S3QueueMessage setReceiptHandle(String ReceiptHandle) {
+    public S3QueueMessage setReceiptHandle(String ReceiptHandle)
+    {
         this.receiptHandle = ReceiptHandle;
         return this;
     }
 
-    public long getTimestamp() {
+    public long getTimestamp() 
+    {
         return timestamp;
     }
 
-    public S3QueueMessage setTimestamp(long timestamp) {
+    public S3QueueMessage setTimestamp(long timestamp)
+    {
         this.timestamp = timestamp;
         return this;
     }
 
-    public String getMetadata() {
+    public String getMetadata() 
+    {
         return metadata;
     }
 
-    public S3QueueMessage setMetadata(String metadata) {
+    public S3QueueMessage setMetadata(String metadata)
+    {
         this.metadata = metadata;
         return this;
     }

--- a/pixels-storage/pixels-storage-s3qs/src/main/java/io/pixelsdb/pixels/storage/s3qs/exception/TaskErrorException.java
+++ b/pixels-storage/pixels-storage-s3qs/src/main/java/io/pixelsdb/pixels/storage/s3qs/exception/TaskErrorException.java
@@ -1,3 +1,22 @@
+/*
+ * Copyright 2025 PixelsDB.
+ *
+ * This file is part of Pixels.
+ *
+ * Pixels is free software: you can redistribute it and/or modify
+ * it under the terms of the Affero GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * Pixels is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Affero GNU General Public License for more details.
+ *
+ * You should have received a copy of the Affero GNU General Public
+ * License along with Pixels.  If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
 package io.pixelsdb.pixels.storage.s3qs.exception;
 
 /**

--- a/pixels-storage/pixels-storage-s3qs/src/test/java/io/pixelsdb/pixels/storage/s3qs/TestS3QS.java
+++ b/pixels-storage/pixels-storage-s3qs/src/test/java/io/pixelsdb/pixels/storage/s3qs/TestS3QS.java
@@ -75,9 +75,11 @@ public class TestS3QS
                         .setWorkerNum(2+i);
                 PhysicalReader reader = null;
                 String receiptHandle = null;
-                try{
+                try
+                {
                     HashMap.Entry<String,PhysicalReader>  pair = s3qs.poll(body,20);
-                    if(pair != null) {
+                    if(pair != null)
+                    {
                         reader = pair.getValue();
                         receiptHandle = pair.getKey();
                         body.setReceiptHandle(receiptHandle);
@@ -89,16 +91,24 @@ public class TestS3QS
                     System.err.println("Error in iteration " + i + ": " + e.getMessage());
                     throw new RuntimeException(e);
                 }
-                finally {
-                    if(reader != null){
-                        try {
+                finally
+                {
+                    if(reader != null)
+                    {
+                        try
+                        {
                             reader.close();
-                        } catch (IOException e) {
+                        }
+                        catch (IOException e)
+                        {
                                 throw new RuntimeException(e);
                         }
-                        try {
+                        try
+                        {
                             s3qs.finishWork(body);
-                        } catch (IOException e) {
+                        }
+                        catch (IOException e)
+                        {
                             throw new RuntimeException(e);
                         }
                     }
@@ -116,9 +126,12 @@ public class TestS3QS
             }
         });
 
-        try {
+        try
+        {
             future.get();
-        } catch (ExecutionException e) {
+        }
+        catch (ExecutionException e)
+        {
             //e.getCause().printStackTrace();
             throw e;
         }
@@ -133,7 +146,8 @@ public class TestS3QS
         S3QS s3qs = (S3QS) StorageFactory.Instance().getStorage(Storage.Scheme.s3qs);
         //S3Queue queue = s3qs.openQueue("https://sqs.us-east-2.amazonaws.com/970089764833/pixels-shuffle");
 
-        Future<?> future = this.executor.submit(() -> {
+        Future<?> future = this.executor.submit(() ->
+        {
             byte[] buffer = new byte[8 * 1024 * 1024];
             long startTime = System.currentTimeMillis();
             for (int i = 0; i < 2; i++)
@@ -165,9 +179,12 @@ public class TestS3QS
             }
         });
 
-        try {
+        try
+        {
             future.get();
-        } catch (ExecutionException e) {
+        }
+        catch (ExecutionException e)
+        {
             //e.getCause().printStackTrace();
             throw e;
         }
@@ -181,7 +198,8 @@ public class TestS3QS
     {
         S3QS s3qs = (S3QS) StorageFactory.Instance().getStorage(Storage.Scheme.s3qs);
 
-        Future<?> future = this.executor.submit(() -> {
+        Future<?> future = this.executor.submit(() ->
+        {
             byte[] buffer = new byte[8 * 1024 * 1024];
             long startTime = System.currentTimeMillis();
             for (int i = 0; i < 2; i++)
@@ -205,9 +223,12 @@ public class TestS3QS
 
         });
 
-        try {
+        try
+        {
             future.get();
-        } catch (ExecutionException e) {
+        }
+        catch (ExecutionException e)
+        {
             e.getCause().printStackTrace();
             throw e;
         }


### PR DESCRIPTION
Related to #1082 
This PR is the first step to enable shuffle support in S3QS. S3QS can now support message passing between workers in different groups, as well as pipeline termination signals.

Key improvements:

Defined the message format provided by workers, enabling identification of worker IDs and partition numbers.
Since S3QS is used exclusively for shuffle tasks, it can serve as the task manager connecting the upstream and downstream of the shuffle, providing communication channels.
