### PR TITLE
[Issue #1350] Improve deployment path compatibility

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -153,7 +153,7 @@ fi
 
 # find and copy pixels-cpp.properties
 if [ -z "$(find $PIXELS_HOME/etc -name "pixels-cpp.properties")" ]; then
-  cp -v ./cpp/pixels-cpp.properties $PIXELS_HOME/etc
+  cp -v ./cpp/etc/pixels-cpp.properties $PIXELS_HOME/etc
   echo "$(
     tput setaf 1
     tput setab 7
@@ -162,7 +162,7 @@ else
   read -p "'$PIXELS_HOME/etc/pixels-cpp.properties' exists, override?[y/n]" -n 1 -r
   echo # move to a new line
   if [[ $REPLY =~ ^[Yy]$ ]]; then
-    cp -v ./cpp/pixels-cpp.properties $PIXELS_HOME/etc
+    cp -v ./cpp/etc/pixels-cpp.properties $PIXELS_HOME/etc
   fi
 fi
 

--- a/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/PixelsRecordReaderBufferImpl.java
+++ b/pixels-core/src/main/java/io/pixelsdb/pixels/core/reader/PixelsRecordReaderBufferImpl.java
@@ -111,7 +111,8 @@ public class PixelsRecordReaderBufferImpl implements PixelsRecordReader
     ) throws IOException
     {
         ConfigFactory configFactory = ConfigFactory.Instance();
-        this.retinaBufferStorageFolder = configFactory.getProperty("retina.buffer.object.storage.folder");
+        this.retinaBufferStorageFolder = normalizeRetinaBufferStorageFolder(
+                configFactory.getProperty("retina.buffer.object.storage.folder"));
         this.retinaHost = retinaHost;
         this.retinaEnabled = Boolean.parseBoolean(configFactory.getProperty("retina.enable"));
 
@@ -454,6 +455,15 @@ public class PixelsRecordReaderBufferImpl implements PixelsRecordReader
         {
             memoryUsage.addAndGet(-b.getMemoryUsage());
         }
+    }
+
+    static String normalizeRetinaBufferStorageFolder(String folder)
+    {
+        if (folder == null || folder.isEmpty())
+        {
+            throw new IllegalArgumentException("retina.buffer.object.storage.folder must not be empty");
+        }
+        return folder.endsWith("/") ? folder : folder + "/";
     }
 
     private String getRetinaBufferStoragePathFromId(long entryId, int virtualId)

--- a/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestPixelsRecordReaderBufferImpl.java
+++ b/pixels-core/src/test/java/io/pixelsdb/pixels/core/reader/TestPixelsRecordReaderBufferImpl.java
@@ -118,4 +118,13 @@ public class TestPixelsRecordReaderBufferImpl
         }
         Assertions.assertEquals(exceptedBatchNum, readBatchNum);
     }
+
+    @Test
+    public void testNormalizeRetinaBufferStorageFolder()
+    {
+        String expected = "minio://pixels/retina-buffer/";
+        Assertions.assertEquals(expected, PixelsRecordReaderBufferImpl.normalizeRetinaBufferStorageFolder(
+                "minio://pixels/retina-buffer"));
+        Assertions.assertEquals(expected, PixelsRecordReaderBufferImpl.normalizeRetinaBufferStorageFolder(expected));
+    }
 }

--- a/scripts/bin/run-class.sh
+++ b/scripts/bin/run-class.sh
@@ -33,11 +33,32 @@ if [ -z "$PIXELS_OPTS" ]; then
   PIXELS_OPTS=""
 fi
 
-# Which java to use
-if [ -z "$JAVA_HOME" ]; then
-  JAVA="java"
-else
+# Which java to use. Prefer an explicit valid JAVA_HOME, then PATH, then common node-local JDK locations.
+JAVA=""
+if [ -n "$JAVA_HOME" ] && [ -x "$JAVA_HOME/bin/java" ]; then
   JAVA="$JAVA_HOME/bin/java"
