### PR TITLE
[Issue #1404] fix Derby compatibility in metadata DAOs

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -103,8 +103,10 @@ if [ $CP_ETC -eq 1 ]; then
 fi
 
 # find and copy pixels.properties
+PIXELS_PROPERTIES_CREATED=0
 if [ ! -f "$PIXELS_HOME/etc/pixels.properties" ]; then
   cp -v ./pixels-common/src/main/resources/pixels.properties $PIXELS_HOME/etc
+  PIXELS_PROPERTIES_CREATED=1
   echo "$(
     tput setaf 1
     tput setab 7
@@ -149,6 +151,12 @@ else
   fi
 
   rm -f $TEMPLATE_KEYS $TARGET_KEYS $NEW_KEYS $DEPRECATED_KEYS $NEW_OPTIONS $DEPRECATED_OPTIONS
+fi
+
+# Make a fresh Derby installation independent of the source checkout path.
+if [ $PIXELS_PROPERTIES_CREATED -eq 1 ]; then
+  sed -i "s#^pixels.var.dir=.*#pixels.var.dir=$PIXELS_HOME/var/#" $PIXELS_HOME/etc/pixels.properties
+  sed -i "s#^metadata.db.url=jdbc:derby:.*#metadata.db.url=jdbc:derby:$PIXELS_HOME/var/pixels_metadata;create=true#" $PIXELS_HOME/etc/pixels.properties
 fi
 
 # find and copy pixels-cpp.properties

--- a/pixels-common/src/main/resources/pixels.properties
+++ b/pixels-common/src/main/resources/pixels.properties
@@ -6,6 +6,7 @@ metadata.db.user=pixels
 metadata.db.password=password
 #metadata.db.url=jdbc:mysql://localhost:3306/pixels_metadata?useUnicode=true&characterEncoding=UTF-8&zeroDateTimeBehavior=convertToNull
 metadata.db.url=jdbc:derby:/home/pixels/opt/pixels/var/pixels_metadata;create=true
+metadata.db.driver=org.apache.derby.jdbc.EmbeddedDriver
 # metadata server host and port
 metadata.server.port=18888
 metadata.server.host=localhost

--- a/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/metadata/dao/impl/RdbColumnDao.java
+++ b/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/metadata/dao/impl/RdbColumnDao.java
@@ -234,14 +234,14 @@ public class RdbColumnDao extends ColumnDao
         Connection conn = db.getConnection();
         String sql = "UPDATE COLS\n" +
                 "SET\n" +
-                "`COL_NAME` = ?," +
-                "`COL_TYPE` = ?," +
-                "`COL_CHUNK_SIZE` = ?," +
-                "`COL_SIZE` = ?," +
-                "`COL_NULL_FRACTION` = ?," +
-                "`COL_CARDINALITY` = ?," +
-                "`COL_RECORD_STATS` = ?\n" +
-                "WHERE `COL_ID` = ?";
+                "COL_NAME = ?," +
+                "COL_TYPE = ?," +
+                "COL_CHUNK_SIZE = ?," +
+                "COL_SIZE = ?," +
+                "COL_NULL_FRACTION = ?," +
+                "COL_CARDINALITY = ?," +
+                "COL_RECORD_STATS = ?\n" +
+                "WHERE COL_ID = ?";
         try (PreparedStatement pst = conn.prepareStatement(sql))
         {
             pst.setString(1, column.getName());

--- a/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/metadata/dao/impl/RdbFileDao.java
+++ b/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/metadata/dao/impl/RdbFileDao.java
@@ -220,14 +220,14 @@ public class RdbFileDao extends FileDao
     {
         Connection conn = db.getConnection();
         String sql = "INSERT INTO FILES(" +
-                "`FILE_NAME`," +
-                "`FILE_TYPE`," +
-                "`FILE_NUM_RG`," +
-                "`FILE_MIN_ROW_ID`," +
-                "`FILE_MAX_ROW_ID`," +
-                "`PATHS_PATH_ID`," +
-                "`FILE_CLEANUP_AT`) VALUES (?,?,?,?,?,?,?)";
-        try (PreparedStatement pst = conn.prepareStatement(sql))
+                "FILE_NAME," +
+                "FILE_TYPE," +
+                "FILE_NUM_RG," +
+                "FILE_MIN_ROW_ID," +
+                "FILE_MAX_ROW_ID," +
+                "PATHS_PATH_ID," +
+                "FILE_CLEANUP_AT) VALUES (?,?,?,?,?,?,?)";
+        try (PreparedStatement pst = conn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS))
         {
             pst.setString(1, file.getName());
             pst.setInt(2, file.getTypeValue());
@@ -238,7 +238,7 @@ public class RdbFileDao extends FileDao
             setCleanupAt(pst, 7, file);
             if (pst.executeUpdate() == 1)
             {
-                try (ResultSet rs = pst.executeQuery("SELECT LAST_INSERT_ID()"))
+                try (ResultSet rs = pst.getGeneratedKeys())
                 {
                     if (rs.next())
                     {
@@ -267,13 +267,13 @@ public class RdbFileDao extends FileDao
     {
         Connection conn = db.getConnection();
         String sql = "INSERT INTO FILES(" +
-                "`FILE_NAME`," +
-                "`FILE_TYPE`," +
-                "`FILE_NUM_RG`," +
-                "`FILE_MIN_ROW_ID`," +
-                "`FILE_MAX_ROW_ID`," +
-                "`PATHS_PATH_ID`," +
-                "`FILE_CLEANUP_AT`) VALUES (?,?,?,?,?,?,?)";
+                "FILE_NAME," +
+                "FILE_TYPE," +
+                "FILE_NUM_RG," +
+                "FILE_MIN_ROW_ID," +
+                "FILE_MAX_ROW_ID," +
+                "PATHS_PATH_ID," +
+                "FILE_CLEANUP_AT) VALUES (?,?,?,?,?,?,?)";
         try (PreparedStatement pst = conn.prepareStatement(sql))
         {
             for (MetadataProto.File file : files)
@@ -301,13 +301,13 @@ public class RdbFileDao extends FileDao
     {
         Connection conn = db.getConnection();
         String sql = "UPDATE FILES SET\n" +
-                "`FILE_NAME` = ?," +
-                "`FILE_TYPE` = ?," +
-                "`FILE_NUM_RG` = ?," +
-                "`FILE_MIN_ROW_ID` = ?," +
-                "`FILE_MAX_ROW_ID` = ?," +
-                "`FILE_CLEANUP_AT` = ?\n" +
-                "WHERE `FILE_ID` = ?";
+                "FILE_NAME = ?," +
+                "FILE_TYPE = ?," +
+                "FILE_NUM_RG = ?," +
+                "FILE_MIN_ROW_ID = ?," +
+                "FILE_MAX_ROW_ID = ?," +
+                "FILE_CLEANUP_AT = ?\n" +
+                "WHERE FILE_ID = ?";
         try (PreparedStatement pst = conn.prepareStatement(sql))
         {
             pst.setString(1, file.getName());

--- a/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/metadata/dao/impl/RdbLayoutDao.java
+++ b/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/metadata/dao/impl/RdbLayoutDao.java
@@ -217,16 +217,16 @@ public class RdbLayoutDao extends LayoutDao
     {
         Connection conn = db.getConnection();
         String sql = "INSERT INTO LAYOUTS(" +
-                "`LAYOUT_VERSION`," +
-                "`LAYOUT_CREATE_AT`," +
-                "`LAYOUT_PERMISSION`," +
-                "`LAYOUT_ORDERED`," +
-                "`LAYOUT_COMPACT`," +
-                "`LAYOUT_SPLITS`," +
-                "`LAYOUT_PROJECTIONS`," +
-                "`SCHEMA_VERSIONS_SV_ID`," +
-                "`TBLS_TBL_ID`) VALUES (?,?,?,?,?,?,?,?,?)";
-        try (PreparedStatement pst = conn.prepareStatement(sql))
+                "LAYOUT_VERSION," +
+                "LAYOUT_CREATE_AT," +
+                "LAYOUT_PERMISSION," +
+                "LAYOUT_ORDERED," +
+                "LAYOUT_COMPACT," +
+                "LAYOUT_SPLITS," +
+                "LAYOUT_PROJECTIONS," +
+                "SCHEMA_VERSIONS_SV_ID," +
+                "TBLS_TBL_ID) VALUES (?,?,?,?,?,?,?,?,?)";
+        try (PreparedStatement pst = conn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS))
         {
             pst.setLong(1, layout.getVersion());
             pst.setLong(2, layout.getCreateAt());
@@ -239,7 +239,7 @@ public class RdbLayoutDao extends LayoutDao
             pst.setLong(9, layout.getTableId());
             if (pst.executeUpdate() == 1)
             {
-                ResultSet rs = pst.executeQuery("SELECT LAST_INSERT_ID()");
+                ResultSet rs = pst.getGeneratedKeys();
                 if (rs.next())
                 {
                     return rs.getLong(1);
@@ -266,14 +266,14 @@ public class RdbLayoutDao extends LayoutDao
         Connection conn = db.getConnection();
         String sql = "UPDATE LAYOUTS\n" +
                 "SET\n" +
-                "`LAYOUT_VERSION` = ?," +
-                "`LAYOUT_CREATE_AT` = ?," +
-                "`LAYOUT_PERMISSION` = ?," +
-                "`LAYOUT_ORDERED` = ?," +
-                "`LAYOUT_COMPACT` = ?," +
-                "`LAYOUT_SPLITS` = ?," +
-                "`LAYOUT_PROJECTIONS` = ?\n" +
-                "WHERE `LAYOUT_ID` = ?";
+                "LAYOUT_VERSION = ?," +
+                "LAYOUT_CREATE_AT = ?," +
+                "LAYOUT_PERMISSION = ?," +
+                "LAYOUT_ORDERED = ?," +
+                "LAYOUT_COMPACT = ?," +
+                "LAYOUT_SPLITS = ?," +
+                "LAYOUT_PROJECTIONS = ?\n" +
+                "WHERE LAYOUT_ID = ?";
         try (PreparedStatement pst = conn.prepareStatement(sql))
         {
             pst.setLong(1, layout.getVersion());

--- a/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/metadata/dao/impl/RdbPathDao.java
+++ b/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/metadata/dao/impl/RdbPathDao.java
@@ -174,11 +174,11 @@ public class RdbPathDao extends PathDao
     {
         Connection conn = db.getConnection();
         String sql = "INSERT INTO PATHS(" +
-                "`PATH_URI`," +
-                "`PATH_TYPE`," +
-                "`LAYOUTS_LAYOUT_ID`," +
-                "`RANGES_RANGE_ID`) VALUES (?,?,?,?)";
-        try (PreparedStatement pst = conn.prepareStatement(sql))
+                "PATH_URI," +
+                "PATH_TYPE," +
+                "LAYOUTS_LAYOUT_ID," +
+                "RANGES_RANGE_ID) VALUES (?,?,?,?)";
+        try (PreparedStatement pst = conn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS))
         {
             pst.setString(1, path.getUri());
             pst.setInt(2, path.getTypeValue());
@@ -193,7 +193,7 @@ public class RdbPathDao extends PathDao
             }
             if (pst.executeUpdate() == 1)
             {
-                ResultSet rs = pst.executeQuery("SELECT LAST_INSERT_ID()");
+                ResultSet rs = pst.getGeneratedKeys();
                 if (rs.next())
                 {
                     return rs.getLong(1);
@@ -221,9 +221,9 @@ public class RdbPathDao extends PathDao
         Connection conn = db.getConnection();
         String sql = "UPDATE PATHS\n" +
                 "SET\n" +
-                "`PATH_URI` = ?," +
-                "`PATH_IS_COMPACT` = ?\n" +
-                "WHERE `PATH_ID` = ?";
+                "PATH_URI = ?," +
+                "PATH_IS_COMPACT = ?\n" +
+                "WHERE PATH_ID = ?";
         try (PreparedStatement pst = conn.prepareStatement(sql))
         {
             pst.setString(1, path.getUri());

--- a/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/metadata/dao/impl/RdbPeerDao.java
+++ b/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/metadata/dao/impl/RdbPeerDao.java
@@ -151,11 +151,11 @@ public class RdbPeerDao extends PeerDao
     {
         Connection conn = db.getConnection();
         String sql = "INSERT INTO PEERS(" +
-                "`PEER_NAME`," +
-                "`PEER_LOCATION`," +
-                "`PEER_HOST`," +
-                "`PEER_PORT`," +
-                "`PEER_STORAGE_SCHEME`) VALUES (?,?,?,?,?)";
+                "PEER_NAME," +
+                "PEER_LOCATION," +
+                "PEER_HOST," +
+                "PEER_PORT," +
+                "PEER_STORAGE_SCHEME) VALUES (?,?,?,?,?)";
         try (PreparedStatement pst = conn.prepareStatement(sql))
         {
             pst.setString(1, peer.getName());
@@ -178,11 +178,11 @@ public class RdbPeerDao extends PeerDao
         Connection conn = db.getConnection();
         String sql = "UPDATE PEERS\n" +
                 "SET\n" +
-                "`PEER_LOCATION` = ?," +
-                "`PEER_HOST` = ?," +
-                "`PEER_PORT` = ?," +
-                "`PEER_STORAGE_SCHEME` = ?\n" +
-                "WHERE `PEER_ID` = ? OR `PEER_NAME` = ?";
+                "PEER_LOCATION = ?," +
+                "PEER_HOST = ?," +
+                "PEER_PORT = ?," +
+                "PEER_STORAGE_SCHEME = ?\n" +
+                "WHERE PEER_ID = ? OR PEER_NAME = ?";
         try (PreparedStatement pst = conn.prepareStatement(sql))
         {
             pst.setString(1, peer.getLocation());

--- a/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/metadata/dao/impl/RdbPeerPathDao.java
+++ b/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/metadata/dao/impl/RdbPeerPathDao.java
@@ -153,11 +153,11 @@ public class RdbPeerPathDao extends PeerPathDao
     {
         Connection conn = db.getConnection();
         String sql = "INSERT INTO PEER_PATHS(" +
-                "`PEER_PATH_URI`," +
-                "`PEER_PATH_COLUMNS`," +
-                "`PATHS_PATH_ID`," +
-                "`PEERS_PEER_ID`) VALUES (?,?,?,?)";
-        try (PreparedStatement pst = conn.prepareStatement(sql))
+                "PEER_PATH_URI," +
+                "PEER_PATH_COLUMNS," +
+                "PATHS_PATH_ID," +
+                "PEERS_PEER_ID) VALUES (?,?,?,?)";
+        try (PreparedStatement pst = conn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS))
         {
             pst.setString(1, peerPath.getUri());
             pst.setString(2, JSON.toJSONString(new Columns(peerPath.getColumnsList())));
@@ -165,7 +165,7 @@ public class RdbPeerPathDao extends PeerPathDao
             pst.setLong(4, peerPath.getPeerId());
             if (pst.executeUpdate() == 1)
             {
-                ResultSet rs = pst.executeQuery("SELECT LAST_INSERT_ID()");
+                ResultSet rs = pst.getGeneratedKeys();
                 if (rs.next())
                 {
                     return rs.getLong(1);
@@ -193,9 +193,9 @@ public class RdbPeerPathDao extends PeerPathDao
         Connection conn = db.getConnection();
         String sql = "UPDATE PEER_PATHS\n" +
                 "SET\n" +
-                "`PEER_PATH_URI` = ?," +
-                "`PEER_PATH_COLUMNS` = ?\n" +
-                "WHERE `PEER_PATH_ID` = ?";
+                "PEER_PATH_URI = ?," +
+                "PEER_PATH_COLUMNS = ?\n" +
+                "WHERE PEER_PATH_ID = ?";
         try (PreparedStatement pst = conn.prepareStatement(sql))
         {
             pst.setString(1, peerPath.getUri());

--- a/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/metadata/dao/impl/RdbRangeDao.java
+++ b/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/metadata/dao/impl/RdbRangeDao.java
@@ -121,11 +121,11 @@ public class RdbRangeDao extends RangeDao
     {
         Connection conn = db.getConnection();
         String sql = "INSERT INTO RANGES(" +
-                "`RANGE_MIN`," +
-                "`RANGE_MAX`," +
-                "`RANGE_PARENT_ID`," +
-                "`RANGE_INDEXES_RI_ID`) VALUES (?,?,?,?)";
-        try (PreparedStatement pst = conn.prepareStatement(sql))
+                "RANGE_MIN," +
+                "RANGE_MAX," +
+                "RANGE_PARENT_ID," +
+                "RANGE_INDEXES_RI_ID) VALUES (?,?,?,?)";
+        try (PreparedStatement pst = conn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS))
         {
             pst.setBytes(1, range.getMin().toByteArray());
             pst.setBytes(2, range.getMax().toByteArray());
@@ -140,7 +140,7 @@ public class RdbRangeDao extends RangeDao
             pst.setLong(4, range.getRangeIndexId());
             if (pst.executeUpdate() == 1)
             {
-                ResultSet rs = pst.executeQuery("SELECT LAST_INSERT_ID()");
+                ResultSet rs = pst.getGeneratedKeys();
                 if (rs.next())
                 {
                     return rs.getLong(1);
@@ -168,11 +168,11 @@ public class RdbRangeDao extends RangeDao
         Connection conn = db.getConnection();
         String sql = "UPDATE RANGES\n" +
                 "SET\n" +
-                "`RANGE_MIN` = ?," +
-                "`RANGE_MXN` = ?," +
-                "`RANGE_PARENT_ID` = ?," +
-                "`RANGE_INDEXES_RI_ID` = ?\n" +
-                "WHERE `RANGE_ID` = ?";
+                "RANGE_MIN = ?," +
+                "RANGE_MXN = ?," +
+                "RANGE_PARENT_ID = ?," +
+                "RANGE_INDEXES_RI_ID = ?\n" +
+                "WHERE RANGE_ID = ?";
         try (PreparedStatement pst = conn.prepareStatement(sql))
         {
             pst.setBytes(1, range.getMin().toByteArray());

--- a/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/metadata/dao/impl/RdbRangeIndexDao.java
+++ b/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/metadata/dao/impl/RdbRangeIndexDao.java
@@ -142,17 +142,17 @@ public class RdbRangeIndexDao extends RangeIndexDao
     {
         Connection conn = db.getConnection();
         String sql = "INSERT INTO RANGE_INDEXES(" +
-                "`RI_KEY_COLUMNS`," +
-                "`TBLS_TBL_ID`," +
-                "`SCHEMA_VERSIONS_SV_ID`) VALUES (?,?,?)";
-        try (PreparedStatement pst = conn.prepareStatement(sql))
+                "RI_KEY_COLUMNS," +
+                "TBLS_TBL_ID," +
+                "SCHEMA_VERSIONS_SV_ID) VALUES (?,?,?)";
+        try (PreparedStatement pst = conn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS))
         {
             pst.setString(1, rangeIndex.getKeyColumns());
             pst.setLong(2, rangeIndex.getTableId());
             pst.setLong(3, rangeIndex.getSchemaVersionId());
             if (pst.executeUpdate() == 1)
             {
-                ResultSet rs = pst.executeQuery("SELECT LAST_INSERT_ID()");
+                ResultSet rs = pst.getGeneratedKeys();
                 if (rs.next())
                 {
                     return rs.getLong(1);
@@ -180,10 +180,10 @@ public class RdbRangeIndexDao extends RangeIndexDao
         Connection conn = db.getConnection();
         String sql = "UPDATE RANGE_INDEXES\n" +
                 "SET\n" +
-                "`RI_KEY_COLUMNS` = ?," +
-                "`TBLS_TBL_ID` = ?," +
-                "`SCHEMA_VERSIONS_SV_ID` = ?\n" +
-                "WHERE `RI_ID` = ?";
+                "RI_KEY_COLUMNS = ?," +
+                "TBLS_TBL_ID = ?," +
+                "SCHEMA_VERSIONS_SV_ID = ?\n" +
+                "WHERE RI_ID = ?";
         try (PreparedStatement pst = conn.prepareStatement(sql))
         {
             pst.setString(1, rangeIndex.getKeyColumns());

--- a/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/metadata/dao/impl/RdbSchemaDao.java
+++ b/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/metadata/dao/impl/RdbSchemaDao.java
@@ -136,8 +136,8 @@ public class RdbSchemaDao extends SchemaDao
     {
         Connection conn = db.getConnection();
         String sql = "INSERT INTO DBS(" +
-                "`DB_NAME`," +
-                "`DB_DESC`) VALUES (?,?)";
+                "DB_NAME," +
+                "DB_DESC) VALUES (?,?)";
         try (PreparedStatement pst = conn.prepareStatement(sql))
         {
             pst.setString(1, schema.getName());
@@ -156,9 +156,9 @@ public class RdbSchemaDao extends SchemaDao
         Connection conn = db.getConnection();
         String sql = "UPDATE DBS\n" +
                 "SET\n" +
-                "`DB_NAME` = ?," +
-                "`DB_DESC` = ?\n" +
-                "WHERE `DB_ID` = ?";
+                "DB_NAME = ?," +
+                "DB_DESC = ?\n" +
+                "WHERE DB_ID = ?";
         try (PreparedStatement pst = conn.prepareStatement(sql))
         {
             pst.setString(1, schema.getName());

--- a/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/metadata/dao/impl/RdbSchemaVersionDao.java
+++ b/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/metadata/dao/impl/RdbSchemaVersionDao.java
@@ -75,17 +75,17 @@ public class RdbSchemaVersionDao extends SchemaVersionDao
     {
         Connection conn = db.getConnection();
         String sql = "INSERT INTO SCHEMA_VERSIONS(" +
-                "`SV_COLUMNS`," +
-                "`SV_TRANS_TS`," +
-                "`TBLS_TBL_ID`) VALUES (?,?,?)";
-        try (PreparedStatement pst = conn.prepareStatement(sql))
+                "SV_COLUMNS," +
+                "SV_TRANS_TS," +
+                "TBLS_TBL_ID) VALUES (?,?,?)";
+        try (PreparedStatement pst = conn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS))
         {
             pst.setString(1, JSON.toJSONString(new Columns(schemaVersion.getColumnsList())));
             pst.setLong(2, schemaVersion.getTransTs());
             pst.setLong(3, schemaVersion.getTableId());
             if (pst.executeUpdate() == 1)
             {
-                ResultSet rs = pst.executeQuery("SELECT LAST_INSERT_ID()");
+                ResultSet rs = pst.getGeneratedKeys();
                 if (rs.next())
                 {
                     return rs.getLong(1);

--- a/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/metadata/dao/impl/RdbSinglePointIndexDao.java
+++ b/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/metadata/dao/impl/RdbSinglePointIndexDao.java
@@ -101,7 +101,7 @@ public class RdbSinglePointIndexDao extends SinglePointIndexDao
     public MetadataProto.SinglePointIndex getPrimaryByTableId(long tableId)
     {
         Connection conn = db.getConnection();
-        String sql = "SELECT * FROM SINGLE_POINT_INDICES WHERE TBLS_TBL_ID=? AND SPI_PRIMARY=TRUE";
+        String sql = "SELECT * FROM SINGLE_POINT_INDICES WHERE TBLS_TBL_ID=? AND SPI_PRIMARY=1";
         try (PreparedStatement pst = conn.prepareStatement(sql))
         {
             pst.setLong(1, tableId);
@@ -151,13 +151,13 @@ public class RdbSinglePointIndexDao extends SinglePointIndexDao
     {
         Connection conn = db.getConnection();
         String sql = "INSERT INTO SINGLE_POINT_INDICES(" +
-                "`SPI_KEY_COLUMNS`," +
-                "`SPI_PRIMARY`," +
-                "`SPI_UNIQUE`," +
-                "`SPI_INDEX_SCHEME`," +
-                "`TBLS_TBL_ID`," +
-                "`SCHEMA_VERSIONS_SV_ID`) VALUES (?,?,?,?,?,?)";
-        try (PreparedStatement pst = conn.prepareStatement(sql))
+                "SPI_KEY_COLUMNS," +
+                "SPI_PRIMARY," +
+                "SPI_UNIQUE," +
+                "SPI_INDEX_SCHEME," +
+                "TBLS_TBL_ID," +
+                "SCHEMA_VERSIONS_SV_ID) VALUES (?,?,?,?,?,?)";
+        try (PreparedStatement pst = conn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS))
         {
             pst.setString(1, singlePointIndex.getKeyColumns());
             pst.setBoolean(2, singlePointIndex.getPrimary());
@@ -167,7 +167,7 @@ public class RdbSinglePointIndexDao extends SinglePointIndexDao
             pst.setLong(6, singlePointIndex.getSchemaVersionId());
             if (pst.executeUpdate() == 1)
             {
-                ResultSet rs = pst.executeQuery("SELECT LAST_INSERT_ID()");
+                ResultSet rs = pst.getGeneratedKeys();
                 if (rs.next())
                 {
                     return rs.getLong(1);
@@ -193,13 +193,13 @@ public class RdbSinglePointIndexDao extends SinglePointIndexDao
         Connection conn = db.getConnection();
         String sql = "UPDATE SINGLE_POINT_INDICES\n" +
                 "SET\n" +
-                "`SPI_KEY_COLUMNS` = ?," +
-                "`SPI_PRIMARY` = ?," +
-                "`SPI_UNIQUE` = ?," +
-                "`SPI_INDEX_SCHEME` = ?," +
-                "`TBLS_TBL_ID` = ?," +
-                "`SCHEMA_VERSIONS_SV_ID` = ?\n" +
-                "WHERE `SPI_ID` = ?";
+                "SPI_KEY_COLUMNS = ?," +
+                "SPI_PRIMARY = ?," +
+                "SPI_UNIQUE = ?," +
+                "SPI_INDEX_SCHEME = ?," +
+                "TBLS_TBL_ID = ?," +
+                "SCHEMA_VERSIONS_SV_ID = ?\n" +
+                "WHERE SPI_ID = ?";
         try (PreparedStatement pst = conn.prepareStatement(sql))
         {
             pst.setString(1, singlePointIndex.getKeyColumns());

--- a/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/metadata/dao/impl/RdbTableDao.java
+++ b/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/metadata/dao/impl/RdbTableDao.java
@@ -192,11 +192,11 @@ public class RdbTableDao extends TableDao
     {
         Connection conn = db.getConnection();
         String sql = "INSERT INTO TBLS(" +
-                "`TBL_NAME`," +
-                "`TBL_TYPE`," +
-                "`TBL_STORAGE_SCHEME`," +
-                "`TBL_ROW_COUNT`," +
-                "`DBS_DB_ID`) VALUES (?,?,?,?,?)";
+                "TBL_NAME," +
+                "TBL_TYPE," +
+                "TBL_STORAGE_SCHEME," +
+                "TBL_ROW_COUNT," +
+                "DBS_DB_ID) VALUES (?,?,?,?,?)";
         try (PreparedStatement pst = conn.prepareStatement(sql))
         {
             pst.setString(1, table.getName());
@@ -218,11 +218,11 @@ public class RdbTableDao extends TableDao
         Connection conn = db.getConnection();
         String sql = "UPDATE TBLS\n" +
                 "SET\n" +
-                "`TBL_NAME` = ?," +
-                "`TBL_TYPE` = ?," +
-                "`TBL_STORAGE_SCHEME` = ?," +
-                "`TBL_ROW_COUNT` = ?\n" +
-                "WHERE `TBL_ID` = ?";
+                "TBL_NAME = ?," +
+                "TBL_TYPE = ?," +
+                "TBL_STORAGE_SCHEME = ?," +
+                "TBL_ROW_COUNT = ?\n" +
+                "WHERE TBL_ID = ?";
         try (PreparedStatement pst = conn.prepareStatement(sql))
         {
             pst.setString(1, table.getName());

--- a/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/metadata/dao/impl/RdbViewDao.java
+++ b/pixels-daemon/src/main/java/io/pixelsdb/pixels/daemon/metadata/dao/impl/RdbViewDao.java
@@ -184,10 +184,10 @@ public class RdbViewDao extends ViewDao
     {
         Connection conn = db.getConnection();
         String sql = "INSERT INTO VIEWS(" +
-                "`VIEW_NAME`," +
-                "`VIEW_TYPE`," +
-                "`VIEW_DATA`," +
-                "`DBS_DB_ID`) VALUES (?,?,?,?)";
+                "VIEW_NAME," +
+                "VIEW_TYPE," +
+                "VIEW_DATA," +
+                "DBS_DB_ID) VALUES (?,?,?,?)";
         try (PreparedStatement pst = conn.prepareStatement(sql))
         {
             pst.setString(1, view.getName());
@@ -208,10 +208,10 @@ public class RdbViewDao extends ViewDao
         Connection conn = db.getConnection();
         String sql = "UPDATE VIEWS\n" +
                 "SET\n" +
-                "`VIEW_NAME` = ?," +
-                "`VIEW_TYPE` = ?," +
-                "`VIEW_DATA` = ?\n" +
-                "WHERE `VIEW_ID` = ?";
+                "VIEW_NAME = ?," +
+                "VIEW_TYPE = ?," +
+                "VIEW_DATA = ?\n" +
+                "WHERE VIEW_ID = ?";
         try (PreparedStatement pst = conn.prepareStatement(sql))
         {
             pst.setString(1, view.getName());

--- a/pixels-daemon/src/test/java/io/pixelsdb/pixels/daemon/metadata/dao/TestRdbFileDao.java
+++ b/pixels-daemon/src/test/java/io/pixelsdb/pixels/daemon/metadata/dao/TestRdbFileDao.java
@@ -537,11 +537,11 @@ public class TestRdbFileDao
     private PreparedStatement stubPreparedStatementForInsert() throws SQLException
     {
         PreparedStatement pst = mock(PreparedStatement.class);
-        when(mockConn.prepareStatement(anyString())).thenReturn(pst);
+        when(mockConn.prepareStatement(anyString(), eq(Statement.RETURN_GENERATED_KEYS))).thenReturn(pst);
         when(pst.executeUpdate()).thenReturn(1);
-        // Stub LAST_INSERT_ID() on the insert statement.
+        // Stub the JDBC-standard generated-keys result on the insert statement.
         ResultSet idRs = mock(ResultSet.class);
-        when(pst.executeQuery(anyString())).thenReturn(idRs);
+        when(pst.getGeneratedKeys()).thenReturn(idRs);
         when(idRs.next()).thenReturn(true);
         when(idRs.getLong(1)).thenReturn(1L);
         return pst;


### PR DESCRIPTION
Remove MySQL-specific identifier quoting from metadata DAO queries. Use JDBC generated keys instead of LAST_INSERT_ID(). Add the default Derby JDBC driver configuration.
Update fresh installations to use PIXELS_HOME for Derby and var paths. Adjust the affected DAO test for generated-key retrieval.
## What does this PR do?

This PR improves Derby compatibility in the metadata DAO implementation while
preserving MySQL support.

## Changes

- Remove MySQL-specific backtick quoting from metadata DAO SQL statements.
- Replace `SELECT LAST_INSERT_ID()` with JDBC `RETURN_GENERATED_KEYS`.
- Use SQL expressions supported by both Derby and MySQL.
- Add the Derby JDBC driver to the default metadata configuration.
- Configure fresh installations to place the Derby database and runtime
  directories under `PIXELS_HOME`.
- Update the affected DAO test to mock JDBC generated-key retrieval.

## Why is this needed?

The default metadata database is Derby, but some DAO statements still use
MySQL-specific SQL syntax. These statements can fail when metadata operations
are executed against Derby.

## Testing

Tested on:

- Huawei Cloud Kunpeng ARM64
- Kylin Linux Advanced Server V10 SP3
- Maven 3.9.16
- Pixels CLI and coordinator using JDK 8
- Apache Derby embedded metadata database
- Trino 466 using ARM64 JDK 23

Verified the following flow:

1. Built and installed Pixels from the modified source.
2. Initialized a fresh Derby metadata database with `INIT-META`.
3. Started etcd and the Pixels coordinator.
4. Created the TPC-H `region` table through the Pixels Trino connector.
5. Loaded the TPC-H `region.tbl` file with pixels-cli.
6. Confirmed that a Pixels `.pxl` file was generated.
7. Queried the table through Trino.

Query:

```sql
SELECT count(*), sum(r_regionkey) FROM tpch.region;

Related to #1393
Related to #1394