### PR TITLE
[Issue #1331] Remove jemalloc prefix in pixels-retina

### DIFF
--- a/cpp/pixels-retina/CMakeLists.txt
+++ b/cpp/pixels-retina/CMakeLists.txt
@@ -21,7 +21,7 @@ find_package(Java REQUIRED)
 find_package(JNI REQUIRED)
 
 # --- Jemalloc Configuration ---
-option(ENABLE_JEMALLOC "Enable jemalloc with pixels_ prefix" ON)
+option(ENABLE_JEMALLOC "Enable jemalloc for pixels-retina" ON)
 include(ExternalProject)
 
 if(ENABLE_JEMALLOC)
@@ -33,7 +33,6 @@ if(ENABLE_JEMALLOC)
             URL https://github.com/jemalloc/jemalloc/releases/download/5.3.0/jemalloc-5.3.0.tar.bz2
             CONFIGURE_COMMAND <SOURCE_DIR>/configure
             --prefix=${JEMALLOC_INSTALL_DIR}
-            --with-jemalloc-prefix=je_
             --enable-prof
             --enable-stats
             --enable-shared

--- a/cpp/pixels-retina/lib/RGVisibilityJni.cpp
+++ b/cpp/pixels-retina/lib/RGVisibilityJni.cpp
@@ -185,13 +185,13 @@ JNIEXPORT jlong JNICALL Java_io_pixelsdb_pixels_retina_RGVisibility_getNativeMem
 
     // 1. Try to refresh jemalloc epoch to ensure stats are current.
     // Return -2 if this fails, as defined in Java's handleMemoryMetric.
-    if (je_mallctl("epoch", NULL, NULL, &epoch, sizeof(uint64_t)) != 0) {
+    if (mallctl("epoch", NULL, NULL, &epoch, sizeof(uint64_t)) != 0) {
         return -2;
     }
 
     // 2. Try to read the actual allocated bytes.
     // Return -3 if this fails, which often implies a config/prefix mismatch.
-    if (je_mallctl("stats.allocated", &allocated, &sz, NULL, 0) != 0) {
+    if (mallctl("stats.allocated", &allocated, &sz, NULL, 0) != 0) {
         return -3;
     }
 


### PR DESCRIPTION
## Summary

- Remove `--with-jemalloc-prefix=je_` from the bundled jemalloc build in `cpp/pixels-retina`.
- Update JNI jemalloc memory metric calls from `je_mallctl` to `mallctl` so they match the unprefixed jemalloc build.
- Keep the optional `ENABLE_JEMALLOC=OFF` build path compiling.

## Validation

- `cmake --build cpp/pixels-retina/build --target pixels-retina -j 4`: passed.
- jemalloc configure output showed `JEMALLOC_PREFIX` empty.
- `nm -D cpp/pixels-retina/build/jemalloc_install/lib/libjemalloc.so | rg ' (malloc|free|calloc|realloc|mallctl)$| je_(malloc|free|mallctl)$'`: exported unprefixed `malloc`, `free`, `calloc`, `realloc`, and `mallctl`.
- `cmake -S cpp/pixels-retina -B /tmp/pixels-retina-no-jemalloc -DENABLE_JEMALLOC=OFF -DFETCHCONTENT_SOURCE_DIR_GOOGLETEST=/home/antio2/projects/pixels/cpp/pixels-retina/build/_deps/googletest-src`: passed.
- `cmake --build /tmp/pixels-retina-no-jemalloc --target pixels-retina -j 4`: passed.

Closes #1331