+elif JAVA="$(command -v java 2>/dev/null)"; then
+  echo "Using Java from PATH: $JAVA"
+else
+  for candidate in "$HOME"/opt/jdk-*/bin/java "$HOME"/.sdkman/candidates/java/current/bin/java /usr/lib/jvm/*/bin/java; do
+    if [ -x "$candidate" ]; then
+      JAVA="$candidate"
+      echo "Using node-local Java: $JAVA"
+      break
+    fi
+  done
+  if [ -z "$JAVA" ]; then
+    echo "ERROR: Java not found. Set JAVA_HOME, add java to PATH, or install a JDK under HOME/opt or /usr/lib/jvm." >&2
+    exit 1
+  fi
+fi
+
+# Resolve the Java home on this node so JNI dependencies (for example libjawt.so) are discoverable.
+PIXELS_JAVA_HOME=$(dirname "$(dirname "$(readlink -f "$JAVA")")")
+export JAVA_HOME="$PIXELS_JAVA_HOME"
+export PATH="$PIXELS_JAVA_HOME/bin:$PATH"
+if [ -d "$PIXELS_JAVA_HOME/lib" ]; then
+  export LD_LIBRARY_PATH="$PIXELS_JAVA_HOME/lib:$PIXELS_JAVA_HOME/lib/server:$LD_LIBRARY_PATH"
 fi
 
 # Parse commands

--- a/scripts/sbin/rsync-cluster.sh
+++ b/scripts/sbin/rsync-cluster.sh
@@ -6,7 +6,7 @@ if [ -z "$PIXELS_HOME" ]; then
   exit 1
 fi
 
-DEFAULT_PIXELS_HOME=$PIXELS_HOME
+DEFAULT_PIXELS_HOME=${PIXELS_HOME%/}
 
 # Get local hostname to detect localhost nodes
 LOCAL_HOSTNAME=$(hostname)
@@ -35,7 +35,10 @@ sync_node_lib() {
     fi
 
     echo "[Info] Syncing lib to node: $node ($home)"
-    rsync -az --delete --info=progress2 "${PIXELS_HOME}" "${node}:${home}"
+    rsync -az --delete --info=progress2 "${PIXELS_HOME}/" "${node}:${home}"
+    # Synchronizing copies the controller config; rewrite its absolute root for this target node.
+    echo "[Info] Synchronizing node-local paths in pixels.properties: $home"
+    ssh -n "${node}" "sed -i 's|${DEFAULT_PIXELS_HOME}|${home}|g' '${home}/etc/pixels.properties'"
 }
 
 # ---------------------------

--- a/scripts/sbin/start-retina.sh
+++ b/scripts/sbin/start-retina.sh
@@ -18,10 +18,9 @@ do
 
     # REMOTE_SCRIPT explanation:
     # 1. Set LD_LIBRARY_PATH to find pixels libraries.
-    # 2. Set LD_PRELOAD to the jemalloc lib. This ensures the symbols are loaded into the process's global scope immediately.
     REMOTE_SCRIPT="export PIXELS_HOME=${home} && \
                    export LD_LIBRARY_PATH=${home}/lib:\$LD_LIBRARY_PATH && \
-                   export LD_PRELOAD=${JEMALLOC_LIB} && \
+                   export LD_PRELOAD=${JEMALLOC_LIB}:\$LD_PRELOAD && \
                    \$PIXELS_HOME/bin/start-daemon.sh retina -daemon"
 
     echo "Starting retina on ${retina} using LD_PRELOAD with jemalloc"

--- a/scripts/sbin/start-workers.sh
+++ b/scripts/sbin/start-workers.sh
@@ -11,7 +11,7 @@ DEFAULT_PIXELS_HOME=$PIXELS_HOME
 while read -r worker home
 do
     home="${home:-${DEFAULT_PIXELS_HOME}}"
-    REMOTE_SCRIPT="export PIXELS_HOME=${home} && $PIXELS_HOME/bin/start-daemon.sh worker -daemon"
+    REMOTE_SCRIPT="export PIXELS_HOME=${home} && \$PIXELS_HOME/bin/start-daemon.sh worker -daemon"
     echo "Starting worker on ${worker}..."
     ssh -n "${worker}" "${REMOTE_SCRIPT}"
 done < $PIXELS_HOME/etc/workers

--- a/scripts/sbin/stop-retina.sh
+++ b/scripts/sbin/stop-retina.sh
@@ -11,7 +11,7 @@ DEFAULT_PIXELS_HOME=$PIXELS_HOME
 while read -r retina home
 do
     home="${home:-${DEFAULT_PIXELS_HOME}}"
-    REMOTE_SCRIPT="export PIXELS_HOME=${home} && $PIXELS_HOME/bin/stop-daemon.sh retina -daemon"
+    REMOTE_SCRIPT="export PIXELS_HOME=${home} && \$PIXELS_HOME/bin/stop-daemon.sh retina -daemon"
     echo "Stop retina on ${retina}."
     ssh -n "${retina}" "${REMOTE_SCRIPT}"
 done < $PIXELS_HOME/etc/retina

--- a/scripts/sbin/stop-workers.sh
+++ b/scripts/sbin/stop-workers.sh
@@ -11,7 +11,7 @@ DEFAULT_PIXELS_HOME=$PIXELS_HOME
 while read -r worker home
 do
     home="${home:-${DEFAULT_PIXELS_HOME}}"
-    REMOTE_SCRIPT="export PIXELS_HOME=${home} && $PIXELS_HOME/bin/stop-daemon.sh worker"
+    REMOTE_SCRIPT="export PIXELS_HOME=${home} && \$PIXELS_HOME/bin/stop-daemon.sh worker"
     echo "Stop worker on ${worker}."
     ssh -n "${worker}" "${REMOTE_SCRIPT}"
 done < $PIXELS_HOME/etc/workers


### PR DESCRIPTION
## Summary

- Normalize retina buffer object-storage folders to avoid malformed keys when the configured folder omits a trailing slash.
- Discover a valid node-local JDK and export its `bin`/library paths so lifecycle commands and `jps` work on heterogeneous nodes.
- Respect target-node `PIXELS_HOME` values for remote lifecycle commands and cluster synchronization.
- Install the C++ properties template from its actual location.

## Validation

- `bash -n install.sh scripts/bin/run-class.sh scripts/sbin/rsync-cluster.sh scripts/sbin/start-retina.sh scripts/sbin/start-workers.sh scripts/sbin/stop-retina.sh scripts/sbin/stop-workers.sh`: passed
- `mvn -pl pixels-core -DskipTests package`: passed

Closes #1350